### PR TITLE
【FIX】 json-rpc传输对象类型时无法转换成数组修复

### DIFF
--- a/src/json-rpc/src/DataFormatter.php
+++ b/src/json-rpc/src/DataFormatter.php
@@ -13,12 +13,20 @@ declare(strict_types=1);
 namespace Hyperf\JsonRpc;
 
 use Hyperf\Rpc\Contract\DataFormatterInterface;
+use Hyperf\Utils\Contracts\Arrayable;
 
 class DataFormatter implements DataFormatterInterface
 {
     public function formatRequest($data)
     {
         [$path, $params, $id] = $data;
+
+        foreach ($params as $key => $param) {
+            if ($param instanceof Arrayable) {
+                $params[$key] = $param->toArray();
+            }
+        }
+        
         return [
             'jsonrpc' => '2.0',
             'method' => $path,

--- a/src/json-rpc/src/DataFormatter.php
+++ b/src/json-rpc/src/DataFormatter.php
@@ -13,20 +13,12 @@ declare(strict_types=1);
 namespace Hyperf\JsonRpc;
 
 use Hyperf\Rpc\Contract\DataFormatterInterface;
-use Hyperf\Utils\Contracts\Arrayable;
 
 class DataFormatter implements DataFormatterInterface
 {
     public function formatRequest($data)
     {
         [$path, $params, $id] = $data;
-
-        foreach ($params as $key => $param) {
-            if ($param instanceof Arrayable) {
-                $params[$key] = $param->toArray();
-            }
-        }
-        
         return [
             'jsonrpc' => '2.0',
             'method' => $path,


### PR DESCRIPTION
【FIX】 json-rpc传输对象类型时无法转换成数组修复