### PR TITLE
Optimized AbstractProcess.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - [#748](https://github.com/hyperf/hyperf/pull/748) Fixed bug that `SymfonyNormalizer` not denormalize result of type `array`.
 - [#769](https://github.com/hyperf/hyperf/pull/769) Fixed invalid response exception throwed when result/error of jsonrpc response is null.
 
+# Changed
+
+- [#767](https://github.com/hyperf/hyperf/pull/767) Renamed property `running` to `listening` for `AbstractProcess`.
+
 # v1.1.2 - 2019-10-17
 
 ## Added

--- a/src/process/src/AbstractProcess.php
+++ b/src/process/src/AbstractProcess.php
@@ -44,7 +44,7 @@ abstract class AbstractProcess implements ProcessInterface
     /**
      * @var int
      */
-    public $pipeType = 2;
+    public $pipeType = SOCK_DGRAM;
 
     /**
      * @var bool
@@ -79,7 +79,7 @@ abstract class AbstractProcess implements ProcessInterface
     /**
      * @var bool
      */
-    private $running = true;
+    protected $listening = true;
 
     public function __construct(ContainerInterface $container)
     {
@@ -108,7 +108,7 @@ abstract class AbstractProcess implements ProcessInterface
 
                     $this->event && $this->event->dispatch(new AfterProcessHandle($this, $i));
                 } finally {
-                    $this->running = false;
+                    $this->listening = false;
                 }
             }, $this->redirectStdinStdout, $this->pipeType, $this->enableCoroutine);
             $server->addProcess($process);
@@ -125,7 +125,7 @@ abstract class AbstractProcess implements ProcessInterface
     protected function listen()
     {
         go(function () {
-            while ($this->running) {
+            while ($this->listening) {
                 try {
                     /** @var \Swoole\Coroutine\Socket $sock */
                     $sock = $this->process->exportSocket();


### PR DESCRIPTION
`$pipeType` 默认值 `2` -> `SOCK_DGRAM`
`$running` 更名为 `$listening`，并且改成 protected，让用户可以自己选择 不去监听是否有数据发过来。
