### PR TITLE
Use channel to communicate, instead of sharing mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Optimized
 
 - [#781](https://github.com/hyperf/hyperf/pull/781) Publish validation language package according to translation setting.
+- [#797](https://github.com/hyperf/hyperf/pull/797) Use channel to communicate, instead of sharing mem
 
 ## Changed
 

--- a/src/process/src/AbstractProcess.php
+++ b/src/process/src/AbstractProcess.php
@@ -82,11 +82,6 @@ abstract class AbstractProcess implements ProcessInterface
      */
     protected $restartInterval = 5;
 
-    /**
-     * @var bool
-     */
-    protected $listening = true;
-
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -109,7 +104,7 @@ abstract class AbstractProcess implements ProcessInterface
                     $this->event && $this->event->dispatch(new BeforeProcessHandle($this, $i));
 
                     $this->process = $process;
-                    if ($this->enableCoroutine && $this->listening) {
+                    if ($this->enableCoroutine) {
                         $quit = new Channel(1);
                         $this->listen($quit);
                     }

--- a/src/process/src/AbstractProcess.php
+++ b/src/process/src/AbstractProcess.php
@@ -82,6 +82,11 @@ abstract class AbstractProcess implements ProcessInterface
      */
     protected $restartInterval = 5;
 
+    /**
+     * @var bool
+     */
+    protected $listening = true;
+
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -104,7 +109,7 @@ abstract class AbstractProcess implements ProcessInterface
                     $this->event && $this->event->dispatch(new BeforeProcessHandle($this, $i));
 
                     $this->process = $process;
-                    if ($this->enableCoroutine) {
+                    if ($this->enableCoroutine && $this->listening) {
                         $quit = new Channel(1);
                         $this->listen($quit);
                     }


### PR DESCRIPTION
A saying from CSP:

Do not communicate by sharing memory; instead, share memory by communicating.

“不要以共享内存的方式来通信，相反，要通过通信来共享内存。”