### PR TITLE
improve response json exception message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Added
 
-- [](https://github.com/hyperf/hyperf/pull/832) Added `Hyperf\Utils\Codec\Json`.
+- [#832](https://github.com/hyperf/hyperf/pull/832) Added `Hyperf\Utils\Codec\Json`.
 
 ## Optimized
 
-- [](https://github.com/hyperf/hyperf/pull/832) Optimized that response will throw a exception when json format failed.
+- [#832](https://github.com/hyperf/hyperf/pull/832) Optimized that response will throw a exception when json format failed.
 
 # v1.1.4 - 2019-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # v1.1.5 - TBD
 
+## Added
+
+- [](https://github.com/hyperf/hyperf/pull/832) Added `Hyperf\Utils\Codec\Json`.
+
+## Optimized
+
+- [](https://github.com/hyperf/hyperf/pull/832) Optimized that response will throw a exception when json format failed.
+
 # v1.1.4 - 2019-10-31
 
 ## Added

--- a/src/http-server/src/Response.php
+++ b/src/http-server/src/Response.php
@@ -460,7 +460,11 @@ class Response implements PsrResponseInterface, ResponseInterface, Sendable
     protected function toJson($data): string
     {
         if (is_array($data)) {
-            return json_encode($data, JSON_UNESCAPED_UNICODE);
+            $jsonRet = json_encode($data, JSON_UNESCAPED_UNICODE);
+            if($jsonRet == false){
+                throw new EncodingException(json_last_error_msg());
+            }
+            return $jsonRet;
         }
 
         if ($data instanceof Jsonable) {
@@ -468,7 +472,11 @@ class Response implements PsrResponseInterface, ResponseInterface, Sendable
         }
 
         if ($data instanceof Arrayable) {
-            return json_encode($data->toArray(), JSON_UNESCAPED_UNICODE);
+            $jsonRet = json_encode($data->toArray(), JSON_UNESCAPED_UNICODE);
+            if($jsonRet == false){
+                throw new EncodingException(json_last_error_msg());
+            }
+            return $jsonRet;
         }
 
         throw new EncodingException('Error encoding response data to JSON.');

--- a/src/http-server/src/Response.php
+++ b/src/http-server/src/Response.php
@@ -23,6 +23,7 @@ use Hyperf\HttpServer\Exception\Http\FileException;
 use Hyperf\HttpServer\Exception\Http\InvalidResponseException;
 use Hyperf\Utils\ApplicationContext;
 use Hyperf\Utils\ClearStatCache;
+use Hyperf\Utils\Codec\Json;
 use Hyperf\Utils\Context;
 use Hyperf\Utils\Contracts\Arrayable;
 use Hyperf\Utils\Contracts\Jsonable;
@@ -459,27 +460,13 @@ class Response implements PsrResponseInterface, ResponseInterface, Sendable
      */
     protected function toJson($data): string
     {
-        if (is_array($data)) {
-            $jsonRet = json_encode($data, JSON_UNESCAPED_UNICODE);
-            if($jsonRet == false){
-                throw new EncodingException(json_last_error_msg());
-            }
-            return $jsonRet;
+        try {
+            $result = Json::encode($data);
+        } catch (\Throwable $exception) {
+            throw new EncodingException($exception->getMessage(), $exception->getCode());
         }
 
-        if ($data instanceof Jsonable) {
-            return (string) $data;
-        }
-
-        if ($data instanceof Arrayable) {
-            $jsonRet = json_encode($data->toArray(), JSON_UNESCAPED_UNICODE);
-            if($jsonRet == false){
-                throw new EncodingException(json_last_error_msg());
-            }
-            return $jsonRet;
-        }
-
-        throw new EncodingException('Error encoding response data to JSON.');
+        return $result;
     }
 
     /**

--- a/src/http-server/tests/ResponseTest.php
+++ b/src/http-server/tests/ResponseTest.php
@@ -179,6 +179,20 @@ class ResponseTest extends TestCase
         $this->assertSame('{"kstring":"string","kint1":1,"kint0":0,"kfloat":0.12345,"kfalse":false,"ktrue":true,"karray":{"kstring":"string","kint1":1,"kint0":0,"kfloat":0.12345,"kfalse":false,"ktrue":true}}', $json->getBody()->getContents());
     }
 
+    public function testObjectToJson()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+
+        $psrResponse = new \Hyperf\HttpMessage\Base\Response();
+        Context::set(PsrResponseInterface::class, $psrResponse);
+
+        $response = new Response();
+        $json = $response->json((object) ['id' => 1, 'name' => 'Hyperf']);
+
+        $this->assertSame('{"id":1,"name":"Hyperf"}', $json->getBody()->getContents());
+    }
+
     public function testPsrResponse()
     {
         $container = Mockery::mock(ContainerInterface::class);

--- a/src/utils/src/Codec/Json.php
+++ b/src/utils/src/Codec/Json.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Utils\Codec;
+
+use Hyperf\Utils\Contracts\Arrayable;
+use Hyperf\Utils\Contracts\Jsonable;
+use InvalidArgumentException;
+
+class Json
+{
+    public static function encode($data, $options = JSON_UNESCAPED_UNICODE): string
+    {
+        if ($data instanceof Jsonable) {
+            return (string) $data;
+        }
+
+        if ($data instanceof Arrayable) {
+            $data = $data->toArray();
+        }
+
+        $json = json_encode($data, $options);
+
+        static::handleJsonError(json_last_error(), json_last_error_msg());
+
+        return $json;
+    }
+
+    public static function decode(string $json, $asArray = true): array
+    {
+        $decode = json_decode($json, $asArray);
+
+        static::handleJsonError(json_last_error(), json_last_error_msg());
+
+        return $decode;
+    }
+
+    protected static function handleJsonError($lastError, $message)
+    {
+        if ($lastError === JSON_ERROR_NONE) {
+            return;
+        }
+
+        throw new InvalidArgumentException($message, $lastError);
+    }
+}

--- a/src/utils/src/Codec/Json.php
+++ b/src/utils/src/Codec/Json.php
@@ -35,9 +35,9 @@ class Json
         return $json;
     }
 
-    public static function decode(string $json, $asArray = true): array
+    public static function decode(string $json, $assoc = true)
     {
-        $decode = json_decode($json, $asArray);
+        $decode = json_decode($json, $assoc);
 
         static::handleJsonError(json_last_error(), json_last_error_msg());
 

--- a/src/utils/tests/Codec/JsonTest.php
+++ b/src/utils/tests/Codec/JsonTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Utils\Codec;
+
+use Hyperf\Utils\Codec\Json;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class JsonTest extends TestCase
+{
+    public function testEncode()
+    {
+        $data = [
+            'name' => 'Hyperf',
+        ];
+        $json = '{"name":"Hyperf"}';
+        $this->assertSame($json, Json::encode($data));
+    }
+
+    public function testDecode()
+    {
+        $data = [
+            'name' => 'Hyperf',
+        ];
+        $json = '{"name":"Hyperf"}';
+        $this->assertSame($data, Json::decode($json));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Control character error, possibly incorrectly encoded
+     */
+    public function testDecodeException()
+    {
+        $data = [
+            'name' => 'Hyperf',
+        ];
+        $json = '{"name":"Hyperf}';
+        $this->assertSame($data, Json::decode($json));
+    }
+
+    public function testJsonEncodeInCoroutine()
+    {
+        $result = null;
+        go(function () use (&$result) {
+            $result = Json::encode([1, 2, 3]);
+        });
+        $this->assertSame('[1,2,3]', $result);
+        go(function () use (&$result) {
+            $result = Json::decode('[1,2,3]');
+        });
+        $this->assertSame([1, 2, 3], $result);
+    }
+}

--- a/src/utils/tests/Codec/JsonTest.php
+++ b/src/utils/tests/Codec/JsonTest.php
@@ -39,6 +39,15 @@ class JsonTest extends TestCase
         $this->assertSame($data, Json::decode($json));
     }
 
+    public function testDecodeToObject()
+    {
+        $data = [
+            'name' => 'Hyperf',
+        ];
+        $json = '{"name":"Hyperf"}';
+        $this->assertEquals((object) $data, Json::decode($json, false));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Control character error, possibly incorrectly encoded


### PR DESCRIPTION
开发过程中，碰到了一个问题，通过数据库查询的数据是带有中文的，中文字段处理的时候出现了编码的问题，导致json_encode()这个地方返回值是false，然后触发response->json()的错误，`Return value of Hyperf\\HttpServer\\Response::toJson() must be of the type string, boolean returned` ，然后一直检查数据是否是array，var_dump一直显示array类型，定位不到问题，所以改善了response->json()这个地方的异常检查，输出相关json的错误，例如：`Malformed UTF-8 characters, possibly incorrectly encoded`
