### PR TITLE
Fixed bug that command init-proxy will not stop when rpc-client exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#897](https://github.com/hyperf/hyperf/pull/897) Fixed `pool` for `Hyperf\Nats\Annotation\Consumer` does not works.
+- [#903](https://github.com/hyperf/hyperf/pull/903) Fixed bug that command init-proxy will not stop when rpc-client exists.
 
 # v1.1.5 - 2019-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Fixed
 
-- [#897](https://github.com/hyperf/hyperf/pull/897) Fixed `pool` for `Hyperf\Nats\Annotation\Consumer` does not works.
-- [#903](https://github.com/hyperf/hyperf/pull/903) Fixed bug that command init-proxy will not stop when rpc-client exists.
+- [#897](https://github.com/hyperf/hyperf/pull/897) Fixed connection pool of `Hyperf\Nats\Annotation\Consumer` does not works as expected.
+- [#903](https://github.com/hyperf/hyperf/pull/903) Fixed execute `init-proxy` command can not stop when `hyperf/rpc-client` component exists.
 
 # v1.1.5 - 2019-11-07
 

--- a/src/di/src/Command/InitProxyCommand.php
+++ b/src/di/src/Command/InitProxyCommand.php
@@ -17,6 +17,7 @@ use Hyperf\Config\ProviderConfig;
 use Hyperf\Di\Annotation\Scanner;
 use Hyperf\Di\Container;
 use Psr\Container\ContainerInterface;
+use Swoole\Timer;
 use Symfony\Component\Console\Exception\LogicException;
 
 class InitProxyCommand extends Command
@@ -50,6 +51,8 @@ class InitProxyCommand extends Command
         $this->warn('This command does not clear the runtime cache, If you want to delete them, use `vendor/bin/init-proxy.sh` instead.');
 
         $this->createAopProxies();
+
+        Timer::clearAll();
 
         $this->output->writeln('<info>Proxy class create success.</info>');
     }

--- a/src/di/src/Container.php
+++ b/src/di/src/Container.php
@@ -54,7 +54,6 @@ class Container implements ContainerInterface
 
     /**
      * Container constructor.
-     * @param Definition\DefinitionSourceInterface $definitionSource
      */
     public function __construct(Definition\DefinitionSourceInterface $definitionSource)
     {

--- a/src/di/src/MethodDefinitionCollectorInterface.php
+++ b/src/di/src/MethodDefinitionCollectorInterface.php
@@ -22,7 +22,6 @@ interface MethodDefinitionCollectorInterface
 
     /**
      * Retrieve the metadata for the return value of the method.
-     * @return ReflectionType
      */
     public function getReturnType(string $class, string $method): ReflectionType;
 }


### PR DESCRIPTION
当使用 RPC 服务，并且把服务注册到 Consul 时，会有 Timer 循环拉取配置，则导致脚本无法被中断。