### PR TITLE
Fixed Uri which build by host is not correct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - [#897](https://github.com/hyperf/hyperf/pull/897) Fixed connection pool of `Hyperf\Nats\Annotation\Consumer` does not works as expected.
 - [#903](https://github.com/hyperf/hyperf/pull/903) Fixed execute `init-proxy` command can not stop when `hyperf/rpc-client` component exists.
 - [#904](https://github.com/hyperf/hyperf/pull/904) Fixed the hooked I/O request does not works in the listener that listening `Hyperf\Framework\Event\BeforeMainServerStart` event.
-- [#906](https://github.com/hyperf/hyperf/pull/906) Fixed Uri which build by host is not correct.
-
+- [#906](https://github.com/hyperf/hyperf/pull/906) Fixed `port` property of URI of `Hyperf\HttpMessage\Server\Request`.
+.
 # v1.1.5 - 2019-11-07
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#897](https://github.com/hyperf/hyperf/pull/897) Fixed connection pool of `Hyperf\Nats\Annotation\Consumer` does not works as expected.
 - [#903](https://github.com/hyperf/hyperf/pull/903) Fixed execute `init-proxy` command can not stop when `hyperf/rpc-client` component exists.
 - [#904](https://github.com/hyperf/hyperf/pull/904) Fixed the hooked I/O request does not works in the listener that listening `Hyperf\Framework\Event\BeforeMainServerStart` event.
+- [#906](https://github.com/hyperf/hyperf/pull/906) Fixed Uri which build by host is not correct.
 
 # v1.1.5 - 2019-11-07
 

--- a/src/http-message/src/Base/MessageTrait.php
+++ b/src/http-message/src/Base/MessageTrait.php
@@ -192,7 +192,6 @@ trait MessageTrait
     }
 
     /**
-     * @param array $headers
      * @return static
      */
     public function withHeaders(array $headers)
@@ -341,7 +340,6 @@ trait MessageTrait
     }
 
     /**
-     * @param array $headers
      * @return static
      */
     private function setHeaders(array $headers)

--- a/src/http-message/src/Cookie/CookieJar.php
+++ b/src/http-message/src/Cookie/CookieJar.php
@@ -274,7 +274,6 @@ class CookieJar implements CookieJarInterface
      *
      * @see https://tools.ietf.org/html/rfc6265#section-5.1.4
      *
-     * @param RequestInterface $request
      * @return string
      */
     private function getCookiePathFromRequest(RequestInterface $request)
@@ -299,8 +298,6 @@ class CookieJar implements CookieJarInterface
     /**
      * If a cookie already exists and the server asks to set it again with a
      * null value, the cookie must be deleted.
-     *
-     * @param SetCookie $cookie
      */
     private function removeCookieIfEmpty(SetCookie $cookie)
     {

--- a/src/http-message/src/Server/Request.php
+++ b/src/http-message/src/Server/Request.php
@@ -66,7 +66,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
     /**
      * Load a swoole request, and transfer to a swoft request object.
      *
-     * @param \Swoole\Http\Request $swooleRequest
      * @return \Hyperf\HttpMessage\Server\Request
      */
     public static function loadFromSwooleRequest(\Swoole\Http\Request $swooleRequest)
@@ -103,7 +102,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
     /**
      * Return an instance with the specified server params.
      *
-     * @param array $serverParams
      * @return static
      */
     public function withServerParams(array $serverParams)
@@ -118,8 +116,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
      * Retrieves cookies sent by the client to the server.
      * The data MUST be compatible with the structure of the $_COOKIE
      * superglobal.
-     *
-     * @return array
      */
     public function getCookieParams(): array
     {
@@ -154,8 +150,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
      * params. If you need to ensure you are only getting the original
      * values, you may need to parse the query string from `getUri()->getQuery()`
      * or from the `QUERY_STRING` server param.
-     *
-     * @return array
      */
     public function getQueryParams(): array
     {
@@ -416,8 +410,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
 
     /**
      * Get the full URL for the request.
-     *
-     * @return string
      */
     public function fullUrl(): string
     {
@@ -451,16 +443,12 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
         return $this->hasHeader('X-Requested-With') == 'XMLHttpRequest';
     }
 
-    /**
-     * @return \Swoole\Http\Request
-     */
     public function getSwooleRequest(): \Swoole\Http\Request
     {
         return $this->swooleRequest;
     }
 
     /**
-     * @param \Swoole\Http\Request $swooleRequest
      * @return $this
      */
     public function setSwooleRequest(\Swoole\Http\Request $swooleRequest)
@@ -532,7 +520,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
      * Loops through all nested files and returns a normalized array of
      * UploadedFileInterface instances.
      *
-     * @param array $files
      * @return UploadedFileInterface[]
      */
     private static function normalizeNestedFileSpec(array $files = [])
@@ -555,7 +542,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
 
     /**
      * Get a Uri populated with values from $swooleRequest->server.
-     * @param \Swoole\Http\Request $swooleRequest
      * @throws \InvalidArgumentException
      * @return \Psr\Http\Message\UriInterface
      */

--- a/src/http-message/src/Server/Request.php
+++ b/src/http-message/src/Server/Request.php
@@ -579,11 +579,10 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
         } elseif (isset($server['server_addr'])) {
             $uri = $uri->withHost($server['server_addr']);
         } elseif (isset($header['host'])) {
+            $hasPort = true;
             if (\strpos($header['host'], ':')) {
-                $hasPort = true;
                 [$host, $port] = explode(':', $header['host'], 2);
-
-                if ($port !== '80') {
+                if ($port != $uri->getDefaultPort()) {
                     $uri = $uri->withPort($port);
                 }
             } else {

--- a/src/http-message/src/Server/Response.php
+++ b/src/http-message/src/Server/Response.php
@@ -29,9 +29,6 @@ class Response extends \Hyperf\HttpMessage\Base\Response implements Sendable
      */
     protected $cookies = [];
 
-    /**
-     * @param null|\Swoole\Http\Response $response
-     */
     public function __construct(\Swoole\Http\Response $response = null)
     {
         $this->swooleResponse = $response;

--- a/src/http-message/src/Stream/SwooleStream.php
+++ b/src/http-message/src/Stream/SwooleStream.php
@@ -28,8 +28,6 @@ class SwooleStream implements StreamInterface
 
     /**
      * SwooleStream constructor.
-     *
-     * @param string $contents
      */
     public function __construct(string $contents = '')
     {

--- a/src/http-message/src/Upload/UploadedFile.php
+++ b/src/http-message/src/Upload/UploadedFile.php
@@ -66,13 +66,6 @@ class UploadedFile extends \SplFileInfo implements UploadedFileInterface
      */
     private $mimeType;
 
-    /**
-     * @param string $tmpFile
-     * @param null|int $size
-     * @param int $errorStatus
-     * @param null|string $clientFilename
-     * @param null|string $clientMediaType
-     */
     public function __construct(
         string $tmpFile,
         ?int $size,
@@ -254,9 +247,6 @@ class UploadedFile extends \SplFileInfo implements UploadedFileInterface
         return $this->clientMediaType;
     }
 
-    /**
-     * @return array
-     */
     public function toArray(): array
     {
         return [

--- a/src/http-message/src/Uri/Uri.php
+++ b/src/http-message/src/Uri/Uri.php
@@ -545,8 +545,6 @@ class Uri implements UriInterface
      * Whether the URI has the default port of the current scheme.
      * `Psr\Http\Message\UriInterface::getPort` may return null or the standard port. This method can be used
      * independently of the implementation.
-     *
-     * @return bool
      */
     public function isDefaultPort(): bool
     {
@@ -708,7 +706,6 @@ class Uri implements UriInterface
     }
 
     /**
-     * @param array $match
      * @return string
      */
     private function rawurlencodeMatchZero(array $match)

--- a/src/http-message/tests/ServerRequestTest.php
+++ b/src/http-message/tests/ServerRequestTest.php
@@ -12,11 +12,14 @@ declare(strict_types=1);
 
 namespace HyperfTest\HttpMessage;
 
+use Hyperf\HttpMessage\Server\Request;
 use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\Utils\Codec\Json;
 use HyperfTest\HttpMessage\Stub\Server\RequestStub;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Swoole\Http\Request as SwooleRequest;
 
 /**
  * @internal
@@ -59,5 +62,25 @@ class ServerRequestTest extends TestCase
         $request->shouldReceive('getHeaderLine')->with('Content-Type')->andReturn('application/JSON');
         $request->shouldReceive('getBody')->andReturn(new SwooleStream(json_encode($json)));
         $this->assertSame($json, RequestStub::normalizeParsedBody($data, $request));
+    }
+
+    public function testGetUriFromGlobals()
+    {
+        $swooleRequest = Mockery::mock(SwooleRequest::class);
+        $data = ['name' => 'Hyperf'];
+        $swooleRequest->shouldReceive('rawContent')->andReturn(Json::encode($data));
+        $swooleRequest->server = ['server_port' => 9501];
+        $request = Request::loadFromSwooleRequest($swooleRequest);
+        $uri = $request->getUri();
+        $this->assertSame(9501, $uri->getPort());
+
+        $swooleRequest = Mockery::mock(SwooleRequest::class);
+        $data = ['name' => 'Hyperf'];
+        $swooleRequest->shouldReceive('rawContent')->andReturn(Json::encode($data));
+        $swooleRequest->header = ['host' => '127.0.0.1'];
+        $swooleRequest->server = ['server_port' => 9501];
+        $request = Request::loadFromSwooleRequest($swooleRequest);
+        $uri = $request->getUri();
+        $this->assertSame(null, $uri->getPort());
     }
 }


### PR DESCRIPTION
\Hyperf\HttpServer\Contract\ResponseInterface::redirect()跳转的URL会自动加上hyperf启动端口