### PR TITLE
propagate errors to parallel::wait()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#903](https://github.com/hyperf/hyperf/pull/903) Fixed execute `init-proxy` command can not stop when `hyperf/rpc-client` component exists.
 - [#904](https://github.com/hyperf/hyperf/pull/904) Fixed the hooked I/O request does not works in the listener that listening `Hyperf\Framework\Event\BeforeMainServerStart` event.
 - [#906](https://github.com/hyperf/hyperf/pull/906) Fixed `port` property of URI of `Hyperf\HttpMessage\Server\Request`.
+- [#909](https://github.com/hyperf/hyperf/pull/909) Fixed a issue that causes staled parallel execution.
 
 # v1.1.5 - 2019-11-07
 

--- a/doc/zh/coroutine.md
+++ b/doc/zh/coroutine.md
@@ -155,6 +155,8 @@ $wg->wait();
 
 ```php
 <?php
+use Hyperf\Utils\Exception\ParallelExecutionException;
+
 $parallel = new \Hyperf\Utils\Parallel();
 $parallel->add(function () {
     \Hyperf\Utils\Coroutine::sleep(1);
@@ -164,8 +166,13 @@ $parallel->add(function () {
     \Hyperf\Utils\Coroutine::sleep(1);
     return \Hyperf\Utils\Coroutine::id();
 });
-// $result 结果为 [1, 2]
-$result = $parallel->wait();
+try{
+    // $results 结果为 [1, 2]
+   $results = $parallel->wait(); 
+} catch(ParallelExecutionException $e){
+    //$e->getResults() 获取协程中的返回值。
+    //$e->getThrowables() 获取协程中出现的异常。
+}
 ```
 
 通过上面的代码我们可以看到仅花了 1 秒就得到了两个不同的协程的 ID，在调用 `add(callable $callable)` 的时候 `Parallel` 类会为之自动创建一个协程，并加入到 `WaitGroup` 的调度去。    

--- a/src/utils/src/Exception/ParallelExecutionException.php
+++ b/src/utils/src/Exception/ParallelExecutionException.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Utils\Exception;
+
+class ParallelExecutionException extends \RuntimeException
+{
+    /**
+     * @var array
+     */
+    private $results;
+
+    /**
+     * @var array
+     */
+    private $throwables;
+
+    public function getResults()
+    {
+        return $this->results;
+    }
+
+    public function setResults(array $results)
+    {
+        $this->results = $results;
+    }
+
+    public function getThrowables()
+    {
+        return $this->throwables;
+    }
+
+    public function setThrowables(array $throwables)
+    {
+        return $this->throwables = $throwables;
+    }
+}

--- a/src/utils/tests/ParallelTest.php
+++ b/src/utils/tests/ParallelTest.php
@@ -115,6 +115,28 @@ class ParallelTest extends TestCase
         $this->assertEquals(count($res), 4);
     }
 
+    public function testParallelThrows()
+    {
+        $parallel = new Parallel();
+
+        $err = function () {
+            Coroutine::sleep(0.001);
+            throw new \RuntimeException();
+        };
+
+        $ok = function () {
+            Coroutine::sleep(0.001);
+            return 1;
+        };
+
+        $parallel->add($err);
+        for ($i = 0; $i < 4; ++$i) {
+            $parallel->add($ok);
+        }
+        $this->expectException(\RuntimeException::class);
+        $res = $parallel->wait();
+    }
+
     public function returnCoId()
     {
         return Coroutine::id();

--- a/src/utils/tests/ParallelTest.php
+++ b/src/utils/tests/ParallelTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace HyperfTest\Utils;
 
 use Hyperf\Utils\Coroutine;
+use Hyperf\Utils\Exception\ParallelExecutionException;
 use Hyperf\Utils\Parallel;
 use PHPUnit\Framework\TestCase;
 
@@ -121,7 +122,7 @@ class ParallelTest extends TestCase
 
         $err = function () {
             Coroutine::sleep(0.001);
-            throw new \RuntimeException();
+            throw new \RuntimeException('something bad happened');
         };
 
         $ok = function () {
@@ -133,7 +134,7 @@ class ParallelTest extends TestCase
         for ($i = 0; $i < 4; ++$i) {
             $parallel->add($ok);
         }
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ParallelExecutionException::class);
         $res = $parallel->wait();
     }
 


### PR DESCRIPTION
请看我新加的一个测试用例。

Coroutine中出现未捕获的异常时：

- 以前的逻辑下，wait会永久hang住。
- 当前逻辑下，会把异常传播到wait()函数这里抛出。