### PR TITLE
apollo（阿波罗）获取的配置都是string类型，修复bool、int等类型支持

### DIFF
--- a/src/config-apollo/publish/apollo.php
+++ b/src/config-apollo/publish/apollo.php
@@ -19,4 +19,5 @@ return [
         'application',
     ],
     'interval' => 5,
+    'strict_mode' => false,
 ];

--- a/src/config-apollo/src/Listener/OnPipeMessageListener.php
+++ b/src/config-apollo/src/Listener/OnPipeMessageListener.php
@@ -91,9 +91,8 @@ class OnPipeMessageListener implements ListenerInterface
     }
 
     /**
-     * format processing
-     * @param $value
-     * @return bool|float|int|string|void
+     * Format processing
+     * @return mixed
      */
     private function formatValue($value)
     {

--- a/src/config-apollo/src/Listener/OnPipeMessageListener.php
+++ b/src/config-apollo/src/Listener/OnPipeMessageListener.php
@@ -83,15 +83,44 @@ class OnPipeMessageListener implements ListenerInterface
                 return;
             }
             foreach ($data->configurations ?? [] as $key => $value) {
-                if (is_numeric($value)) {
-                    $value = (strpos($value, '.') === false) ? (int) $value : (float) $value;
-                } elseif(in_array($value, ['true', 'false'])) {
-                    $value = ($value === 'true') ? true : false;
-                }
-                $this->config->set($key, $value);
+                $this->config->set($key, $this->formatValue($value));
                 $this->logger->debug(sprintf('Config [%s] is updated', $key));
             }
             ReleaseKey::set($cacheKey, $data->releaseKey);
         }
     }
+
+    /**
+     * format processing
+     * @param $value
+     * @return bool|float|int|string|void
+     */
+    private function formatValue($value)
+    {
+        if ($this->config->get('apollo.strict_mode', false) === false) {
+            return $value;
+        }
+
+        switch (strtolower($value)) {
+            case 'true':
+            case '(true)':
+                return true;
+            case 'false':
+            case '(false)':
+                return false;
+            case 'empty':
+            case '(empty)':
+                return '';
+            case 'null':
+            case '(null)':
+                return;
+        }
+
+        if (is_numeric($value)) {
+            $value = (strpos($value, '.') === false) ? (int) $value : (float) $value;
+        }
+
+        return $value;
+    }
+
 }

--- a/src/config-apollo/src/Listener/OnPipeMessageListener.php
+++ b/src/config-apollo/src/Listener/OnPipeMessageListener.php
@@ -84,9 +84,9 @@ class OnPipeMessageListener implements ListenerInterface
             }
             foreach ($data->configurations ?? [] as $key => $value) {
                 if (is_numeric($value)) {
-                    $value = (int) $value;
-                } else if(in_array($value, ['true', 'false'])) {
-                    $value = ($value == 'true') ? true : false;
+                    $value = (strpos($value, '.') === false) ? (int) $value : (float) $value;
+                } elseif(in_array($value, ['true', 'false'])) {
+                    $value = ($value === 'true') ? true : false;
                 }
                 $this->config->set($key, $value);
                 $this->logger->debug(sprintf('Config [%s] is updated', $key));

--- a/src/config-apollo/src/Listener/OnPipeMessageListener.php
+++ b/src/config-apollo/src/Listener/OnPipeMessageListener.php
@@ -83,6 +83,11 @@ class OnPipeMessageListener implements ListenerInterface
                 return;
             }
             foreach ($data->configurations ?? [] as $key => $value) {
+                if (is_numeric($value)) {
+                    $value = (int) $value;
+                } else if(in_array($value, ['true', 'false'])) {
+                    $value = ($value == 'true') ? true : false;
+                }
                 $this->config->set($key, $value);
                 $this->logger->debug(sprintf('Config [%s] is updated', $key));
             }


### PR DESCRIPTION
apollo（阿波罗）获取的配置都是string类型，修复bool、int等类型支持
fix https://github.com/hyperf/hyperf/issues/861