### PR TITLE
apollo（阿波罗）获取的配置都是string类型，修复bool、int、float等类型支持 

### DIFF
--- a/src/config-apollo/publish/apollo.php
+++ b/src/config-apollo/publish/apollo.php
@@ -19,4 +19,5 @@ return [
         'application',
     ],
     'interval' => 5,
+    'strict_mode' => false,
 ];

--- a/src/config-apollo/src/Listener/OnPipeMessageListener.php
+++ b/src/config-apollo/src/Listener/OnPipeMessageListener.php
@@ -83,10 +83,43 @@ class OnPipeMessageListener implements ListenerInterface
                 return;
             }
             foreach ($data->configurations ?? [] as $key => $value) {
-                $this->config->set($key, $value);
+                $this->config->set($key, $this->formatValue($value));
                 $this->logger->debug(sprintf('Config [%s] is updated', $key));
             }
             ReleaseKey::set($cacheKey, $data->releaseKey);
         }
     }
+
+    /**
+     * Format processing
+     * @return mixed
+     */
+    private function formatValue($value)
+    {
+        if ($this->config->get('apollo.strict_mode', false) === false) {
+            return $value;
+        }
+
+        switch (strtolower($value)) {
+            case 'true':
+            case '(true)':
+                return true;
+            case 'false':
+            case '(false)':
+                return false;
+            case 'empty':
+            case '(empty)':
+                return '';
+            case 'null':
+            case '(null)':
+                return;
+        }
+
+        if (is_numeric($value)) {
+            $value = (strpos($value, '.') === false) ? (int) $value : (float) $value;
+        }
+
+        return $value;
+    }
+
 }


### PR DESCRIPTION
apollo（阿波罗）获取的配置都是string类型，修复bool、int、float等类型支持 