### PR TITLE
Optimized DbConnectionResolver::connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - [#982](https://github.com/hyperf/hyperf/pull/982) Fixed `Hyperf\GrpcClient\GrpcClient::yield` does not get the correct channel pool.
 - [#987](https://github.com/hyperf/hyperf/pull/987) Fixed missing method call `parent::configure()` of `command.stub`.
 
+# Optimized
+
+- [#991](https://github.com/hyperf/hyperf/pull/991) Optimized `Hyperf\DbConnection\ConnectionResolver::connection`. 
+
 # Changed
 
 - [#977](https://github.com/hyperf/hyperf/pull/977) Changed `init-proxy.sh` command to only delete the `runtime/container` directory.

--- a/src/db-connection/src/ConnectionResolver.php
+++ b/src/db-connection/src/ConnectionResolver.php
@@ -64,13 +64,18 @@ class ConnectionResolver implements ConnectionResolverInterface
 
         if (! $connection instanceof ConnectionInterface) {
             $pool = $this->factory->getPool($name);
-            // When Mysql connect failed, it will be catched by `Hyperf\Database\Connectors\ConnectionFactory`.
-            $connection = $pool->get()->getConnection();
-            Context::set($id, $connection);
-            if (Coroutine::inCoroutine()) {
-                defer(function () use ($connection) {
-                    $connection->release();
-                });
+            $connection = $pool->get();
+            try {
+                // PDO is initialized as an anonymous function, so there is no IO exception,
+                // but if other exceptions are thrown, the connection will not return to the connection pool properly.
+                $connection = $connection->getConnection();
+                Context::set($id, $connection);
+            } finally {
+                if (Coroutine::inCoroutine()) {
+                    defer(function () use ($connection) {
+                        $connection->release();
+                    });
+                }
             }
         }
 

--- a/src/db-connection/tests/Stubs/FrequencyStub.php
+++ b/src/db-connection/tests/Stubs/FrequencyStub.php
@@ -18,9 +18,6 @@ class FrequencyStub extends Frequency
 {
     protected $time = 2;
 
-    /**
-     * @return array
-     */
     public function getHits(): array
     {
         return $this->hits;


### PR DESCRIPTION
这里分成两步来做，第一步 $connection = $pool->get(); 是不会有问题的，就算失败，Pool层级也会回收连接。
第二步，$connection->getConnection(); 因为这里 PDO 是以匿名函数返回，用到的时候判断如果是匿名函数，才会真正连接，所以这里理论上不会抛出异常，也就是不会存在连接被取出来，但是没有归还的问题。但保险起见，还是需要增加 finally。

```php
    /**
     * Create a new Closure that resolves to a PDO instance with a specific host or an array of hosts.
     *
     * @return \Closure
     */
    protected function createPdoResolverWithHosts(array $config)
    {
        return function () use ($config) {
            foreach (Arr::shuffle($hosts = $this->parseHosts($config)) as $key => $host) {
                $config['host'] = $host;

                try {
                    return $this->createConnector($config)->connect($config);
                } catch (PDOException $e) {
                    continue;
                }
            }

            throw $e;
        };
    }
```