### PR TITLE
修复从apollo拉取redis配置类型不符问题

### DIFF
--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -98,7 +98,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         $redis = null;
         if ($cluster !== true) {
             $redis = new \Redis();
-            if (! $redis->connect($host, $port, $timeout)) {
+            if (! $redis->connect($host, (int) $port, $timeout)) {
                 throw new ConnectionException('Connection reconnect failed.');
             }
         } else {


### PR DESCRIPTION
apollo配置中心拉取的redis 端口配置为string 类型 , redis连接要求端口为int类型,修复类型问题