### PR TITLE
增加组件http_consul_register

### DIFF
--- a/src/http-consul-register/.gitattributes
+++ b/src/http-consul-register/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore

--- a/src/http-consul-register/.travis.yml
+++ b/src/http-consul-register/.travis.yml
@@ -1,0 +1,40 @@
+language: php
+
+sudo: required
+
+matrix:
+  include:
+    - php: 7.2
+      env: SW_VERSION="4.4.7"
+    - php: 7.3
+      env: SW_VERSION="4.4.7"
+    - php: master
+      env: SW_VERSION="4.4.7"
+
+  allow_failures:
+    - php: master
+
+services:
+  - mysql
+  - redis-server
+  - docker
+
+before_install:
+  - export PHP_MAJOR="$(`phpenv which php` -r 'echo phpversion();' | cut -d '.' -f 1)"
+  - export PHP_MINOR="$(`phpenv which php` -r 'echo phpversion();' | cut -d '.' -f 2)"
+  - echo $PHP_MAJOR
+  - echo $PHP_MINOR
+
+install:
+  - cd $TRAVIS_BUILD_DIR
+  - bash ./tests/swoole.install.sh
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  - phpenv config-add ./tests/ci.ini
+
+before_script:
+  - cd $TRAVIS_BUILD_DIR
+  - composer config -g process-timeout 900 && composer update
+
+script:
+  - composer analyze
+  - composer test

--- a/src/http-consul-register/README.md
+++ b/src/http-consul-register/README.md
@@ -1,0 +1,26 @@
+# http_consul_register
+
+## 功能
+目前hyperf 只实现了微服务之间的rpc 协议的server 注册到consul
+
+这个包基于hyperf将hyperf 监听的http server 注册到consul，使得 consul 的内置dns 可以通过注册的service name 找到提供http1.1协议的可用服务实例
+
+
+### 安装 
+```
+composer require hyperf/http_consul_register
+
+```
+
+### 配置
+```
+// config/autoload/consul.php
+
+return [
+    'uri' => '127.0.0.1:8500',
+    'http_consul_register' => false, // 是否开启注册http server 到consul
+    'service_name' => 'front-api-gateway' // 注册到consul 的服务名称
+];
+
+```
+！注意config/autoload/server.php 必须有 name 为 http 的server，且只注册name为http 的server

--- a/src/http-consul-register/composer.json
+++ b/src/http-consul-register/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "hyperf/http_consul_register",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "php",
+        "hyperf",
+        "consul"
+    ],
+    "description": "",
+    "autoload": {
+        "psr-4": {
+            "Hyperf\\HttpConsulRegister\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "HyperfTest\\": "tests"
+        }
+    },
+    "require": {
+        "php": ">=7.2",
+        "ext-swoole": ">=4.4"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.14",
+        "phpstan/phpstan": "^0.10.5",
+        "hyperf/testing": "1.1.*",
+        "swoft/swoole-ide-helper": "dev-master"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "co-phpunit -c phpunit.xml --colors=always",
+        "analyze": "phpstan analyse --memory-limit 300M -l 0 ./src",
+        "cs-fix": "php-cs-fixer fix $1"
+    },
+    "extra": {
+        "hyperf": {
+            "config": "Hyperf\\HttpConsulRegister\\ConfigProvider"
+        }
+    }
+}

--- a/src/http-consul-register/phpunit.xml
+++ b/src/http-consul-register/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         verbose="true"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuite name="Testsuite">
+        <directory>./tests/</directory>
+    </testsuite>
+</phpunit>

--- a/src/http-consul-register/src/ConfigProvider.php
+++ b/src/http-consul-register/src/ConfigProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\HttpConsulRegister;
+
+class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies' => [
+            ],
+            'commands' => [
+            ],
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/http-consul-register/src/EnableHttpConsulRegisterListener.php
+++ b/src/http-consul-register/src/EnableHttpConsulRegisterListener.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\HttpConsulRegister;
+
+use Hyperf\Consul\Exception\ServerException;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Framework\Event\MainWorkerStart;
+use Hyperf\ServiceGovernance\Register\ConsulAgent;
+use Psr\Container\ContainerInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+
+/**
+ * @Listener()
+ */
+class EnableHttpConsulRegisterListener implements ListenerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var ConsulAgent
+     */
+    private $consulAgent;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var StdoutLoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array
+     */
+    private $registeredServices;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->consulAgent = $container->get(ConsulAgent::class);
+
+        $this->config = $container->get(ConfigInterface::class);
+
+        $this->logger = $container->get(StdoutLoggerInterface::class);
+    }
+
+    public function listen(): array
+    {
+        return [
+            MainWorkerStart::class,
+        ];
+    }
+
+    public function isEnable(): bool
+    {
+        return $this->config->get('consul.http_consul_register', false);
+    }
+
+    public function process(object $event)
+    {
+        if (!$this->isEnable()){
+            return;
+        }
+
+        $this->registeredServices = [];
+        $continue = true;
+
+        $httpServerConfig = $this->getHttpServerConfig();
+        $address = $httpServerConfig['host'];
+        if (in_array($address, ['0.0.0.0', 'localhost'])) {
+            $address = $this->getInternalIp();
+        }
+        $port = $httpServerConfig['port'];
+
+        $protocol = 'http';
+        $serviceName = $this->config->get('consul.service_name');
+
+        while ($continue) {
+            try {
+                $this->publishToConsul($address, (int) $port, $protocol, $serviceName);
+                $continue = false;
+            } catch (ServerException $throwable) {
+                if (strpos($throwable->getMessage(), 'Connection failed') !== false) {
+                    $this->logger->warning('Cannot register service, connection of service center failed, re-register after 10 seconds.');
+                    sleep(10);
+                } else {
+                    throw $throwable;
+                }
+            }
+        }
+    }
+
+    public function getHttpServerConfig()
+    {
+        $serverConfigs = $this->config->get('server.servers');
+        $httpServerConfigs = array_filter($serverConfigs, function($config) {
+            return $config['name'] = 'http';
+        });
+        if (count($httpServerConfigs)){
+            return $httpServerConfigs[0];
+        }
+
+        throw new \RuntimeException('Cannot register service, http server not exists.');
+    }
+
+    private function publishToConsul(string $address, int $port, string $protocol, string $serviceName)
+    {
+        $this->logger->debug(sprintf('Service %s is registering to the consul.', $serviceName));
+        if ($this->isRegistered($serviceName, $address, $port, $protocol)) {
+            $this->logger->info(sprintf('Service %s has been already registered to the consul.', $serviceName));
+            return;
+        }
+
+        $nextId = $this->generateId($this->getLastServiceId($serviceName));
+
+        $requestBody = [
+            'Name' => $serviceName,
+            'ID' => $nextId,
+            'Address' => $address,
+            'Port' => $port,
+            'Meta' => [
+                'Protocol' => $protocol,
+            ],
+        ];
+
+        $requestBody['Check'] = [
+            'DeregisterCriticalServiceAfter' => '90m',
+            'HTTP' => "http://{$address}:{$port}/",
+            'Interval' => '1s',
+        ];
+
+        $response = $this->consulAgent->registerService($requestBody);
+        if ($response->getStatusCode() === 200) {
+            $this->registeredServices[$serviceName][$protocol][$address][$port] = true;
+            $this->logger->info(sprintf('Service %s:%s register to the consul successfully.', $serviceName, $nextId));
+        } else {
+            $this->logger->warning(sprintf('Service %s register to the consul failed.', $serviceName));
+        }
+    }
+
+    private function generateId(string $name)
+    {
+        $exploded = explode('-', $name);
+        $length = count($exploded);
+        $end = -1;
+        if ($length > 1 && is_numeric($exploded[$length - 1])) {
+            $end = $exploded[$length - 1];
+            unset($exploded[$length - 1]);
+        }
+        $end = intval($end);
+        ++$end;
+        $exploded[] = $end;
+        return implode('-', $exploded);
+    }
+
+    private function getLastServiceId(string $name)
+    {
+        $maxId = -1;
+        $lastService = $name;
+        $services = $this->consulAgent->services()->json();
+        foreach ($services ?? [] as $id => $service) {
+            if (isset($service['Service']) && $service['Service'] === $name) {
+                $exploded = explode('-', (string) $id);
+                $length = count($exploded);
+                if ($length > 1 && is_numeric($exploded[$length - 1]) && $maxId < $exploded[$length - 1]) {
+                    $maxId = $exploded[$length - 1];
+                    $lastService = $service;
+                }
+            }
+        }
+        return $lastService['ID'] ?? $name;
+    }
+
+    private function getInternalIp(): string
+    {
+        $ips = swoole_get_local_ip();
+        if (is_array($ips)) {
+            return current($ips);
+        }
+        $ip = gethostbyname(gethostname());
+        if (is_string($ip)) {
+            return $ip;
+        }
+        throw new \RuntimeException('Can not get the internal IP.');
+    }
+
+    private function isRegistered(string $name, string $address, int $port, string $protocol): bool
+    {
+        if (isset($this->registeredServices[$name][$protocol][$address][$port])) {
+            return true;
+        }
+        $response = $this->consulAgent->services();
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->warning(sprintf('Service %s register to the consul failed.', $name));
+            return false;
+        }
+        $services = $response->json();
+        $glue = ',';
+        $tag = implode($glue, [$name, $address, $port, $protocol]);
+        foreach ($services as $serviceId => $service) {
+            if (! isset($service['Service'], $service['Address'], $service['Port'], $service['Meta']['Protocol'])) {
+                continue;
+            }
+            $currentTag = implode($glue, [
+                $service['Service'],
+                $service['Address'],
+                $service['Port'],
+                $service['Meta']['Protocol'],
+            ]);
+            if ($currentTag === $tag) {
+                $this->registeredServices[$name][$protocol][$address][$port] = true;
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/http-consul-register/tests/Cases/AbstractTestCase.php
+++ b/src/http-consul-register/tests/Cases/AbstractTestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Cases;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AbstractTestCase.
+ */
+abstract class AbstractTestCase extends TestCase
+{
+}

--- a/src/http-consul-register/tests/Cases/ExampleTest.php
+++ b/src/http-consul-register/tests/Cases/ExampleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Cases;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ExampleTest extends AbstractTestCase
+{
+    public function testExample()
+    {
+        $this->assertTrue(true);
+
+        $this->assertTrue(extension_loaded('swoole'));
+    }
+}

--- a/src/http-consul-register/tests/bootstrap.php
+++ b/src/http-consul-register/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';

--- a/src/http-consul-register/tests/ci.ini
+++ b/src/http-consul-register/tests/ci.ini
@@ -1,0 +1,8 @@
+[opcache]
+opcache.enable_cli=1
+
+[redis]
+extension = "redis.so"
+
+[swoole]
+extension = "swoole.so"

--- a/src/http-consul-register/tests/swoole.install.sh
+++ b/src/http-consul-register/tests/swoole.install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+wget https://github.com/swoole/swoole-src/archive/v"${SW_VERSION}".tar.gz -O swoole.tar.gz
+mkdir -p swoole
+tar -xf swoole.tar.gz -C swoole --strip-components=1
+rm swoole.tar.gz
+cd swoole || exit
+phpize
+./configure --enable-openssl --enable-mysqlnd
+make -j "$(nproc)"
+make install


### PR DESCRIPTION
 将 hyperf 工程中 server 为 http 的  http1.1 协的端口地址 注册到consul， 然后可以配置consul 的dns 到kong， 空根据consul 的nds service name  做转发， 这样 可以实现controller 层的 http 协议的 接口高可用