### PR TITLE
Connection Pool Error message no longer requires the understanding of implementation …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [#1021](https://github.com/hyperf/hyperf/pull/1021) Added default port to WebSocket client.
 
+## Optimized
+
+- [#1022](https://github.com/hyperf/hyperf/pull/1022) Provided cleaner connection pool error message without implementation details.
+
 # v1.1.7 - 2019-11-21
 
 ## Added

--- a/src/pool/src/Pool.php
+++ b/src/pool/src/Pool.php
@@ -133,7 +133,7 @@ abstract class Pool implements PoolInterface
 
         $connection = $this->channel->pop($this->option->getWaitTimeout());
         if (! $connection instanceof ConnectionInterface) {
-            throw new RuntimeException('Cannot pop the connection, pop timeout.');
+            throw new RuntimeException('Connection pool exhausted. Cannot establish new connection before wait_timeout.');
         }
         return $connection;
     }


### PR DESCRIPTION
…details

Users should not be bothered with the term related to Channel. It is purely an implementation detail.