### PR TITLE
Add set/define methods to $container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.1.9 - TBD
 
+## Added
+
+- [#1056](https://github.com/hyperf/hyperf/pull/1056) Added `define()` and `set()` to Container. Added `Hyperf\Contract\ContainerInterface`.
+
 ## Fixed
 
 - [#1049](https://github.com/hyperf/hyperf/pull/1049) Fixed `Hyperf\Cache\Driver\RedisDriver::clear` sometimes fails to delete all caches.

--- a/doc/en/middleware/middleware.md
+++ b/doc/en/middleware/middleware.md
@@ -233,6 +233,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 // $request and $response are the modified objects
-\Hyperf\Utils\Context::set(ServerRequestInterface::class, $request);
-\Hyperf\Utils\Context::set(ResponseInterface::class, $response);
+$request = \Hyperf\Utils\Context::set(ServerRequestInterface::class, $request);
+$response = \Hyperf\Utils\Context::set(ResponseInterface::class, $response);
 ```

--- a/doc/zh/middleware/middleware.md
+++ b/doc/zh/middleware/middleware.md
@@ -235,8 +235,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 // $request 和 $response 为修改后的对象
-\Hyperf\Utils\Context::set(ServerRequestInterface::class, $request);
-\Hyperf\Utils\Context::set(ResponseInterface::class, $response);
+$request = \Hyperf\Utils\Context::set(ServerRequestInterface::class, $request);
+$response = \Hyperf\Utils\Context::set(ResponseInterface::class, $response);
 ```
 
 ## 自定义 CoreMiddleWare 的行为

--- a/src/di/src/Container.php
+++ b/src/di/src/Container.php
@@ -93,6 +93,28 @@ class Container implements ContainerInterface
     }
 
     /**
+     * Bind an arbitrary resolved entry to an identifier.
+     * Useful for testing 'get'.
+     *
+     * @param mixed entry
+     */
+    public function set(string $name, $entry)
+    {
+        $this->resolvedEntries[$name] = $entry;
+    }
+
+    /**
+     * Bind an arbitrary definition to an identifier.
+     * Useful for testing 'make'.
+     *
+     * @param array|callable|string $definition
+     */
+    public function define(string $name, $definition)
+    {
+        $this->definitionSource->addDefinition($name) = $definition;
+    }
+
+    /**
      * Finds an entry of the container by its identifier and returns it.
      *
      * @param string $name identifier of the entry to look for


### PR DESCRIPTION
Add two methods (set and define) to the container, in order to smooth the testing.

usage:

```php
    public function testSet()
    {
        $container = new Container(new DefinitionSource([], new ScanConfig()));
        $subject = new Foo();
        $container->set(FooInterface::class, $subject);
        $this->assertSame($subject, $container->get(FooInterface::class));
    }

    public function testDefine()
    {
        $container = new Container(new DefinitionSource([], new ScanConfig()));
        $container->define(FooInterface::class, Foo::class);
        $this->assertInstanceOf(Foo::class, $container->make(FooInterface::class));
    }
```


