### PR TITLE
Fix bug

### DIFF
--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -78,7 +78,7 @@ class Request implements RequestInterface
      *
      * @param mixed $default
      */
-    public function input(string $key, $default = null)
+    public function input(?string $key, $default = null)
     {
         $data = $this->getInputData();
 

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -703,9 +703,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        json_decode($value);
-
-        return json_last_error() === JSON_ERROR_NONE;
+        return is_array(json_decode($value, true));
     }
 
     /**


### PR DESCRIPTION
input方法input参数key不能传null，验证器json规则如果参数传入null或整型数值则json_decode可以正常解码，使用json_last_error验证会导致规则绕过。