### PR TITLE
FIX (Hyperf\Validation\Request\FormRequest)：修复验证器表单请求调用validated方法不会触发ValidationException的问题

### DIFF
--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -69,7 +69,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated(): array
     {
-        return $this->getValidatorInstance()->validated();
+        return $this->getValidatorInstance()->validate();
     }
 
     /**

--- a/src/validation/tests/Cases/ValidationMiddlewareTest.php
+++ b/src/validation/tests/Cases/ValidationMiddlewareTest.php
@@ -104,7 +104,10 @@ class ValidationMiddlewareTest extends TestCase
     public function testGetValidatorInstance()
     {
         $container = $this->createContainer();
-        Context::set(ServerRequestInterface::class, new Request('POST', new Uri('/')));
+        Context::set(
+            ServerRequestInterface::class,
+            (new Request('POST', new Uri('/')))->withParsedBody(['username' => 'Hyperf', 'password' => 'Hyperf'])
+        );
         $request = $container->get(DemoRequest::class);
 
         $request->validated();


### PR DESCRIPTION
如果验证失败，验证器会抛一个 Hyperf\Validation\ValidationException 异常，您可以在通过添加一个自定义的异常处理类来处理该异常，与此同时，我们也提供了一个Hyperf\Validation\ValidationExceptionHandler 异常处理器来处理该异常，您也可以直接配置我们提供的异常处理器来处理。

但是实际上并不会出触发异常，而是仅仅绑定数据。