### PR TITLE
當JsonRpc TCP客戶端傳入非JSON格式字串，服務端沒有任何回應

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1104](https://github.com/hyperf/hyperf/pull/1104) Fixed guzzle will be retried when the response has the correct status code 2xx.
 - [#1106](https://github.com/hyperf/hyperf/pull/1106) Fixed bug that sticky mode will affect the next request.
+- [#1119](https://github.com/hyperf/hyperf/pull/1119) Fixed JSONRPC on TCP Server cannot response the expected error response when cannot unpack the data.
 
 ## Changed
 

--- a/src/json-rpc/src/TcpServer.php
+++ b/src/json-rpc/src/TcpServer.php
@@ -72,7 +72,7 @@ class TcpServer extends Server
 
     protected function buildRequest(int $fd, int $fromId, string $data): ServerRequestInterface
     {
-        return $this->buildJsonRpcRequest($fd, $fromId, $this->packer->unpack($data));
+        return $this->buildJsonRpcRequest($fd, $fromId, $this->packer->unpack($data) ?? ['jsonrpc' => '2.0']);
     }
 
     protected function buildJsonRpcRequest(int $fd, int $fromId, array $data)


### PR DESCRIPTION
當客戶端發生數據格式錯誤時，TCP服務端接收後，會在TcpServer::buildRequest()進行unpack (json_decode)。

對非JSON字串進行json_decode，會返回NULL值，
傳入到TcpServer::buildJsonRpcRequest()的array $data參數，
由於此參數不允許NULL，強行改為接受NULL亦會令接下來的出錯。
![image](https://user-images.githubusercontent.com/16300420/70527809-b4701280-1b87-11ea-9291-0900d25f2e15.png)

所以改為當json_decode返回NULL時，替換為 ['jsonrpc' => '2.0']
令TcpServer::buildJsonRpcRequest()能返回 $responseBuilder->buildErrorResponse()的結果。