### PR TITLE
静态调用 Hyperf\Validation\ValidationException::withMessages([])时, 报错: ValidatorFactory::make 方法不可静态调用

### DIFF
--- a/src/validation/src/ValidationException.php
+++ b/src/validation/src/ValidationException.php
@@ -14,7 +14,9 @@ namespace Hyperf\Validation;
 
 use Hyperf\Contract\ValidatorInterface;
 use Hyperf\Server\Exception\ServerException;
+use Hyperf\Utils\ApplicationContext;
 use Hyperf\Utils\Arr;
+use Hyperf\Validation\Contract\ValidatorFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class ValidationException extends ServerException
@@ -75,7 +77,9 @@ class ValidationException extends ServerException
      */
     public static function withMessages(array $messages)
     {
-        return new static(tap(make(ValidatorFactory::class)->make([], []), function ($validator) use ($messages) {
+        $factory = ApplicationContext::getContainer()->get(ValidatorFactoryInterface::class);
+
+        return new static(tap($factory->make([], []), function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
                 foreach (Arr::wrap($value) as $message) {
                     $validator->errors()->add($key, $message);

--- a/src/validation/src/ValidationException.php
+++ b/src/validation/src/ValidationException.php
@@ -75,7 +75,7 @@ class ValidationException extends ServerException
      */
     public static function withMessages(array $messages)
     {
-        return new static(tap(ValidatorFactory::make([], []), function ($validator) use ($messages) {
+        return new static(tap(make(ValidatorFactory::class)->make([], []), function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
                 foreach (Arr::wrap($value) as $message) {
                     $validator->errors()->add($key, $message);

--- a/src/validation/tests/Cases/ValidationExceptionTest.php
+++ b/src/validation/tests/Cases/ValidationExceptionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Validation\Cases;
+
+use Hyperf\Contract\TranslatorInterface;
+use Hyperf\Utils\ApplicationContext;
+use Hyperf\Utils\MessageBag;
+use Hyperf\Validation\Contract\ValidatorFactoryInterface;
+use Hyperf\Validation\ValidationException;
+use Hyperf\Validation\ValidatorFactory;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ValidationExceptionTest extends TestCase
+{
+    protected function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testWithMessages()
+    {
+        $this->getContainer();
+        $exception = ValidationException::withMessages([
+            'id' => 'id is required.',
+            'name' => ['name is required.'],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $exception);
+        $errors = $exception->validator->errors();
+        $this->assertInstanceOf(MessageBag::class, $errors);
+        $this->assertEquals([
+            'id' => ['id is required.'],
+            'name' => ['name is required.'],
+        ], $errors->getMessages());
+    }
+
+    protected function getContainer()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+
+        $container->shouldReceive('get')->with(ValidatorFactoryInterface::class)->andReturnUsing(function () use ($container) {
+            $translator = Mockery::mock(TranslatorInterface::class);
+            return new ValidatorFactory($translator, $container);
+        });
+
+        return $container;
+    }
+}


### PR DESCRIPTION
静态调用 Hyperf\Validation\ValidationException::withMessages([])时, 报错: ValidatorFactory::make 方法不可静态调用