### PR TITLE
解决个别情况下一个内存溢出问题

### DIFF
--- a/src/http-server/src/CoreMiddleware.php
+++ b/src/http-server/src/CoreMiddleware.php
@@ -81,10 +81,10 @@ class CoreMiddleware implements CoreMiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = Context::set(ServerRequestInterface::class, $request);
-
         /** @var Dispatched $dispatched */
         $dispatched = $request->getAttribute(Dispatched::class);
+        
+        $request = Context::set(ServerRequestInterface::class, $request->withAttribute(Dispatched::class, $dispatched));
 
         if (! $dispatched instanceof Dispatched) {
             throw new ServerException(sprintf('The dispatched object is not a %s object.', Dispatched::class));


### PR DESCRIPTION
Hyperf\HttpServer\Request::getAttribute 会陷入死循环，导致内存溢出，程序崩溃 php_swoole_server_rshutdown, swManager_check_exit_status: worker#0[pid=1331] abnormal exit, status=1, signal=0