### PR TITLE
修复将查询结果转为数组后chunkById方法去lastId有误的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Fixed
 
-- [#1189](https://github.com/hyperf/hyperf/pull/1189) Fixed default operator `=` does not works for `Hyperf\Utils\Collection::operatorForWhere`.
+- [#1189](https://github.com/hyperf/hyperf/pull/1189) Fixed default operator does not works for `Hyperf\Utils\Collection::operatorForWhere`.
+- [#1178](https://github.com/hyperf/hyperf/pull/1178) Fixed `Hyperf\Database\Query\Builder::chunkById` does not works when the collection item is array.
 
 ## Optimized
 

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -1175,6 +1175,7 @@ class Connection implements ConnectionInterface
 
     /**
      * Fire the given event if possible.
+     * @param mixed $event
      */
     protected function event($event)
     {

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -1934,7 +1934,8 @@ class Builder
                 return false;
             }
 
-            $lastId = $results->last()->{$alias};
+            $lastResult = $results->last();
+            $lastId = is_array($lastResult) ? $lastResult[$alias] : $lastResult->{$alias};
 
             unset($results);
         } while ($countResults == $count);


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/1155 ，去lastId时候增加类型判定