### PR TITLE
Fixed #1205 开启严格模式，导致mb_strlen函数报类型错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [#1175](https://github.com/hyperf/hyperf/pull/1175) Fixed `Hyperf\Utils\Collection::random` does not works when the number is null.
 - [#1200](https://github.com/hyperf/hyperf/pull/1200) Request path shouldn't include query parameters in hyperf/metric middleware.
-
+- [#1205](https://github.com/hyperf/hyperf/issues/1205) Fixed validation `size` does not works without `numeric` or `integer` rules when the type of value is numeric.
 
 # v1.1.12 - 2019-12-26
 

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -1493,7 +1493,7 @@ trait ValidatesAttributes
             return $value->getSize() / 1024;
         }
 
-        return mb_strlen((string)$value);
+        return mb_strlen((string) $value);
     }
 
     /**

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -30,7 +30,6 @@ use Hyperf\Validation\ValidationData;
 use InvalidArgumentException;
 use SplFileInfo;
 use Throwable;
-use function DI\string;
 
 trait ValidatesAttributes
 {

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -30,6 +30,7 @@ use Hyperf\Validation\ValidationData;
 use InvalidArgumentException;
 use SplFileInfo;
 use Throwable;
+use function DI\string;
 
 trait ValidatesAttributes
 {
@@ -1492,7 +1493,7 @@ trait ValidatesAttributes
             return $value->getSize() / 1024;
         }
 
-        return mb_strlen($value);
+        return mb_strlen((string)$value);
     }
 
     /**

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -1505,6 +1505,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '3'], ['foo' => 'Numeric|Size:3']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => 123], ['foo' => 'Size:123']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 3], ['foo' => 'Size:1']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Size:3']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
- 修复严格模式下 getSize 调用 mb_strlen类型报错
- testValidateSize 添加两个数值参数的非数值类型验证测试用例