### PR TITLE
Add amqp extension whether consumers follow service startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.1.14 - TBD
 
+## Added
+
+- [#1219](https://github.com/hyperf/hyperf/pull/1219) Add amqp extension whether consumers follow service startup.
+
 # v1.1.13 - 2020-01-03
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-- [#1219](https://github.com/hyperf/hyperf/pull/1219) Add amqp extension whether consumers follow service startup.
+- [#1219](https://github.com/hyperf/hyperf/pull/1219) Added property `enable` for amqp consumer, which controls whether consumers should start along with the service.
 
 ## Fixed
 

--- a/doc/zh-cn/amqp.md
+++ b/doc/zh-cn/amqp.md
@@ -159,7 +159,8 @@ class DemoConsumer extends ConsumerMessage
 }
 ```
 
-框架会根据 `@Consumer` 注解自动创建 `Process 进程`，进程意外退出后会被重新拉起。
+框架会根据 `@Consumer` 注解自动创建 `Process 进程`，进程意外退出后会被重新拉起。如果不想让 `Process 进程` 跟随服务启动，可在 `@Consumer` 
+注解中配置 `isEnable=false` (默认为 `true` 跟随服务启动)或者在对应的消费者中重写类方法 `isEnable()` 返回 `false` 即可
 
 ### 消费结果
 

--- a/doc/zh-cn/amqp.md
+++ b/doc/zh-cn/amqp.md
@@ -159,8 +159,41 @@ class DemoConsumer extends ConsumerMessage
 }
 ```
 
-框架会根据 `@Consumer` 注解自动创建 `Process 进程`，进程意外退出后会被重新拉起。如果不想让 `Process 进程` 跟随服务启动，可在 `@Consumer` 
-注解中配置 `isEnable=false` (默认为 `true` 跟随服务启动)或者在对应的消费者中重写类方法 `isEnable()` 返回 `false` 即可
+### 禁止消费进程自启
+
+默认情况下，使用了 `@Consumer` 注解后，框架会自动创建子进程启动消费者，并且会在子进程异常退出后，重新拉起。
+如果出于开发阶段，进行消费者调试时，可能会因为消费其他消息而导致调试不便。
+
+这种情况，只需要在 `@Consumer` 注解中配置 `enable=false` (默认为 `true` 跟随服务启动)或者在对应的消费者中重写类方法 `isEnable()` 返回 `false` 即可
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Amqp\Consumers;
+
+use Hyperf\Amqp\Annotation\Consumer;
+use Hyperf\Amqp\Message\ConsumerMessage;
+use Hyperf\Amqp\Result;
+
+/**
+ * @Consumer(exchange="hyperf", routingKey="hyperf", queue="hyperf", nums=1, enable=false)
+ */
+class DemoConsumer extends ConsumerMessage
+{
+    public function consume($data): string
+    {
+        print_r($data);
+        return Result::ACK;
+    }
+
+    public function isEnable(): bool
+    {
+        return parent::isEnable();
+    }
+}
+```
 
 ### 消费结果
 

--- a/src/amqp/src/Annotation/Consumer.php
+++ b/src/amqp/src/Annotation/Consumer.php
@@ -46,7 +46,7 @@ class Consumer extends AbstractAnnotation
     public $nums = 1;
 
     /**
-     * @var bool
+     * @var null|bool
      */
-    public $isEnable = true;
+    public $enable;
 }

--- a/src/amqp/src/Annotation/Consumer.php
+++ b/src/amqp/src/Annotation/Consumer.php
@@ -44,4 +44,9 @@ class Consumer extends AbstractAnnotation
      * @var int
      */
     public $nums = 1;
+
+    /**
+     * @var bool
+     */
+    public $isEnable = true;
 }

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -82,6 +82,11 @@ class ConsumerManager
             {
                 $this->consumer->consume($this->consumerMessage);
             }
+
+            public function isEnable(): bool
+            {
+                return $this->consumerMessage->isEnable();
+            }
         };
     }
 }

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -43,9 +43,7 @@ class ConsumerManager
             if (! $instance instanceof ConsumerMessageInterface) {
                 continue;
             }
-            if ($annotation->isEnable === false) {
-                continue;
-            }
+
             $annotation->exchange && $instance->setExchange($annotation->exchange);
             $annotation->routingKey && $instance->setRoutingKey($annotation->routingKey);
             $annotation->queue && $instance->setQueue($annotation->queue);

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -43,6 +43,9 @@ class ConsumerManager
             if (! $instance instanceof ConsumerMessageInterface) {
                 continue;
             }
+            if ($annotation->isEnable === false) {
+                continue;
+            }
             $annotation->exchange && $instance->setExchange($annotation->exchange);
             $annotation->routingKey && $instance->setRoutingKey($annotation->routingKey);
             $annotation->queue && $instance->setQueue($annotation->queue);

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -47,7 +47,7 @@ class ConsumerManager
             $annotation->exchange && $instance->setExchange($annotation->exchange);
             $annotation->routingKey && $instance->setRoutingKey($annotation->routingKey);
             $annotation->queue && $instance->setQueue($annotation->queue);
-            $annotation->enable && $instance->setEnable($annotation->enable);
+            ! is_null($annotation->enable) && $instance->setEnable($annotation->enable);
             property_exists($instance, 'container') && $instance->container = $this->container;
             $nums = $annotation->nums;
             $process = $this->createProcess($instance);
@@ -80,6 +80,11 @@ class ConsumerManager
             public function handle(): void
             {
                 $this->consumer->consume($this->consumerMessage);
+            }
+
+            public function getConsumerMessage(): ConsumerMessageInterface
+            {
+                return $this->consumerMessage;
             }
 
             public function isEnable(): bool

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -49,6 +49,7 @@ class ConsumerManager
             $annotation->exchange && $instance->setExchange($annotation->exchange);
             $annotation->routingKey && $instance->setRoutingKey($annotation->routingKey);
             $annotation->queue && $instance->setQueue($annotation->queue);
+            $annotation->enable && $instance->setEnable($annotation->enable);
             property_exists($instance, 'container') && $instance->container = $this->container;
             $nums = $annotation->nums;
             $process = $this->createProcess($instance);

--- a/src/amqp/src/Message/ConsumerMessage.php
+++ b/src/amqp/src/Message/ConsumerMessage.php
@@ -44,6 +44,11 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
      */
     protected $qos;
 
+    /**
+     * @var bool
+     */
+    protected $enable = true;
+
     public function setQueue(string $queue): self
     {
         $this->queue = $queue;
@@ -80,11 +85,17 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
 
     public function getConsumerTag(): string
     {
-        return implode(',', (array)$this->getRoutingKey());
+        return implode(',', (array) $this->getRoutingKey());
     }
 
     public function isEnable(): bool
     {
-        return true;
+        return $this->enable;
+    }
+
+    public function setEnable(bool $enable): self
+    {
+        $this->enable = $enable;
+        return $this;
     }
 }

--- a/src/amqp/src/Message/ConsumerMessage.php
+++ b/src/amqp/src/Message/ConsumerMessage.php
@@ -80,6 +80,11 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
 
     public function getConsumerTag(): string
     {
-        return implode(',', (array) $this->getRoutingKey());
+        return implode(',', (array)$this->getRoutingKey());
+    }
+
+    public function isEnable(): bool
+    {
+        return true;
     }
 }

--- a/src/amqp/src/Message/ConsumerMessageInterface.php
+++ b/src/amqp/src/Message/ConsumerMessageInterface.php
@@ -29,4 +29,8 @@ interface ConsumerMessageInterface extends MessageInterface
     public function getQueueBuilder(): QueueBuilder;
 
     public function getConsumerTag(): string;
+
+    public function isEnable(): bool;
+
+    public function setEnable(bool $enable);
 }

--- a/src/amqp/tests/ConsumerManagerTest.php
+++ b/src/amqp/tests/ConsumerManagerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Amqp;
+
+use Hyperf\Amqp\Annotation\Consumer;
+use Hyperf\Amqp\ConsumerManager;
+use Hyperf\Amqp\Message\ConsumerMessageInterface;
+use Hyperf\Di\Annotation\AnnotationCollector;
+use Hyperf\Process\ProcessManager;
+use HyperfTest\Amqp\Stub\ContainerStub;
+use HyperfTest\Amqp\Stub\DemoConsumer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ConsumerManagerTest extends TestCase
+{
+    protected function tearDown()
+    {
+        ProcessManager::clear();
+    }
+
+    public function testConsumerAnnotation()
+    {
+        $container = ContainerStub::getContainer();
+
+        AnnotationCollector::collectClass(DemoConsumer::class, Consumer::class, new Consumer([
+            'exchange' => $exchange = uniqid(),
+            'routingKey' => $routingKey = uniqid(),
+            'queue' => $queue = uniqid(),
+            'nums' => $nums = rand(1, 10),
+        ]));
+
+        $manager = new ConsumerManager($container);
+        $manager->run();
+
+        $hasRegisted = false;
+        foreach (ProcessManager::all() as $item) {
+            if (method_exists($item, 'getConsumerMessage')) {
+                $hasRegisted = true;
+                /** @var ConsumerMessageInterface $message */
+                $message = $item->getConsumerMessage();
+                $this->assertTrue($item->isEnable());
+                $this->assertSame($exchange, $message->getExchange());
+                $this->assertSame($routingKey, $message->getRoutingKey());
+                $this->assertSame($queue, $message->getQueue());
+                $this->assertSame($nums, $item->nums);
+                break;
+            }
+        }
+
+        $this->assertTrue($hasRegisted);
+    }
+
+    public function testConsumerAnnotationNotEnable()
+    {
+        $container = ContainerStub::getContainer();
+
+        AnnotationCollector::collectClass(DemoConsumer::class, Consumer::class, new Consumer([
+            'exchange' => $exchange = uniqid(),
+            'routingKey' => $routingKey = uniqid(),
+            'queue' => $queue = uniqid(),
+            'nums' => $nums = rand(1, 10),
+            'enable' => false,
+        ]));
+
+        $manager = new ConsumerManager($container);
+        $manager->run();
+
+        $hasRegisted = false;
+        foreach (ProcessManager::all() as $item) {
+            if (method_exists($item, 'getConsumerMessage')) {
+                $hasRegisted = true;
+                $this->assertFalse($item->isEnable());
+                break;
+            }
+        }
+
+        $this->assertTrue($hasRegisted);
+    }
+}

--- a/src/amqp/tests/Stub/ContainerStub.php
+++ b/src/amqp/tests/Stub/ContainerStub.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace HyperfTest\Amqp\Stub;
 
+use Hyperf\Amqp\Consumer;
 use Hyperf\Amqp\Pool\PoolFactory;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Utils\ApplicationContext;
@@ -40,6 +41,9 @@ class ContainerStub
         });
         $container->shouldReceive('has')->andReturnUsing(function ($class) {
             return true;
+        });
+        $container->shouldReceive('get')->with(Consumer::class)->andReturnUsing(function () use ($container) {
+            return new Consumer($container, $container->get(PoolFactory::class), $container->get(StdoutLoggerInterface::class));
         });
 
         return $container;


### PR DESCRIPTION
```php
// 注解中 isEnable 默认为 true 跟随服务启动
/**
 * @Consumer(
 *     routingKey="",
 *     queue="",
 *     name ="",
 *     nums=1,
 *     isEnable=false
 *     )
 */
class DemoConsumer extends ConsumerMessage
{
    public function consume($data): string
    {
        return Result::ACK;
    }
}

// 如果配置 isEnable 为 false，不跟随服务启动，可通过Commmand手动处理消息
$consumer = new \Hyperf\Amqp\Consumer(
       $this->container,
       $this->container->get(\Hyperf\Amqp\Pool\PoolFactory::class),
       $this->container->get(\Hyperf\Contract\StdoutLoggerInterface::class)
);
$consumer->consume(new App\Amqp\Consumer\DemoConsumer());
```