### PR TITLE
Upgrades jcchavezs/zipkin-php-opentracing to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.1.14 - TBD
 
+## Changed
+
+- [#1227](https://github.com/hyperf/hyperf/pull/1227) Upgraded jcchavezs/zipkin-php-opentracing to 0.1.4.
+
 # v1.1.13 - 2020-01-03
 
 ## Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "grpc/grpc": "^1.15",
         "guzzlehttp/guzzle": "^6.3",
         "ircmaxell/random-lib": "^1.2",
-        "jcchavezs/zipkin-opentracing": "^0.1.2",
+        "jcchavezs/zipkin-opentracing": "^0.1.4",
         "jean85/pretty-package-versions": "^1.2",
         "laminas/laminas-mime": "^2.7",
         "monolog/monolog": "^1.24",


### PR DESCRIPTION
This includes one bugfix and one new feature for propagation. For more details see https://github.com/jcchavezs/zipkin-php-opentracing/releases/tag/0.1.4