### PR TITLE
perfect request uri

### DIFF
--- a/src/http-server/src/CoreMiddleware.php
+++ b/src/http-server/src/CoreMiddleware.php
@@ -68,11 +68,16 @@ class CoreMiddleware implements CoreMiddlewareInterface
 
     public function dispatch(ServerRequestInterface $request): ServerRequestInterface
     {
-        $routes = $this->dispatcher->dispatch($request->getMethod(), $request->getUri()->getPath());
+        $routes = $this->dispatcher->dispatch($request->getMethod(), $this->perfectUri($request->getUri()->getPath()));
 
         $dispatched = new Dispatched($routes);
 
         return Context::set(ServerRequestInterface::class, $request->withAttribute(Dispatched::class, $dispatched));
+    }
+
+    protected function perfectUri($uri)
+    {
+        return '/' . trim($uri);
     }
 
     /**


### PR DESCRIPTION
127.0.0.1:9501/index/index/ 和 127.0.0.1:9501//index/index/ 访问时会找不到路由，做了下兼容