### PR TITLE
di 容器 get 方法删除多余逻辑。

### DIFF
--- a/src/di/src/Container.php
+++ b/src/di/src/Container.php
@@ -122,7 +122,7 @@ class Container implements HyperfContainerInterface
     public function get($name)
     {
         // If the entry is already resolved we return it
-        if (isset($this->resolvedEntries[$name]) || array_key_exists($name, $this->resolvedEntries)) {
+        if (array_key_exists($name, $this->resolvedEntries)) {
             return $this->resolvedEntries[$name];
         }
         $this->resolvedEntries[$name] = $value = $this->make($name);


### PR DESCRIPTION
`isset($this->resolvedEntries[$name]) || array_key_exists($name, $this->resolvedEntries)`  与 `array_key_exists($name, $this->resolvedEntries)` 效果一样。