### PR TITLE
Added `ModelRewriteInheritanceVisitor` to rewrite the model inheritance for command `gen:model`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- [#1328](https://github.com/hyperf/hyperf/pull/1328) Added `ModelRewriteInheritanceVisitor` to rewrite the model inheritance for command `gen:model`.
 - [#1331](https://github.com/hyperf/hyperf/pull/1331) Added `Hyperf\LoadBalancer\LoadBalancerInterface::getNodes()`.
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - [#1303](https://github.com/hyperf/hyperf/pull/1303) Deleted useless `$httpMethod` for `Hyperf\RpcServer\Router\Router`.
 
+## Fixed
+
+- [#1328](https://github.com/hyperf/hyperf/pull/1328) Fixed when model exists,and reset the parent class,but ModelCommand::createModel not update.
+
+
 # v1.1.17 - 2020-01-24
 
 ## Added

--- a/src/database/src/Commands/Ast/ModelRewriteInheritanceVisitor.php
+++ b/src/database/src/Commands/Ast/ModelRewriteInheritanceVisitor.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Database\Commands\Ast;
+
+use Hyperf\Database\Commands\ModelData;
+use Hyperf\Database\Commands\ModelOption;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\NodeVisitorAbstract;
+
+class ModelRewriteInheritanceVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var ModelOption
+     */
+    protected $option;
+
+    /**
+     * @var ModelData
+     */
+    protected $data;
+
+    public function __construct(ModelOption $option, ModelData $data)
+    {
+        $this->option = $option;
+        $this->data = $data;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        switch ($node) {
+            case $node instanceof Node\Stmt\Class_:
+                $inheritance = $this->option->getInheritance();
+                if (is_object($node->extends) && ! empty($inheritance)) {
+                    $node->extends->parts = [$inheritance];
+                }
+                return $node;
+            case $node instanceof Node\Stmt\UseUse:
+                $modelParent = get_parent_class($this->data->getClass());
+
+                $class = end($node->name->parts);
+                $alias = is_object($node->alias) ? $node->alias->name : '';
+                if ($class == $modelParent || $alias == $modelParent) {
+                    preg_match_all('/\s*([a-z0-9\\\\]+)(as)?([a-z0-9]+)?;?\s*/is', $this->option->getUses(), $match);
+                    if (! empty($match) && isset($match[1][0])) {
+                        $newClass = $match[1][0];
+                        $newAlias = $match[1][2] ?? '';
+
+                        $node->name->parts = explode('\\', $newClass);
+                        $node->alias = null;
+
+                        if (! empty($newAlias)) {
+                            $node->alias = new Identifier($newAlias);
+                            $node->alias->setAttribute('startLine', $node->getAttribute('startLine'));
+                            $node->alias->setAttribute('endLine', $node->getAttribute('endLine'));
+                        }
+                    }
+                }
+                return $node;
+        }
+    }
+}

--- a/src/database/src/Commands/Ast/ModelRewriteInheritanceVisitor.php
+++ b/src/database/src/Commands/Ast/ModelRewriteInheritanceVisitor.php
@@ -30,10 +30,51 @@ class ModelRewriteInheritanceVisitor extends NodeVisitorAbstract
      */
     protected $data;
 
+    /**
+     * @var null|string
+     */
+    protected $parentClass;
+
+    /**
+     * @var bool
+     */
+    protected $shouldAddUseUse = true;
+
     public function __construct(ModelOption $option, ModelData $data)
     {
         $this->option = $option;
         $this->data = $data;
+
+        if (! empty($option->getUses())) {
+            preg_match_all('/\s*([a-z0-9\\\\]+)(as)?([a-z0-9]+)?;?\s*/is', $option->getUses(), $match);
+            if (isset($match[1][0])) {
+                $this->parentClass = $match[1][0];
+            }
+        }
+    }
+
+    public function afterTraverse(array $nodes)
+    {
+        if (empty($this->option->getUses())) {
+            return null;
+        }
+
+        $use = new Node\Stmt\UseUse(
+            new Node\Name($this->parentClass),
+            $this->option->getInheritance()
+        );
+
+        foreach ($nodes as $namespace) {
+            if (! $namespace instanceof Node\Stmt\Namespace_) {
+                continue;
+            }
+
+            if ($this->shouldAddUseUse) {
+                array_unshift($namespace->stmts, new Node\Stmt\Use_([$use]));
+            }
+        }
+
+        return null;
     }
 
     public function leaveNode(Node $node)
@@ -46,24 +87,14 @@ class ModelRewriteInheritanceVisitor extends NodeVisitorAbstract
                 }
                 return $node;
             case $node instanceof Node\Stmt\UseUse:
-                $modelParent = get_parent_class($this->data->getClass());
-
-                $class = end($node->name->parts);
-                $alias = is_object($node->alias) ? $node->alias->name : '';
-                if ($class == $modelParent || $alias == $modelParent) {
-                    preg_match_all('/\s*([a-z0-9\\\\]+)(as)?([a-z0-9]+)?;?\s*/is', $this->option->getUses(), $match);
-                    if (! empty($match) && isset($match[1][0])) {
-                        $newClass = $match[1][0];
-                        $newAlias = $match[1][2] ?? '';
-
-                        $node->name->parts = explode('\\', $newClass);
-                        $node->alias = null;
-
-                        if (! empty($newAlias)) {
-                            $node->alias = new Identifier($newAlias);
-                            $node->alias->setAttribute('startLine', $node->getAttribute('startLine'));
-                            $node->alias->setAttribute('endLine', $node->getAttribute('endLine'));
-                        }
+                $class = implode('\\', $node->name->parts);
+                $alias = is_object($node->alias) ? $node->alias->name : null;
+                if ($class == $this->parentClass) {
+                    // The parent class is exists.
+                    $this->shouldAddUseUse = false;
+                    if (end($node->name->parts) !== $this->option->getInheritance() && $alias !== $this->option->getInheritance()) {
+                        // Rewrite the alias, if the class is not equal with inheritance.
+                        $node->alias = new Identifier($this->option->getInheritance());
                     }
                 }
                 return $node;

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -47,12 +47,6 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
 
                 return $node;
             case $node instanceof Node\Stmt\Class_:
-                //更改模型继承的父类名;
-                $inheritance = $this->option->getInheritance();
-                if (is_object($node->extends) && ! empty($inheritance)) {
-                    $node->extends->parts = [$inheritance];
-                }
-
                 $doc = '/**' . PHP_EOL;
                 foreach ($this->columns as $column) {
                     [$name, $type, $comment] = $this->getProperty($column);

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -172,9 +172,8 @@ class ModelCommand extends Command
             if (! is_dir($dir)) {
                 @mkdir($dir, 0755, true);
             }
-
-            file_put_contents($path, $this->buildClass($table, $class, $option));
         }
+        file_put_contents($path, $this->buildClass($table, $class, $option));
 
         $columns = $this->getColumns($class, $columns, $option->isForceCasts());
 

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -172,8 +172,8 @@ class ModelCommand extends Command
             if (! is_dir($dir)) {
                 @mkdir($dir, 0755, true);
             }
+            file_put_contents($path, $this->buildClass($table, $class, $option));
         }
-        file_put_contents($path, $this->buildClass($table, $class, $option));
 
         $columns = $this->getColumns($class, $columns, $option->isForceCasts());
 
@@ -182,6 +182,7 @@ class ModelCommand extends Command
         $visitor = make(ModelUpdateVisitor::class, [
             'columns' => $columns,
             'option' => $option,
+            'class' => $class,
         ]);
         $traverser->addVisitor($visitor);
         $traverser->addVisitor(make(ModelRewriteConnectionVisitor::class, [$class, $option->getPool()]));

--- a/src/database/src/Commands/ModelData.php
+++ b/src/database/src/Commands/ModelData.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Database\Commands;
+
+class ModelData
+{
+    /**
+     * @var array
+     */
+    protected $columns;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function setColumns(array $columns): self
+    {
+        $this->columns = $columns;
+        return $this;
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function setClass(string $class): self
+    {
+        $this->class = $class;
+        return $this;
+    }
+}

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -64,12 +64,17 @@ class ModelOption
      */
     protected $ignoreTables = [];
 
+    /**
+     * @var array
+     */
+    protected $visitors = [];
+
     public function getPool(): string
     {
         return $this->pool;
     }
 
-    public function setPool(string $pool): ModelOption
+    public function setPool(string $pool): self
     {
         $this->pool = $pool;
         return $this;
@@ -80,7 +85,7 @@ class ModelOption
         return $this->path;
     }
 
-    public function setPath(string $path): ModelOption
+    public function setPath(string $path): self
     {
         $this->path = $path;
         return $this;
@@ -91,7 +96,7 @@ class ModelOption
         return $this->forceCasts;
     }
 
-    public function setForceCasts(bool $forceCasts): ModelOption
+    public function setForceCasts(bool $forceCasts): self
     {
         $this->forceCasts = $forceCasts;
         return $this;
@@ -102,7 +107,7 @@ class ModelOption
         return $this->prefix;
     }
 
-    public function setPrefix(string $prefix): ModelOption
+    public function setPrefix(string $prefix): self
     {
         $this->prefix = $prefix;
         return $this;
@@ -113,7 +118,7 @@ class ModelOption
         return $this->inheritance;
     }
 
-    public function setInheritance(string $inheritance): ModelOption
+    public function setInheritance(string $inheritance): self
     {
         $this->inheritance = $inheritance;
         return $this;
@@ -124,7 +129,7 @@ class ModelOption
         return $this->uses;
     }
 
-    public function setUses(string $uses): ModelOption
+    public function setUses(string $uses): self
     {
         $this->uses = $uses;
         return $this;
@@ -135,7 +140,7 @@ class ModelOption
         return $this->refreshFillable;
     }
 
-    public function setRefreshFillable(bool $refreshFillable): ModelOption
+    public function setRefreshFillable(bool $refreshFillable): self
     {
         $this->refreshFillable = $refreshFillable;
         return $this;
@@ -146,7 +151,7 @@ class ModelOption
         return $this->tableMapping;
     }
 
-    public function setTableMapping(array $tableMapping): ModelOption
+    public function setTableMapping(array $tableMapping): self
     {
         foreach ($tableMapping as $item) {
             [$key, $name] = explode(':', $item);
@@ -161,7 +166,7 @@ class ModelOption
         return $this->ignoreTables;
     }
 
-    public function setIgnoreTables(array $ignoreTables): ModelOption
+    public function setIgnoreTables(array $ignoreTables): self
     {
         $this->ignoreTables = $ignoreTables;
         return $this;
@@ -172,9 +177,20 @@ class ModelOption
         return $this->withComments;
     }
 
-    public function setWithComments(bool $withComments): ModelOption
+    public function setWithComments(bool $withComments): self
     {
         $this->withComments = $withComments;
+        return $this;
+    }
+
+    public function getVisitors(): array
+    {
+        return $this->visitors;
+    }
+
+    public function setVisitors(array $visitors): self
+    {
+        $this->visitors = $visitors;
         return $this;
     }
 }

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -408,7 +408,7 @@ class Blueprint
      *
      * @param array|string $columns
      * @param string $name
-     * @return \Hyperf\Utils\Fluent|\Hyperf\Database\Schema\ForeignKeyDefinition
+     * @return \Hyperf\Database\Schema\ForeignKeyDefinition|\Hyperf\Utils\Fluent
      */
     public function foreign($columns, $name = null)
     {

--- a/src/database/src/Schema/ForeignKeyDefinition.php
+++ b/src/database/src/Schema/ForeignKeyDefinition.php
@@ -15,7 +15,7 @@ namespace Hyperf\Database\Schema;
 use Hyperf\Utils\Fluent;
 
 /**
- * @method ForeignKeyDefinition references(string|array $columns) Specify the referenced column(s)
+ * @method ForeignKeyDefinition references(array|string $columns) Specify the referenced column(s)
  * @method ForeignKeyDefinition on(string $table) Specify the referenced table
  * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
  * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action


### PR DESCRIPTION
修复命令行创建模型,当模型类已存在时,重新指定uses继承其他父类,而该模型没有更新新父类的问题
```sh
#如
php bin/hyperf.php --uses="App\Model\Model" gen:model test
```