### PR TITLE
允许客户端访问 content-disposition

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -59,7 +59,7 @@ Hyperf 还提供了 `基于 PSR-11 的依赖注入容器`、`注解`、`AOP 面�
 
 ## 金牌赞助方
 
-<!--gold start-->
+<!--gold start test-->
 <table>
   <tbody>
     <tr>

--- a/README-CN.md
+++ b/README-CN.md
@@ -59,7 +59,7 @@ Hyperf 还提供了 `基于 PSR-11 的依赖注入容器`、`注解`、`AOP 面�
 
 ## 金牌赞助方
 
-<!--gold start test-->
+<!--gold start-->
 <table>
   <tbody>
     <tr>

--- a/src/http-server/src/Response.php
+++ b/src/http-server/src/Response.php
@@ -168,6 +168,7 @@ class Response implements PsrResponseInterface, ResponseInterface, Sendable
 
         return $this->withHeader('content-description', 'File Transfer')
             ->withHeader('content-type', $contentType)
+            ->withHeader('access-control-expose-headers', 'content-disposition')
             ->withHeader('content-disposition', "attachment; filename={$filename}")
             ->withHeader('content-transfer-encoding', 'binary')
             ->withHeader('pragma', 'public')


### PR DESCRIPTION
我需要使用服务端返回的文件名

Response Headers中能获取如下：
Content-Disposition: attachment; filename=12.xlsx

但是 JS 中获取不到，如下：
headers:
content-length: "6395"
content-type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
pragma: "public"

https://cloud.tencent.com/developer/section/1189898