### PR TITLE
add gen:model --camel-case configure. properties as camel case, instead of snake case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v1.1.19 - TBD
 
+## Changed
+
+- [#1384](https://github.com/hyperf/hyperf/pull/1384) add `gen:model --property-case` configure. properties as camel
+case,
+instead of snake case
+
 # v1.1.18 - 2020-02-27
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Changed
 
-- [#1384](https://github.com/hyperf/hyperf/pull/1384) add `gen:model --property-case` configure. properties as camel
+- [#1384](https://github.com/hyperf/hyperf/pull/1384) Added option `property-case` for command `gen:model`.
 
 ## Fixed
 

--- a/doc/zh-cn/db/model.md
+++ b/doc/zh-cn/db/model.md
@@ -30,7 +30,7 @@ $ php bin/hyperf.php db:model table_name
 |  --table-mapping   | array  |       `[]`        | 为表名 -> 模型增加映射关系 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加字段注释                 |
-|  --camel-case      |  bool  |      `false`      |                将字段转成驼峰式                 |
+|  --property-case   |  bool  |      `false`      |               是否将表字段转为驼峰式                 |
 
 
 对应配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
@@ -53,7 +53,7 @@ return [
                 'table_mapping' => [],
                 // 注意这里都是下划线
                 'with_comments' => true,
-                'camel_case'    => true,
+                'property_case' => true,
             ],
         ],
     ],

--- a/doc/zh-cn/db/model.md
+++ b/doc/zh-cn/db/model.md
@@ -23,13 +23,15 @@ $ php bin/hyperf.php db:model table_name
 |       --pool       | string |     `default`     |      连接池，脚本会根据当前连接池配置创建       |
 |       --path       | string |    `app/Model`    |                    模型路径                     |
 |   --force-casts    |  bool  |      `false`      |            是否强制重置 `casts` 参数            |
-|      --prefix      | string |     空字符串      |                     表前缀                      |
+|      --prefix      | string |     空字符串       |                     表前缀                      |
 |   --inheritance    | string |      `Model`      |                      父类                       |
 |       --uses       | string | `App\Model\Model` |             配合 `inheritance` 使用             |
 | --refresh-fillable |  bool  |      `false`      |            是否刷新 `fillable` 参数             |
 |  --table-mapping   | array  |       `[]`        | 为表名 -> 模型增加映射关系 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加字段注释                 |
+|  --camel-case      |  bool  |      `false`      |                将字段转成驼峰式                 |
+
 
 对应配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
 
@@ -49,6 +51,9 @@ return [
                 'uses' => '',
                 'refresh_fillable' => true,
                 'table_mapping' => [],
+                // 注意这里都是下划线
+                'with_comments' => true,
+                'camel_case'    => true,
             ],
         ],
     ],

--- a/doc/zh-cn/db/model.md
+++ b/doc/zh-cn/db/model.md
@@ -30,15 +30,20 @@ $ php bin/hyperf.php db:model table_name
 |  --table-mapping   | array  |       `[]`        | 为表名 -> 模型增加映射关系 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加字段注释                 |
-|  --property-case   |  bool  |      `false`      |               是否将表字段转为驼峰式                 |
+|  --property-case   |  int   |      `0`          |               字段类型 0蛇形 1驼峰               |
 
+当使用 `--property-case` 将字段类型转化为驼峰时，还需要手动在模型中加入 `Hyperf\Database\Model\Concerns\CamelCase`。
 
 对应配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
+
+> 中划线都需要转化为下划线
 
 ```php
 <?php
 
 declare(strict_types=1);
+
+use Hyperf\Database\Commands\ModelOption;
 
 return [
     'default' => [
@@ -51,9 +56,8 @@ return [
                 'uses' => '',
                 'refresh_fillable' => true,
                 'table_mapping' => [],
-                // 注意这里都是下划线
                 'with_comments' => true,
-                'property_case' => true,
+                'property_case' => ModelOption::PROPERTY_SNAKE_CASE,
             ],
         ],
     ],

--- a/doc/zh-hk/db/model.md
+++ b/doc/zh-hk/db/model.md
@@ -23,13 +23,14 @@ $ php bin/hyperf.php db:model table_name
 |       --pool       | string |     `default`     |      連接池，腳本會根據當前連接池配置創建       |
 |       --path       | string |    `app/Model`    |                    模型路徑                     |
 |   --force-casts    |  bool  |      `false`      |            是否強制重置 `casts` 參數            |
-|      --prefix      | string |     空字符串      |                     表前綴                      |
+|      --prefix      | string |     空字符串       |                     表前綴                      |
 |   --inheritance    | string |      `Model`      |                      父類                       |
 |       --uses       | string | `App\Model\Model` |             配合 `inheritance` 使用             |
 | --refresh-fillable |  bool  |      `false`      |            是否刷新 `fillable` 參數             |
 |  --table-mapping   | array  |       `[]`        | 為表名 -> 模型增加映射關係 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加字段註釋                 |
+|  --camel-case      |  bool  |      `false`      |                將字段轉成駝峯式                |
 
 對應配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
 
@@ -49,6 +50,9 @@ return [
                 'uses' => '',
                 'refresh_fillable' => true,
                 'table_mapping' => [],
+                // 注意這裏都是下劃線
+                'with_comments' => true,
+                'camel_case'    => true,
             ],
         ],
     ],

--- a/doc/zh-hk/db/model.md
+++ b/doc/zh-hk/db/model.md
@@ -30,7 +30,7 @@ $ php bin/hyperf.php db:model table_name
 |  --table-mapping   | array  |       `[]`        | 為表名 -> 模型增加映射關係 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加字段註釋                 |
-|  --camel-case      |  bool  |      `false`      |                將字段轉成駝峯式                |
+|  --property-case   |  bool  |      `false`      |                是否將表字段轉為駝峯式                |
 
 對應配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
 
@@ -52,7 +52,7 @@ return [
                 'table_mapping' => [],
                 // 注意這裏都是下劃線
                 'with_comments' => true,
-                'camel_case'    => true,
+                'property_case' => true,
             ],
         ],
     ],

--- a/doc/zh-tw/db/model.md
+++ b/doc/zh-tw/db/model.md
@@ -23,13 +23,14 @@ $ php bin/hyperf.php db:model table_name
 |       --pool       | string |     `default`     |      連線池，指令碼會根據當前連線池配置建立       |
 |       --path       | string |    `app/Model`    |                    模型路徑                     |
 |   --force-casts    |  bool  |      `false`      |            是否強制重置 `casts` 引數            |
-|      --prefix      | string |     空字串      |                     表字首                      |
+|      --prefix      | string |     空字串         |                     表字首                      |
 |   --inheritance    | string |      `Model`      |                      父類                       |
 |       --uses       | string | `App\Model\Model` |             配合 `inheritance` 使用             |
 | --refresh-fillable |  bool  |      `false`      |            是否重新整理 `fillable` 引數             |
 |  --table-mapping   | array  |       `[]`        | 為表名 -> 模型增加對映關係 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加欄位註釋                 |
+|  --camel-case      |  bool  |      `false`      |                將欄位轉成駝峰式                |
 
 對應配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
 
@@ -49,6 +50,9 @@ return [
                 'uses' => '',
                 'refresh_fillable' => true,
                 'table_mapping' => [],
+                // 注意這裡都是下劃線
+                'with_comments' => true,
+                'camel_case'    => true,
             ],
         ],
     ],

--- a/doc/zh-tw/db/model.md
+++ b/doc/zh-tw/db/model.md
@@ -30,7 +30,7 @@ $ php bin/hyperf.php db:model table_name
 |  --table-mapping   | array  |       `[]`        | 為表名 -> 模型增加對映關係 比如 ['users:Account'] |
 |  --ignore-tables   | array  |       `[]`        |       不需要生成模型的表名 比如 ['users']       |
 |  --with-comments   |  bool  |      `false`      |                是否增加欄位註釋                 |
-|  --camel-case      |  bool  |      `false`      |                將欄位轉成駝峰式                |
+|  --property-case   |  bool  |      `false`      |                是否將表欄位轉為駝峰式               |
 
 對應配置也可以配置到 `databases.{pool}.commands.gen:model` 中，如下
 
@@ -52,7 +52,7 @@ return [
                 'table_mapping' => [],
                 // 注意這裡都是下劃線
                 'with_comments' => true,
-                'camel_case'    => true,
+                'property_case' => true,
             ],
         ],
     ],

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Database\Commands\Ast;
 
 use Hyperf\Database\Commands\ModelOption;
+use Hyperf\Utils\Str;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -93,7 +94,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
 
     protected function getProperty($column): array
     {
-        $name = $column['column_name'];
+        $name = $this->option->isCamelCase() ? Str::camel($column['column_name']) : $column['column_name'];
 
         $type = $this->formatPropertyType($column['data_type'], $column['cast'] ?? null);
 

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -94,7 +94,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
 
     protected function getProperty($column): array
     {
-        $name = $this->option->isCamelCase() ? Str::camel($column['column_name']) : $column['column_name'];
+        $name = $this->option->isPropertyCase() ? Str::camel($column['column_name']) : $column['column_name'];
 
         $type = $this->formatPropertyType($column['data_type'], $column['cast'] ?? null);
 

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -94,7 +94,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
 
     protected function getProperty($column): array
     {
-        $name = $this->option->isPropertyCase() ? Str::camel($column['column_name']) : $column['column_name'];
+        $name = $this->option->isCamelCase() ? Str::camel($column['column_name']) : $column['column_name'];
 
         $type = $this->formatPropertyType($column['data_type'], $column['cast'] ?? null);
 

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -100,7 +100,7 @@ class ModelCommand extends Command
             ->setIgnoreTables($this->getOption('ignore-tables', 'commands.gen:model.ignore_tables', $pool, []))
             ->setWithComments($this->getOption('with-comments', 'commands.gen:model.with_comments', $pool, false))
             ->setVisitors($this->getOption('visitors', 'commands.gen:model.visitors', $pool, []))
-            ->setCamelCase($this->getOption("camel-case","commands.gen:model.camel_case",$pool,false));
+            ->setPropertyCase($this->getOption("property-case","commands.gen:model.property_case",$pool,false));
 
 
         if ($table) {
@@ -125,7 +125,7 @@ class ModelCommand extends Command
         $this->addOption('ignore-tables', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Ignore tables for creating models.');
         $this->addOption('with-comments', null, InputOption::VALUE_NONE, 'Whether generate the property comments for model.');
         $this->addOption('visitors', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Custom visitors for ast traverser.');
-        $this->addOPtion('camel-case',null,InputOption::VALUE_NONE,'properties as camel case, instead of snake case.');
+        $this->addOPtion('property-case',null,InputOption::VALUE_NONE,'properties as camel case, instead of snake case.');
 
     }
 
@@ -238,7 +238,7 @@ class ModelCommand extends Command
     {
         $result = $this->input->getOption($name);
         $nonInput = null;
-        if (in_array($name, ['force-casts', 'refresh-fillable', 'with-comments','camel-case'])) {
+        if (in_array($name, ['force-casts', 'refresh-fillable', 'with-comments','property-case'])) {
             $nonInput = false;
         }
         if (in_array($name, ['table-mapping', 'ignore-tables', 'visitors'])) {

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -100,8 +100,7 @@ class ModelCommand extends Command
             ->setIgnoreTables($this->getOption('ignore-tables', 'commands.gen:model.ignore_tables', $pool, []))
             ->setWithComments($this->getOption('with-comments', 'commands.gen:model.with_comments', $pool, false))
             ->setVisitors($this->getOption('visitors', 'commands.gen:model.visitors', $pool, []))
-            ->setPropertyCase($this->getOption("property-case","commands.gen:model.property_case",$pool,false));
-
+            ->setPropertyCase($this->getOption('property-case', 'commands.gen:model.property_case', $pool));
 
         if ($table) {
             $this->createModel($table, $option);
@@ -125,8 +124,7 @@ class ModelCommand extends Command
         $this->addOption('ignore-tables', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Ignore tables for creating models.');
         $this->addOption('with-comments', null, InputOption::VALUE_NONE, 'Whether generate the property comments for model.');
         $this->addOption('visitors', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Custom visitors for ast traverser.');
-        $this->addOPtion('property-case',null,InputOption::VALUE_NONE,'properties as camel case, instead of snake case.');
-
+        $this->addOption('property-case', null, InputOption::VALUE_OPTIONAL, 'Which property case you want use, 0: snake case, 1: camel case.');
     }
 
     protected function getSchemaBuilder(string $poolName): MySqlBuilder
@@ -238,7 +236,7 @@ class ModelCommand extends Command
     {
         $result = $this->input->getOption($name);
         $nonInput = null;
-        if (in_array($name, ['force-casts', 'refresh-fillable', 'with-comments','property-case'])) {
+        if (in_array($name, ['force-casts', 'refresh-fillable', 'with-comments'])) {
             $nonInput = false;
         }
         if (in_array($name, ['table-mapping', 'ignore-tables', 'visitors'])) {

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -181,7 +181,7 @@ class ModelCommand extends Command
             file_put_contents($path, $this->buildClass($table, $class, $option));
         }
 
-        $columns = $this->getColumns($class, $columns, $option->isForceCasts(), $option->isCamelCase());
+        $columns = $this->getColumns($class, $columns, $option->isForceCasts());
 
         $stms = $this->astParser->parse(file_get_contents($path));
         $traverser = new NodeTraverser();
@@ -211,7 +211,7 @@ class ModelCommand extends Command
         }, $columns);
     }
 
-    protected function getColumns($className, $columns, $forceCasts,$camelCase): array
+    protected function getColumns($className, $columns, $forceCasts): array
     {
         /** @var Model $model */
         $model = new $className();
@@ -229,9 +229,6 @@ class ModelCommand extends Command
 
         foreach ($columns as $key => $value) {
             $columns[$key]['cast'] = $casts[$value['column_name']] ?? null;
-            if ($camelCase) {
-                $columns[$key]['column_name'] = Str::camel($columns[$key]['column_name']);
-            }
         }
 
         return $columns;

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -72,7 +72,7 @@ class ModelOption
     /**
      * @var bool
      */
-    protected $camelCase;
+    protected $propertyCase;
 
     public function getPool(): string
     {
@@ -199,14 +199,14 @@ class ModelOption
         return $this;
     }
 
-    public function isCamelCase(): bool
+    public function isPropertyCase(): bool
     {
-        return $this->camelCase;
+        return $this->propertyCase;
     }
 
-    public function setCamelCase(bool $camelCase): self
+    public function setPropertyCase(bool $propertyCase): self
     {
-        $this->camelCase = $camelCase;
+        $this->propertyCase = $propertyCase;
         return $this;
     }
 }

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -14,6 +14,10 @@ namespace Hyperf\Database\Commands;
 
 class ModelOption
 {
+    const PROPERTY_SNAKE_CASE = 0;
+
+    const PROPERTY_CAMEL_CASE = 1;
+
     /**
      * @var string
      */
@@ -70,9 +74,9 @@ class ModelOption
     protected $visitors = [];
 
     /**
-     * @var bool
+     * @var int
      */
-    protected $propertyCase;
+    protected $propertyCase = self::PROPERTY_SNAKE_CASE;
 
     public function getPool(): string
     {
@@ -199,14 +203,14 @@ class ModelOption
         return $this;
     }
 
-    public function isPropertyCase(): bool
+    public function isCamelCase(): bool
     {
-        return $this->propertyCase;
+        return $this->propertyCase === self::PROPERTY_CAMEL_CASE;
     }
 
-    public function setPropertyCase(bool $propertyCase): self
+    public function setPropertyCase($propertyCase): self
     {
-        $this->propertyCase = $propertyCase;
+        $this->propertyCase = (int) $propertyCase;
         return $this;
     }
 }

--- a/src/database/src/Commands/ModelOption.php
+++ b/src/database/src/Commands/ModelOption.php
@@ -69,6 +69,11 @@ class ModelOption
      */
     protected $visitors = [];
 
+    /**
+     * @var bool
+     */
+    protected $camelCase;
+
     public function getPool(): string
     {
         return $this->pool;
@@ -191,6 +196,17 @@ class ModelOption
     public function setVisitors(array $visitors): self
     {
         $this->visitors = $visitors;
+        return $this;
+    }
+
+    public function isCamelCase(): bool
+    {
+        return $this->camelCase;
+    }
+
+    public function setCamelCase(bool $camelCase): self
+    {
+        $this->camelCase = $camelCase;
         return $this;
     }
 }

--- a/src/database/src/Model/Concerns/CamelCase.php
+++ b/src/database/src/Model/Concerns/CamelCase.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Hyperf\Database\Model\Concerns;
+
+
+use Hyperf\Utils\Str;
+
+trait CamelCase
+{
+    protected function keyTransform($key)
+    {
+        return Str::camel($key);
+    }
+
+    public function getAttribute($key)
+    {
+        return parent::getAttribute(Str::snake($key));
+    }
+
+    public function setAttribute($key, $value)
+    {
+        return parent::setAttribute(Str::snake($key), $value);
+    }
+
+    protected function addMutatedAttributesToArray(array $attributes, array $mutatedAttributes)
+    {
+        foreach ($mutatedAttributes as $key) {
+            if (!array_key_exists($this->keyTransform($key), $attributes)) {
+                continue;
+            }
+            $attributes[$this->keyTransform($key)] = $this->mutateAttributeForArray(
+                $this->keyTransform($key), $attributes[$this->keyTransform($key)]
+            );
+        }
+        return $attributes;
+    }
+
+    public function jsonSerialize()
+    {
+        $array = [];
+        foreach ($this->toArray() as $key => $value) {
+            $array[$this->keyTransform($key)] = $value;
+        }
+        return $array;
+    }
+
+    public function toArray(): array
+    {
+        $array = [];
+        foreach (parent::toArray() as $key => $value) {
+            $array[$this->keyTransform($key)] = $value;
+        }
+        return $array;
+    }
+
+    public function toOriginalArray(): array
+    {
+        return parent::toArray();
+    }
+}

--- a/src/database/src/Model/Concerns/CamelCase.php
+++ b/src/database/src/Model/Concerns/CamelCase.php
@@ -1,18 +1,21 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
 
 namespace Hyperf\Database\Model\Concerns;
-
 
 use Hyperf\Utils\Str;
 
 trait CamelCase
 {
-    protected function keyTransform($key)
-    {
-        return Str::camel($key);
-    }
-
     public function getAttribute($key)
     {
         return parent::getAttribute($key) ?? parent::getAttribute(Str::snake($key));
@@ -21,19 +24,6 @@ trait CamelCase
     public function setAttribute($key, $value)
     {
         return parent::setAttribute(Str::snake($key), $value);
-    }
-
-    protected function addMutatedAttributesToArray(array $attributes, array $mutatedAttributes)
-    {
-        foreach ($mutatedAttributes as $key) {
-            if (!array_key_exists($this->keyTransform($key), $attributes)) {
-                continue;
-            }
-            $attributes[$this->keyTransform($key)] = $this->mutateAttributeForArray(
-                $this->keyTransform($key), $attributes[$this->keyTransform($key)]
-            );
-        }
-        return $attributes;
     }
 
     public function jsonSerialize()
@@ -57,5 +47,24 @@ trait CamelCase
     public function toOriginalArray(): array
     {
         return parent::toArray();
+    }
+
+    protected function keyTransform($key)
+    {
+        return Str::camel($key);
+    }
+
+    protected function addMutatedAttributesToArray(array $attributes, array $mutatedAttributes)
+    {
+        foreach ($mutatedAttributes as $key) {
+            if (! array_key_exists($this->keyTransform($key), $attributes)) {
+                continue;
+            }
+            $attributes[$this->keyTransform($key)] = $this->mutateAttributeForArray(
+                $this->keyTransform($key),
+                $attributes[$this->keyTransform($key)]
+            );
+        }
+        return $attributes;
     }
 }

--- a/src/database/src/Model/Concerns/CamelCase.php
+++ b/src/database/src/Model/Concerns/CamelCase.php
@@ -15,7 +15,7 @@ trait CamelCase
 
     public function getAttribute($key)
     {
-        return parent::getAttribute(Str::snake($key));
+        return parent::getAttribute($key) ?? parent::getAttribute(Str::snake($key));
     }
 
     public function setAttribute($key, $value)


### PR DESCRIPTION
给gen:model增加 --camel-case参数 将生成的property转成驼峰
也可在commands.gen:model 中设置camel_case为true
默认转换驼峰  只修改文档上方的 `@property`