### PR TITLE
fix () model-cache/manager:formatModel

### DIFF
--- a/src/model-cache/src/Manager.php
+++ b/src/model-cache/src/Manager.php
@@ -225,9 +225,9 @@ class Manager
     protected function formatModel(Model $model): array
     {
         $casts = $model->getCasts();
-        $result = $model->toArray();
+        $result = method_exists($model,'toOriginalArray') ? $model->toOriginalArray() :$model->toArray();
         foreach ($result as $key => $value) {
-            if (isset($casts[$key]) && $casts[$key] === 'json' && ! is_null($value)) {
+            if (isset($casts[$key]) && in_array($casts[$key],['array', 'json', 'object', 'collection'])&& ! is_null($value)) {
                 $result[$key] = json_encode($value);
             }
         }


### PR DESCRIPTION
修复使用CamelCase时 toArray会让所有key变成驼峰的问题
修复模型缓存配置了casts为array,object,collection时没有json_encode存入数据库的bug