### PR TITLE
修正：配置变更后（从Apollo等同步）连接池未重置导致的配置不生效。

### DIFF
--- a/src/db/src/AbstractConnection.php
+++ b/src/db/src/AbstractConnection.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Hyperf\DB;
 
+use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Pool\Connection;
 use Hyperf\Pool\Exception\ConnectionException;
@@ -29,6 +30,16 @@ abstract class AbstractConnection extends Connection implements ConnectionInterf
     public function getConfig(): array
     {
         return $this->config;
+    }
+
+    public function conifgReload($poolName): bool
+    {
+        $nowConfig = $this->container->get(ConfigInterface::class)->get('db');
+        if (isset($nowConfig[$poolName]) && $this->getConfig() !== $nowConfig[$poolName]) {
+            $this->config = $nowConfig[$poolName];
+            return $this->reconnect();
+        }
+        return true;
     }
 
     public function release(): void

--- a/src/db/src/DB.php
+++ b/src/db/src/DB.php
@@ -48,6 +48,7 @@ class DB
     {
         $hasContextConnection = Context::has($this->getContextKey());
         $connection = $this->getConnection($hasContextConnection);
+        $connection->conifgReload($this->poolName);
 
         try {
             $connection = $connection->getConnection();


### PR DESCRIPTION
在使用过程中发现：在Apollo中修改了Mysql链接配置之后，极简db并没有使用新的配置
现在修复了下，具体方法为：每次调取DB都判断下配置是否变更了，经对比：大约增加了0.2ms。可以接受

推荐方案：在apollo组件中增加回调，由注册的事件去接手这个工作，批量重载需要的组件，如：redis等。