### PR TITLE
Fixed optional header 'SecurityToken'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#1405](https://github.com/hyperf/hyperf/pull/1405) Fixed attributes are not right, when the model has property `hidden`.
 - [#1410](https://github.com/hyperf/hyperf/pull/1410) Fixed tracer cannot trace the call chains of redis connection that created by `Hyperf\Redis\RedisFactory`.
+- [#1415](https://github.com/hyperf/hyperf/pull/1415) Fixed bug that decoded sts token failed when optional header `SecurityToken` is empty.
 
 # v1.1.19 - 2020-03-05
 

--- a/src/config-aliyun-acm/src/Client.php
+++ b/src/config-aliyun-acm/src/Client.php
@@ -54,9 +54,6 @@ class Client implements ClientInterface
 
     public function __construct(ContainerInterface $container)
     {
-        /**
-         * @var GuzzleClientFactory
-         */
         $clientFactory = $container->get(GuzzleClientFactory::class);
         $this->client = $clientFactory->create();
         $this->config = $container->get(ConfigInterface::class);

--- a/src/config-aliyun-acm/src/Client.php
+++ b/src/config-aliyun-acm/src/Client.php
@@ -78,13 +78,15 @@ class Client implements ClientInterface
         $accessKey = $this->config->get('aliyun_acm.access_key', '');
         $secretKey = $this->config->get('aliyun_acm.secret_key', '');
         $ecsRamRole = (string) $this->config->get('aliyun_acm.ecs_ram_role', '');
-        $securityToken = null;
+        $securityToken = [];
         if (empty($accessKey) && ! empty($ecsRamRole)) {
             $securityCredentials = $this->getSecurityCredentialsWithEcsRamRole($ecsRamRole);
             if (! empty($securityCredentials)) {
                 $accessKey = $securityCredentials['AccessKeyId'];
                 $secretKey = $securityCredentials['AccessKeySecret'];
-                $securityToken = $securityCredentials['SecurityToken'];
+                $securityToken = [
+                    'Spas-SecurityToken'=>$securityCredentials['SecurityToken']
+                ];
             }
         }
 
@@ -105,13 +107,12 @@ class Client implements ClientInterface
 
             // Get config
             $response = $client->get("http://{$server}:8080/diamond-server/config.co", [
-                'headers' => [
+                'headers' => array_merge([
                     'Spas-AccessKey' => $accessKey,
                     'timeStamp' => $timestamp,
                     'Spas-Signature' => $sign,
-                    'Spas-SecurityToken' => $securityToken ?? '',
                     'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
-                ],
+                ], $securityToken),
                 'query' => [
                     'tenant' => $namespace,
                     'dataId' => $dataId,

--- a/src/config-aliyun-acm/src/Client.php
+++ b/src/config-aliyun-acm/src/Client.php
@@ -55,7 +55,7 @@ class Client implements ClientInterface
     public function __construct(ContainerInterface $container)
     {
         /**
-         * @var GuzzleClientFactory $clientFactory
+         * @var GuzzleClientFactory
          */
         $clientFactory = $container->get(GuzzleClientFactory::class);
         $this->client = $clientFactory->create();
@@ -85,7 +85,7 @@ class Client implements ClientInterface
                 $accessKey = $securityCredentials['AccessKeyId'];
                 $secretKey = $securityCredentials['AccessKeySecret'];
                 $securityToken = [
-                    'Spas-SecurityToken'=>$securityCredentials['SecurityToken']
+                    'Spas-SecurityToken' => $securityCredentials['SecurityToken'],
                 ];
             }
         }

--- a/src/config-aliyun-acm/src/Listener/OnPipeMessageListener.php
+++ b/src/config-aliyun-acm/src/Listener/OnPipeMessageListener.php
@@ -17,8 +17,8 @@ use Hyperf\ConfigAliyunAcm\PipeMessage;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
-use Hyperf\Process\Event\PipeMessage as UserProcessPipeMessage;
 use Hyperf\Framework\Event\OnPipeMessage;
+use Hyperf\Process\Event\PipeMessage as UserProcessPipeMessage;
 
 class OnPipeMessageListener implements ListenerInterface
 {


### PR DESCRIPTION
aliyun acm
传入一个空的可选HTTP头信息<Spas-SecurityToken>会引发一个错误。
```
[ERROR] Client error: `GET http://139.196.135.144:8080/diamond-server/config.co?tenant=a7e83e1b-ec9e-4093-894f-f01eceecf6bb&dataId=leap.userportal.db&group=DEFAULT_GROUP` resulted in a `403 Forbidden` response:
false:40008:can not get decodedStsToken from ramAuth
```