### PR TITLE
fix: Hyperf\Testing\Client::flushContext Invalid argument supplied for foreach() 

### DIFF
--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -194,7 +194,9 @@ class Client extends Server
 
     protected function flushContext()
     {
-        $context = SwCoroutine::getContext();
+        // https://github.com/hyperf/hyperf/issues/1473
+        // SwCoroutine::getContext() 返回 null 时, foreach Invalid argument supplied for foreach()
+        $context = SwCoroutine::getContext() ?? [];
 
         foreach ($context as $key => $value) {
             if (Str::startsWith($key, $this->ignoreContextPrefix)) {


### PR DESCRIPTION
- 解决 Hyperf\Testing\Client::flushContext 因获取上下文返回 null 时报 Invalid argument supplied for foreach() 的问题