### PR TITLE
fixed: Hyperf\Testing\Client::flushContext Invalid argument supplied for foreach()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1471](https://github.com/hyperf/hyperf/pull/1471) Fixed data recved failed, when the body is larger than max-output-buffer-size.
 - [#1472](https://github.com/hyperf/hyperf/pull/1472) Fixed consume failed when publish message in consumer of NSQ.
 - [#1474](https://github.com/hyperf/hyperf/pull/1474) Fixed the consumer of NSQ will restart when requeue message.
+- [#1477](https://github.com/hyperf/hyperf/pull/1477) Fixed Invalid argument supplied for `Hyperf\Testing\Client::flushContext`.
 
 ## Changed
 

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -194,7 +194,7 @@ class Client extends Server
 
     protected function flushContext()
     {
-        $context = SwCoroutine::getContext();
+        $context = SwCoroutine::getContext() ?? [];
 
         foreach ($context as $key => $value) {
             if (Str::startsWith($key, $this->ignoreContextPrefix)) {


### PR DESCRIPTION
- https://github.com/hyperf/hyperf/issues/1473
- 解决 Hyperf\Testing\Client::flushContext 因获取上下文返回 null 时报 Invalid argument supplied for foreach() 的问题