### PR TITLE
Fixed dynamic parameter does not work after requiring translation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#1494](https://github.com/hyperf/hyperf/pull/1494) Ignore `@mixin` annotation in redis component
+- [#1499](https://github.com/hyperf/hyperf/pull/1499) Fixed dynamic parameter does not work after requiring translation for `hyperf/constants`.
 
 # v1.1.23 - 2020-04-02
 

--- a/src/constants/src/AbstractConstants.php
+++ b/src/constants/src/AbstractConstants.php
@@ -38,7 +38,10 @@ abstract class AbstractConstants
         array_shift($arguments);
 
         if ($result = self::translate($message, $arguments)) {
-            return $result;
+            // If the result of translate doesn't exist, the result is equal with message, so we will skip it.
+            if ($result !== $message) {
+                return $result;
+            }
         }
 
         $count = count($arguments);

--- a/src/constants/src/AbstractConstants.php
+++ b/src/constants/src/AbstractConstants.php
@@ -37,11 +37,10 @@ abstract class AbstractConstants
 
         array_shift($arguments);
 
-        if ($result = self::translate($message, $arguments)) {
-            // If the result of translate doesn't exist, the result is equal with message, so we will skip it.
-            if ($result !== $message) {
-                return $result;
-            }
+        $result = self::translate($message, $arguments);
+        // If the result of translate doesn't exist, the result is equal with message, so we will skip it.
+        if ($result && $result !== $message) {
+            return $result;
         }
 
         $count = count($arguments);

--- a/src/constants/tests/AnnotationReaderTest.php
+++ b/src/constants/tests/AnnotationReaderTest.php
@@ -86,6 +86,12 @@ class AnnotationReaderTest extends TestCase
         $res = ErrorCodeStub::getMessage(ErrorCodeStub::TRANSLATOR_NOT_EXIST, ['name' => 'Hyperf']);
         $this->assertSame('Hyperf is not exist.', $res);
 
+        $res = ErrorCodeStub::getMessage(ErrorCodeStub::PARAMS_INVALID, 'user_id');
+        $this->assertSame('Params[user_id] is invalid.', $res);
+
+        $res = ErrorCodeStub::getMessage(ErrorCodeStub::PARAMS_INVALID, ['order_id']);
+        $this->assertSame('Params[order_id] is invalid.', $res);
+
         Context::set(sprintf('%s::%s', TranslatorInterface::class, 'locale'), 'zh_CN');
         $res = ErrorCodeStub::getMessage(ErrorCodeStub::TRANSLATOR_ERROR_MESSAGE);
         $this->assertSame('错误信息', $res);


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/1487

修复引入国际化组件后枚举类动态参数无法正常使用的BUG