### PR TITLE
feat: bridge symfony events to hyperf event dispatcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.1.24 - TBD
 
+## Added
+
+- [#1501](https://github.com/hyperf/hyperf/pull/1501) Bridged Symfony command events to Hyperf event dispatcher.
+
 ## Fixed
 
 - [#1494](https://github.com/hyperf/hyperf/pull/1494) Ignore `@mixin` annotation in redis component

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -40,6 +40,11 @@ class ApplicationFactory
 
         $commands = array_unique(array_merge($commands, $annotationCommands));
         $application = new Application();
+
+        if (isset($eventDispatcher)) {
+            $application->setDispatcher(new SymfonyEventDispatcher($eventDispatcher));
+        }
+
         foreach ($commands as $command) {
             $application->add($container->get($command));
         }

--- a/src/framework/src/Exception/NotImplementedException.php
+++ b/src/framework/src/Exception/NotImplementedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Framework\Exception;
+
+class NotImplementedException extends \RuntimeException
+{
+}

--- a/src/framework/src/SymfonyEventDispatcher.php
+++ b/src/framework/src/SymfonyEventDispatcher.php
@@ -17,6 +17,10 @@ use Psr\EventDispatcher\EventDispatcherInterface as PsrDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * Class SymfonyEventDispatcher.
+ * @internal
+ */
 class SymfonyEventDispatcher implements SymfonyDispatcherInterface
 {
     /**
@@ -29,25 +33,16 @@ class SymfonyEventDispatcher implements SymfonyDispatcherInterface
         $this->psrDispatcher = $psrDispatcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addListener($eventName, $listener, $priority = 0)
     {
         throw new NotImplementedException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addSubscriber(EventSubscriberInterface $subscriber)
     {
         throw new NotImplementedException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeListener($eventName, $listener)
     {
         throw new NotImplementedException();
@@ -58,33 +53,21 @@ class SymfonyEventDispatcher implements SymfonyDispatcherInterface
         throw new NotImplementedException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getListeners($eventName = null)
     {
         throw new NotImplementedException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function dispatch($event)
     {
         $this->psrDispatcher->dispatch($event);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getListenerPriority($eventName, $listener)
     {
         throw new NotImplementedException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasListeners($eventName = null)
     {
         throw new NotImplementedException();

--- a/src/framework/src/SymfonyEventDispatcher.php
+++ b/src/framework/src/SymfonyEventDispatcher.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Framework;
+
+use Hyperf\Framework\Exception\NotImplementedException;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SymfonyEventDispatcher implements SymfonyDispatcherInterface
+{
+    /**
+     * @var PsrDispatcherInterface
+     */
+    private $psrDispatcher;
+
+    public function __construct(PsrDispatcherInterface $psrDispatcher)
+    {
+        $this->psrDispatcher = $psrDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeListener($eventName, $listener)
+    {
+        throw new NotImplementedException();
+    }
+
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListeners($eventName = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch($event)
+    {
+        $this->psrDispatcher->dispatch($event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasListeners($eventName = null)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Symfony Command自带一些事件，现在这些事件从Hyperf里无法监听。

本PR解决了这个问题。

这些事件还是有用的，可以获得当前执行的命令、输入、输出、exitcode等。更优雅的处理#1500 

举个例子，合并本PR后，就可以这样获取命令输入了：

```php
<?php


namespace App\Listener;


use Hyperf\Event\Annotation\Listener;
use Hyperf\Event\Contract\ListenerInterface;
use Symfony\Component\Console\Event\ConsoleCommandEvent;

/**
 * Class SymfonyListener
 * @package App\Listener
 * @Listener()
 */
class SymfonyListener implements ListenerInterface
{

    /**
     * @inheritDoc
     */
    public function listen(): array
    {
        return [
            ConsoleCommandEvent::class
        ];
    }

    /**
     * @inheritDoc
     */
    public function process(object $event)
    {
        var_dump($event->getInput());
    }
}
```