### PR TITLE
better handling of graceful start & graceful stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - [#1501](https://github.com/hyperf/hyperf/pull/1501) Bridged Symfony command events to Hyperf event dispatcher.
+- [#1510](https://github.com/hyperf/hyperf/pull/1510) Added `Hyperf/Utils/CoordinatorManager` to better handling of graceful start and graceful stop.
 
 ## Fixed
 

--- a/src/config-aliyun-acm/src/Listener/BootProcessListener.php
+++ b/src/config-aliyun-acm/src/Listener/BootProcessListener.php
@@ -19,6 +19,7 @@ use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\Container\ContainerInterface;
@@ -72,7 +73,7 @@ class BootProcessListener implements ListenerInterface
                 retry(INF, function () use ($interval) {
                     $prevConfig = [];
                     while (true) {
-                        $coordinator = CoordinatorManager::get('workerExit');
+                        $coordinator = CoordinatorManager::get(Constants::ON_WORKER_EXIT);
                         $workerExited = $coordinator->yield($interval);
                         if ($workerExited) {
                             break;

--- a/src/config-aliyun-acm/src/Listener/BootProcessListener.php
+++ b/src/config-aliyun-acm/src/Listener/BootProcessListener.php
@@ -19,6 +19,7 @@ use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\Container\ContainerInterface;
 
@@ -71,7 +72,11 @@ class BootProcessListener implements ListenerInterface
                 retry(INF, function () use ($interval) {
                     $prevConfig = [];
                     while (true) {
-                        sleep($interval);
+                        $coordinator = CoordinatorManager::get('workerExit');
+                        $workerExited = $coordinator->yield($interval);
+                        if ($workerExited) {
+                            break;
+                        }
                         $config = $this->client->pull();
                         if ($config !== $prevConfig) {
                             $this->updateConfig($config);

--- a/src/config-apollo/src/Listener/BootProcessListener.php
+++ b/src/config-apollo/src/Listener/BootProcessListener.php
@@ -18,6 +18,7 @@ use Hyperf\ConfigApollo\PipeMessage;
 use Hyperf\ConfigApollo\ReleaseKey;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 
 class BootProcessListener extends OnPipeMessageListener
@@ -71,7 +72,11 @@ class BootProcessListener extends OnPipeMessageListener
                 $interval = $this->config->get('apollo.interval', 5);
                 retry(INF, function () use ($namespaces, $callbacks, $interval) {
                     while (true) {
-                        sleep($interval);
+                        $coordinator = CoordinatorManager::get('workerExit');
+                        $workerExited = $coordinator->yield($interval);
+                        if ($workerExited) {
+                            break;
+                        }
                         $this->client->pull($namespaces, $callbacks);
                     }
                 }, $interval * 1000);

--- a/src/config-apollo/src/Listener/BootProcessListener.php
+++ b/src/config-apollo/src/Listener/BootProcessListener.php
@@ -18,6 +18,7 @@ use Hyperf\ConfigApollo\PipeMessage;
 use Hyperf\ConfigApollo\ReleaseKey;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 
@@ -72,7 +73,7 @@ class BootProcessListener extends OnPipeMessageListener
                 $interval = $this->config->get('apollo.interval', 5);
                 retry(INF, function () use ($namespaces, $callbacks, $interval) {
                     while (true) {
-                        $coordinator = CoordinatorManager::get('workerExit');
+                        $coordinator = CoordinatorManager::get(Constants::ON_WORKER_EXIT);
                         $workerExited = $coordinator->yield($interval);
                         if ($workerExited) {
                             break;

--- a/src/config-etcd/src/Listener/BootProcessListener.php
+++ b/src/config-etcd/src/Listener/BootProcessListener.php
@@ -21,6 +21,7 @@ use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Hyperf\Utils\Packer\JsonPacker;
@@ -88,7 +89,7 @@ class BootProcessListener implements ListenerInterface
                 retry(INF, function () use ($interval) {
                     $prevConfig = [];
                     while (true) {
-                        $coordinator = CoordinatorManager::get('workerExit');
+                        $coordinator = CoordinatorManager::get(Constants::ON_WORKER_EXIT);
                         $workerExited = $coordinator->yield($interval);
                         if ($workerExited) {
                             break;

--- a/src/config-zookeeper/src/Listener/BootProcessListener.php
+++ b/src/config-zookeeper/src/Listener/BootProcessListener.php
@@ -19,6 +19,7 @@ use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 
@@ -67,7 +68,7 @@ class BootProcessListener implements ListenerInterface
                 retry(INF, function () use ($interval) {
                     $prevConfig = [];
                     while (true) {
-                        $coordinator = CoordinatorManager::get('workerExit');
+                        $coordinator = CoordinatorManager::get(Constants::ON_WORKER_EXIT);
                         $workerExited = $coordinator->yield($interval);
                         if ($workerExited) {
                             break;

--- a/src/framework/src/Bootstrap/WorkerExitCallback.php
+++ b/src/framework/src/Bootstrap/WorkerExitCallback.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Framework\Bootstrap;
 
 use Hyperf\Framework\Event\OnWorkerExit;
-use Hyperf\Server\SwooleEvent;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -35,8 +35,7 @@ class WorkerExitCallback
     {
         $this->dispatcher->dispatch(new OnWorkerExit($server, $workerId));
         Coroutine::create(function () {
-            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_EXIT);
-            $coordinator->resume();
+            CoordinatorManager::get(Constants::ON_WORKER_EXIT)->resume();
         });
     }
 }

--- a/src/framework/src/Bootstrap/WorkerExitCallback.php
+++ b/src/framework/src/Bootstrap/WorkerExitCallback.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace Hyperf\Framework\Bootstrap;
 
 use Hyperf\Framework\Event\OnWorkerExit;
+use Hyperf\Server\SwooleEvent;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Swoole\Server;
 
@@ -31,5 +33,7 @@ class WorkerExitCallback
     public function onWorkerExit(Server $server, int $workerId)
     {
         $this->dispatcher->dispatch(new OnWorkerExit($server, $workerId));
+        $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_EXIT);
+        $coordinator->resume();
     }
 }

--- a/src/framework/src/Bootstrap/WorkerExitCallback.php
+++ b/src/framework/src/Bootstrap/WorkerExitCallback.php
@@ -15,6 +15,7 @@ namespace Hyperf\Framework\Bootstrap;
 use Hyperf\Framework\Event\OnWorkerExit;
 use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
+use Hyperf\Utils\Coroutine;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Swoole\Server;
 
@@ -33,7 +34,9 @@ class WorkerExitCallback
     public function onWorkerExit(Server $server, int $workerId)
     {
         $this->dispatcher->dispatch(new OnWorkerExit($server, $workerId));
-        $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_EXIT);
-        $coordinator->resume();
+        Coroutine::create(function () {
+            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_EXIT);
+            $coordinator->resume();
+        });
     }
 }

--- a/src/framework/src/Bootstrap/WorkerStartCallback.php
+++ b/src/framework/src/Bootstrap/WorkerStartCallback.php
@@ -17,6 +17,8 @@ use Hyperf\Framework\Event\AfterWorkerStart;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Framework\Event\MainWorkerStart;
 use Hyperf\Framework\Event\OtherWorkerStart;
+use Hyperf\Server\SwooleEvent;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Swoole\Server as SwooleServer;
 
@@ -58,5 +60,7 @@ class WorkerStartCallback
         }
 
         $this->eventDispatcher->dispatch(new AfterWorkerStart($server, $workerId));
+        $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
+        $coordinator->resume();
     }
 }

--- a/src/framework/src/Bootstrap/WorkerStartCallback.php
+++ b/src/framework/src/Bootstrap/WorkerStartCallback.php
@@ -17,7 +17,7 @@ use Hyperf\Framework\Event\AfterWorkerStart;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Framework\Event\MainWorkerStart;
 use Hyperf\Framework\Event\OtherWorkerStart;
-use Hyperf\Server\SwooleEvent;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Swoole\Server as SwooleServer;
@@ -60,7 +60,6 @@ class WorkerStartCallback
         }
 
         $this->eventDispatcher->dispatch(new AfterWorkerStart($server, $workerId));
-        $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
-        $coordinator->resume();
+        CoordinatorManager::get(Constants::ON_WORKER_START)->resume();
     }
 }

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -59,7 +59,7 @@ class Request implements RequestInterface
         }
         return data_get($this->getQueryParams(), $key, $default);
     }
-    
+
     /**
      * Retrieve the data from route parameters.
      *

--- a/src/http-server/src/Server.php
+++ b/src/http-server/src/Server.php
@@ -25,9 +25,8 @@ use Hyperf\HttpServer\Contract\CoreMiddlewareInterface;
 use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 use Hyperf\HttpServer\Router\Dispatched;
 use Hyperf\HttpServer\Router\DispatcherFactory;
-use Hyperf\HttpServer\Router\Handler;
-use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -99,8 +98,7 @@ class Server implements OnRequestInterface, MiddlewareInitializerInterface
     public function onRequest(SwooleRequest $request, SwooleResponse $response): void
     {
         try {
-            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_START)->yield();
 
             [$psr7Request, $psr7Response] = $this->initRequestAndResponse($request, $response);
 

--- a/src/http-server/src/Server.php
+++ b/src/http-server/src/Server.php
@@ -26,7 +26,9 @@ use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 use Hyperf\HttpServer\Router\Dispatched;
 use Hyperf\HttpServer\Router\DispatcherFactory;
 use Hyperf\HttpServer\Router\Handler;
+use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -97,6 +99,9 @@ class Server implements OnRequestInterface, MiddlewareInitializerInterface
     public function onRequest(SwooleRequest $request, SwooleResponse $response): void
     {
         try {
+            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
+            $coordinator->yield();
+
             [$psr7Request, $psr7Response] = $this->initRequestAndResponse($request, $response);
 
             $psr7Request = $this->coreMiddleware->dispatch($psr7Request);

--- a/src/metric/src/Adapter/InfluxDB/MetricFactory.php
+++ b/src/metric/src/Adapter/InfluxDB/MetricFactory.php
@@ -31,7 +31,6 @@ use InfluxDB\Driver\DriverInterface;
 use InfluxDB\Point;
 use Prometheus\CollectorRegistry;
 use Prometheus\Sample;
-use Swoole\Coroutine;
 
 class MetricFactory implements MetricFactoryInterface
 {
@@ -119,7 +118,7 @@ class MetricFactory implements MetricFactoryInterface
         }
         while (true) {
             $workerExited = CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield($interval);
-            if ($workerExited){
+            if ($workerExited) {
                 break;
             }
             $points = [];

--- a/src/metric/src/Adapter/NoOp/MetricFactory.php
+++ b/src/metric/src/Adapter/NoOp/MetricFactory.php
@@ -17,7 +17,7 @@ use Hyperf\Metric\Contract\CounterInterface;
 use Hyperf\Metric\Contract\GaugeInterface;
 use Hyperf\Metric\Contract\HistogramInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
-use Swoole\Coroutine;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 
 class MetricFactory implements MetricFactoryInterface
 {
@@ -48,6 +48,7 @@ class MetricFactory implements MetricFactoryInterface
 
     public function handle(): void
     {
-        Coroutine::yield();
+        $coordinator = CoordinatorManager::get('workerExit');
+        $coordinator->yield();
     }
 }

--- a/src/metric/src/Adapter/NoOp/MetricFactory.php
+++ b/src/metric/src/Adapter/NoOp/MetricFactory.php
@@ -17,6 +17,7 @@ use Hyperf\Metric\Contract\CounterInterface;
 use Hyperf\Metric\Contract\GaugeInterface;
 use Hyperf\Metric\Contract\HistogramInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 
 class MetricFactory implements MetricFactoryInterface
@@ -48,7 +49,7 @@ class MetricFactory implements MetricFactoryInterface
 
     public function handle(): void
     {
-        $coordinator = CoordinatorManager::get('workerExit');
+        $coordinator = CoordinatorManager::get(Constants::ON_WORKER_EXIT);
         $coordinator->yield();
     }
 }

--- a/src/metric/src/Adapter/Prometheus/MetricFactory.php
+++ b/src/metric/src/Adapter/Prometheus/MetricFactory.php
@@ -20,11 +20,11 @@ use Hyperf\Metric\Contract\HistogramInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Metric\Exception\InvalidArgumentException;
 use Hyperf\Metric\Exception\RuntimeException;
+use Hyperf\Utils\Coordinator\Constants as Coord;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Str;
 use Prometheus\CollectorRegistry;
 use Prometheus\RenderTextFormat;
-use Hyperf\Utils\Coordinator\Constants as Coord;
 use Swoole\Coroutine\Http\Server;
 
 class MetricFactory implements MetricFactoryInterface
@@ -131,7 +131,7 @@ class MetricFactory implements MetricFactoryInterface
             $port = $this->config->get("metric.metric.{$this->name}.push_port");
             $this->doRequest("{$host}:{$port}", $this->getNamespace(), 'put');
             $workerExited = CoordinatorManager::get(Coord::ON_WORKER_EXIT)->yield($interval);
-            if ($workerExited){
+            if ($workerExited) {
                 break;
             }
         }

--- a/src/metric/src/Adapter/Prometheus/MetricFactory.php
+++ b/src/metric/src/Adapter/Prometheus/MetricFactory.php
@@ -20,10 +20,11 @@ use Hyperf\Metric\Contract\HistogramInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Metric\Exception\InvalidArgumentException;
 use Hyperf\Metric\Exception\RuntimeException;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Str;
 use Prometheus\CollectorRegistry;
 use Prometheus\RenderTextFormat;
-use Swoole\Coroutine;
+use Hyperf\Utils\Coordinator\Constants as Coord;
 use Swoole\Coroutine\Http\Server;
 
 class MetricFactory implements MetricFactoryInterface
@@ -129,13 +130,16 @@ class MetricFactory implements MetricFactoryInterface
             $host = $this->config->get("metric.metric.{$this->name}.push_host");
             $port = $this->config->get("metric.metric.{$this->name}.push_port");
             $this->doRequest("{$host}:{$port}", $this->getNamespace(), 'put');
-            Coroutine::sleep($interval);
+            $workerExited = CoordinatorManager::get(Coord::ON_WORKER_EXIT)->yield($interval);
+            if ($workerExited){
+                break;
+            }
         }
     }
 
     protected function customHandle()
     {
-        Coroutine::yield(); // Yield forever
+        CoordinatorManager::get(Coord::ON_WORKER_EXIT)->yield(); // Yield forever
     }
 
     private function getNamespace(): string

--- a/src/metric/src/Adapter/StatsD/MetricFactory.php
+++ b/src/metric/src/Adapter/StatsD/MetricFactory.php
@@ -21,7 +21,6 @@ use Hyperf\Metric\Contract\HistogramInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
-use Swoole\Coroutine;
 
 class MetricFactory implements MetricFactoryInterface
 {
@@ -91,7 +90,7 @@ class MetricFactory implements MetricFactoryInterface
                 $this->client->startBatch();
                 $workerExited = CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield($interval);
                 $this->client->endBatch();
-                if ($workerExited){
+                if ($workerExited) {
                     break;
                 }
             } while (true);

--- a/src/metric/src/Listener/OnMetricFactoryReady.php
+++ b/src/metric/src/Listener/OnMetricFactoryReady.php
@@ -17,6 +17,7 @@ use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Metric\Event\MetricFactoryReady;
 use Hyperf\Metric\MetricSetter;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\Container\ContainerInterface;
 use Swoole\Coroutine;
@@ -110,8 +111,7 @@ class OnMetricFactoryReady implements ListenerInterface
         });
         // Clean up timer on worker exit;
         Coroutine::create(function () use ($timerId) {
-            $coordinator = CoordinatorManager::get('workerExit');
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield();
             Timer::clear($timerId);
         });
     }

--- a/src/metric/src/Listener/OnWorkerStart.php
+++ b/src/metric/src/Listener/OnWorkerStart.php
@@ -19,6 +19,7 @@ use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Metric\Event\MetricFactoryReady;
 use Hyperf\Metric\MetricSetter;
 use Hyperf\Retry\Retry;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\Container\ContainerInterface;
@@ -145,8 +146,7 @@ class OnWorkerStart implements ListenerInterface
         });
         // Clean up timer on worker exit;
         Coroutine::create(function () use ($timerId) {
-            $coordinator = CoordinatorManager::get('workerExit');
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield();
             Timer::clear($timerId);
         });
     }

--- a/src/metric/src/Listener/PoolWatcher.php
+++ b/src/metric/src/Listener/PoolWatcher.php
@@ -16,6 +16,7 @@ use Hyperf\Contract\ConfigInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Pool\Pool;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\Container\ContainerInterface;
@@ -79,8 +80,7 @@ abstract class PoolWatcher
             $connectionsInUseGauge->set((float) $pool->getCurrentConnections());
         });
         Coroutine::create(function () use ($timerId) {
-            $coordinator = CoordinatorManager::get('workerExit');
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield();
             Timer::clear($timerId);
         });
     }

--- a/src/metric/src/Listener/QueueWatcher.php
+++ b/src/metric/src/Listener/QueueWatcher.php
@@ -15,7 +15,6 @@ namespace Hyperf\Metric\Listener;
 use Hyperf\AsyncQueue\Driver\DriverFactory;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Event\Contract\ListenerInterface;
-use Hyperf\Framework\Bootstrap\WorkerExitCallback;
 use Hyperf\Metric\Event\MetricFactoryReady;
 use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
@@ -82,9 +81,9 @@ class QueueWatcher implements ListenerInterface
             $failed->set((float) $info['failed']);
             $timeout->set((float) $info['timeout']);
         });
-        Coroutine::create(function() use ($timerId) {
-           CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield();
-           Timer::clear($timerId);
+        Coroutine::create(function () use ($timerId) {
+            CoordinatorManager::get(Constants::ON_WORKER_EXIT)->yield();
+            Timer::clear($timerId);
         });
     }
 }

--- a/src/rpc-server/src/Server.php
+++ b/src/rpc-server/src/Server.php
@@ -23,8 +23,8 @@ use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 use Hyperf\Rpc\Context as RpcContext;
 use Hyperf\Rpc\Protocol;
 use Hyperf\Server\ServerManager;
-use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -106,8 +106,7 @@ abstract class Server implements OnReceiveInterface, MiddlewareInitializerInterf
     {
         $request = $response = null;
         try {
-            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_START)->yield();
 
             // Initialize PSR-7 Request and Response objects.
             Context::set(ServerRequestInterface::class, $request = $this->buildRequest($fd, $fromId, $data));

--- a/src/rpc-server/src/Server.php
+++ b/src/rpc-server/src/Server.php
@@ -23,7 +23,9 @@ use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 use Hyperf\Rpc\Context as RpcContext;
 use Hyperf\Rpc\Protocol;
 use Hyperf\Server\ServerManager;
+use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -104,6 +106,9 @@ abstract class Server implements OnReceiveInterface, MiddlewareInitializerInterf
     {
         $request = $response = null;
         try {
+            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
+            $coordinator->yield();
+
             // Initialize PSR-7 Request and Response objects.
             Context::set(ServerRequestInterface::class, $request = $this->buildRequest($fd, $fromId, $data));
             Context::set(ResponseInterface::class, $this->buildResponse($fd, $server));

--- a/src/server/src/Server.php
+++ b/src/server/src/Server.php
@@ -220,6 +220,7 @@ class Server implements ServerInterface
                 SwooleEvent::ON_START => [Bootstrap\StartCallback::class, 'onStart'],
                 SwooleEvent::ON_MANAGER_START => [Bootstrap\ManagerStartCallback::class, 'onManagerStart'],
                 SwooleEvent::ON_WORKER_START => [Bootstrap\WorkerStartCallback::class, 'onWorkerStart'],
+                SwooleEvent::ON_WORKER_STOP => [Bootstrap\WorkerStopCallback::class, 'onWorkerStop'],
             ];
         }
 

--- a/src/server/src/ServerManager.php
+++ b/src/server/src/ServerManager.php
@@ -24,7 +24,6 @@ class ServerManager
     protected static $container = [];
 
     /**
-     * @param string $name
      * @param array $value [$serverType, $server]
      */
     public static function add(string $name, array $value)

--- a/src/utils/src/Coordinator/Constants.php
+++ b/src/utils/src/Coordinator/Constants.php
@@ -1,8 +1,16 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
 
 namespace Hyperf\Utils\Coordinator;
-
 
 class Constants
 {
@@ -10,9 +18,9 @@ class Constants
      * Swoole onWorkerStart event.
      */
     const ON_WORKER_START = 'workerStart';
+
     /**
      * Swoole onWorkerExit event.
      */
     const ON_WORKER_EXIT = 'workerExit';
-
 }

--- a/src/utils/src/Coordinator/Constants.php
+++ b/src/utils/src/Coordinator/Constants.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Hyperf\Utils\Coordinator;
+
+
+class Constants
+{
+    /**
+     * Swoole onWorkerStart event.
+     */
+    const ON_WORKER_START = 'workerStart';
+    /**
+     * Swoole onWorkerExit event.
+     */
+    const ON_WORKER_EXIT = 'workerExit';
+
+}

--- a/src/utils/src/Coordinator/Coordinator.php
+++ b/src/utils/src/Coordinator/Coordinator.php
@@ -42,7 +42,7 @@ class Coordinator
     /**
      * Wakeup all coroutines yielding for this coordinator.
      */
-    public function resume()
+    public function resume(): void
     {
         $this->channel->close();
     }

--- a/src/utils/src/Coordinator/Coordinator.php
+++ b/src/utils/src/Coordinator/Coordinator.php
@@ -36,11 +36,7 @@ class Coordinator
     public function yield($timeout = -1): bool
     {
         $this->channel->pop((float) $timeout);
-        $code = $this->channel->errCode;
-        if ($code == -2) {
-            return true;
-        }
-        return false;
+        return $this->channel->errCode === -2;
     }
 
     /**

--- a/src/utils/src/Coordinator/Coordinator.php
+++ b/src/utils/src/Coordinator/Coordinator.php
@@ -30,13 +30,13 @@ class Coordinator
      * Yield the current coroutine for a given timeout,
      * unless the coordinator is woke up from outside.
      *
-     * @param int|float $timeout
+     * @param float|int $timeout
      * @return bool returns true if the coordinator has been woken up
      */
     public function yield($timeout = -1): bool
     {
         $this->channel->pop((float) $timeout);
-        return $this->channel->errCode === -2;
+        return $this->channel->errCode === SWOOLE_CHANNEL_CLOSED;
     }
 
     /**

--- a/src/utils/src/Coordinator/Coordinator.php
+++ b/src/utils/src/Coordinator/Coordinator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Utils\Coordinator;
+
+use Swoole\Coroutine\Channel;
+
+class Coordinator
+{
+    /**
+     * @var Channel
+     */
+    private $channel;
+
+    public function __construct()
+    {
+        $this->channel = new Channel(1);
+    }
+
+    /**
+     * Yield the current coroutine for a given timeout,
+     * unless the coordinator is woke up from outside.
+     * @return bool returns true if the coordinator has been woken up
+     */
+    public function yield(float $timeout = -1): bool
+    {
+        $this->channel->pop($timeout);
+        $code = $this->channel->errCode;
+        if ($code == -2) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Wakeup all coroutines yielding for this coordinator.
+     */
+    public function resume()
+    {
+        $this->channel->close();
+    }
+}

--- a/src/utils/src/Coordinator/Coordinator.php
+++ b/src/utils/src/Coordinator/Coordinator.php
@@ -29,11 +29,13 @@ class Coordinator
     /**
      * Yield the current coroutine for a given timeout,
      * unless the coordinator is woke up from outside.
+     *
+     * @param int|float $timeout
      * @return bool returns true if the coordinator has been woken up
      */
-    public function yield(float $timeout = -1): bool
+    public function yield($timeout = -1): bool
     {
-        $this->channel->pop($timeout);
+        $this->channel->pop((float) $timeout);
         $code = $this->channel->errCode;
         if ($code == -2) {
             return true;

--- a/src/utils/src/Coordinator/CoordinatorManager.php
+++ b/src/utils/src/Coordinator/CoordinatorManager.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Utils\Coordinator;
+
+class CoordinatorManager
+{
+    /**
+     * A container that use to store coordinator.
+     *
+     * @var array
+     */
+    private static $container = [];
+
+    /**
+     * You should initialize a Coordinator with the identifier before use it.
+     */
+    public static function initialize(string $identifier): void
+    {
+        static::$container[$identifier] = new Coordinator();
+    }
+
+    /**
+     * Get a coordinator from container by the identifier.
+     *
+     * @throws \RuntimeException when the Lock with the identifier has not initialization
+     */
+    public static function get(string $identifier): Coordinator
+    {
+        if (! isset(static::$container[$identifier])) {
+            static::$container[$identifier] = new Coordinator();
+        }
+
+        return static::$container[$identifier];
+    }
+
+    /**
+     * Remove the coordinator by the identifier from container after used,
+     * otherwise memory leaks will occur.
+     */
+    public static function clear(string $identifier): void
+    {
+        unset(static::$container[$identifier]);
+    }
+}

--- a/src/utils/tests/Coordinator/CoordinatorTest.php
+++ b/src/utils/tests/Coordinator/CoordinatorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Utils\Coordinator;
+
+use Hyperf\Utils\Coordinator\Coordinator;
+use Hyperf\Utils\WaitGroup;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class CoordinatorTest extends TestCase
+{
+    public function testYield()
+    {
+        $coord = new Coordinator();
+        $aborted = $coord->yield(0.001);
+        $this->assertFalse($aborted);
+    }
+
+    public function testYieldResume()
+    {
+        $coord = new Coordinator();
+        $wg = new WaitGroup();
+        $wg->add();
+        go(function () use ($coord, $wg) {
+            $aborted = $coord->yield(10);
+            $this->assertTrue($aborted);
+            $wg->done();
+        });
+        $wg->add();
+        go(function () use ($coord, $wg) {
+            $aborted = $coord->yield(10);
+            $this->assertTrue($aborted);
+            $wg->done();
+        });
+        $coord->resume();
+        $wg->wait();
+    }
+}

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -26,8 +26,8 @@ use Hyperf\HttpMessage\Server\Response as Psr7Response;
 use Hyperf\HttpServer\Contract\CoreMiddlewareInterface;
 use Hyperf\HttpServer\MiddlewareManager;
 use Hyperf\HttpServer\Router\Dispatched;
-use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\WebSocketServer\Collector\FdCollector;
 use Hyperf\WebSocketServer\Exception\Handler\WebSocketExceptionHandler;
@@ -116,8 +116,7 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
     public function onHandShake(SwooleRequest $request, SwooleResponse $response): void
     {
         try {
-            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
-            $coordinator->yield();
+            CoordinatorManager::get(Constants::ON_WORKER_START)->yield();
 
             $security = $this->container->get(Security::class);
 

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -26,7 +26,9 @@ use Hyperf\HttpMessage\Server\Response as Psr7Response;
 use Hyperf\HttpServer\Contract\CoreMiddlewareInterface;
 use Hyperf\HttpServer\MiddlewareManager;
 use Hyperf\HttpServer\Router\Dispatched;
+use Hyperf\Server\SwooleEvent;
 use Hyperf\Utils\Context;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\WebSocketServer\Collector\FdCollector;
 use Hyperf\WebSocketServer\Exception\Handler\WebSocketExceptionHandler;
 use Hyperf\WebSocketServer\Exception\WebSocketHandeShakeException;
@@ -114,6 +116,9 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
     public function onHandShake(SwooleRequest $request, SwooleResponse $response): void
     {
         try {
+            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
+            $coordinator->yield();
+
             $security = $this->container->get(Security::class);
 
             $psr7Request = $this->initRequest($request);


### PR DESCRIPTION
Signed-off-by: reasno <guxi99@gmail.com>

这个PR值需要详细探讨。

fixes #4

## Coordinator
下面都是伪码。

有时我们需要优雅启动。

```php
$worker->on('request', function($r){
  sleepUntilServerReady();
  handle($r)
});
```

有时我们需要优雅终止。

```php
$server->on('workerStart', function($r){
  allocateResource();
  sleepUntilServerExit();
  reclaimResource();
});
```
有时我们需要可中断的睡眠
```php
while(true){
   $interrupted = sleep(5);
   if ($interrupted) {
      break;
   }
   doSomething();
}
```

诚然这些需求也可以通过psr14事件实现。但是事件类似Callback机制，没有办法在同一个函数内实现资源分配和资源回收，需要传递参数比较多的时候就会很乱，需要分配很多全局变量。

新加入的utils类Coordinator对这种需求进行了基于CSP编程风格的封装。

#4 变成了这样：

```php
    public function onRequest(SwooleRequest $request, SwooleResponse $response): void
    {
            $coordinator = CoordinatorManager::get(SwooleEvent::ON_WORKER_START);
            $coordinator->yield();
            //handle requesets
    }
```

如果初始化未完成，onRequest协程就会挂起，直到初始化完成才继续执行。如果初始化已完成，则没有协程切换。

Timer的分配和回收变成了这样：

```php
go(function()){
    $timerId = Timer::tick(1000, function(){});
    defer(function(){
        Timer::clear($timerId);
    });
    $coordinator = CoordinatorManager::get('workerExit');
    $coordinator->yield();
});
```
这样就不用给保存一个全局id，然后在onWorkerExit事件里回收了，更符合CSP风格。

协程Config拉取变成了这样：
```php
                    $prevConfig = [];
                    while (true) {
                        $coordinator = CoordinatorManager::get('workerExit');
                        $workerExited = $coordinator->yield($interval);
                        if ($workerExited) {
                            break;
                        }
                        $config = $this->client->pull();
                        if ($config !== $prevConfig) {
                            $this->updateConfig($config);
                        }
                        $prevConfig = $config;
                    }
```
当worker退出时，睡眠会立刻中断，并且退出死循环，从而实现优雅停止。



