### PR TITLE
AMQP增加最大消费数属性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1575](https://github.com/hyperf/hyperf/pull/1575) Added document of property with relation, scope and attributes.
 - [#1586](https://github.com/hyperf/hyperf/pull/1586) Added conflict of symfony/event-dispatcher which < 4.3.
+- [#1597](https://github.com/hyperf/hyperf/pull/1597) Added `maxConsumption` for amqp consumer.
 
 ## Fixed
 

--- a/doc/zh-cn/amqp.md
+++ b/doc/zh-cn/amqp.md
@@ -195,6 +195,10 @@ class DemoConsumer extends ConsumerMessage
 }
 ```
 
+### 设置最大消费数
+
+可以修改 `@Consumer` 注解中的 `maxConsumption` 属性，设置此消费者最大处理的消息数，达到指定消费数后，消费者进程会重启。
+
 ### 消费结果
 
 框架会根据 `Consumer` 内的 `consume` 方法所返回的结果来决定该消息的响应行为，共有 4 中响应结果，分别为 `\Hyperf\Amqp\Result::ACK`、`\Hyperf\Amqp\Result::NACK`、`\Hyperf\Amqp\Result::REQUEUE`、`\Hyperf\Amqp\Result::DROP`，每个返回值分别代表如下行为：

--- a/src/amqp/src/Annotation/Consumer.php
+++ b/src/amqp/src/Annotation/Consumer.php
@@ -48,4 +48,9 @@ class Consumer extends AbstractAnnotation
      * @var null|bool
      */
     public $enable;
+
+    /**
+     * @var int
+     */
+    public $maxConsumption = 0;
 }

--- a/src/amqp/src/Consumer.php
+++ b/src/amqp/src/Consumer.php
@@ -96,7 +96,6 @@ class Consumer extends Builder
                 $channel->wait();
             }
         } catch (MaxConsumptionException $ex) {
-
         }
 
         $pool->release($connection);

--- a/src/amqp/src/Consumer.php
+++ b/src/amqp/src/Consumer.php
@@ -14,6 +14,7 @@ namespace Hyperf\Amqp;
 use Hyperf\Amqp\Event\AfterConsume;
 use Hyperf\Amqp\Event\BeforeConsume;
 use Hyperf\Amqp\Event\FailToConsume;
+use Hyperf\Amqp\Exception\MaxConsumptionException;
 use Hyperf\Amqp\Exception\MessageException;
 use Hyperf\Amqp\Message\ConsumerMessageInterface;
 use Hyperf\Amqp\Message\MessageInterface;
@@ -67,6 +68,9 @@ class Consumer extends Builder
         $this->declare($consumerMessage, $channel);
         $concurrent = $this->getConcurrent();
 
+        $maxConsumption = $consumerMessage->getMaxConsumption();
+        $currentConsumption = 0;
+
         $channel->basic_consume(
             $consumerMessage->getQueue(),
             $consumerMessage->getConsumerTag(),
@@ -74,7 +78,10 @@ class Consumer extends Builder
             false,
             false,
             false,
-            function (AMQPMessage $message) use ($consumerMessage, $concurrent) {
+            function (AMQPMessage $message) use ($consumerMessage, $concurrent, $maxConsumption, &$currentConsumption) {
+                if ($maxConsumption > 0 && $currentConsumption++ >= $maxConsumption) {
+                    throw new MaxConsumptionException();
+                }
                 $callback = $this->getCallback($consumerMessage, $message);
                 if (! $concurrent instanceof Concurrent) {
                     return parallel([$callback]);
@@ -84,8 +91,12 @@ class Consumer extends Builder
             }
         );
 
-        while (count($channel->callbacks) > 0) {
-            $channel->wait();
+        try {
+            while (count($channel->callbacks) > 0) {
+                $channel->wait();
+            }
+        } catch (MaxConsumptionException $ex) {
+
         }
 
         $pool->release($connection);

--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -48,6 +48,7 @@ class ConsumerManager
             $annotation->queue && $instance->setQueue($annotation->queue);
             ! is_null($annotation->enable) && $instance->setEnable($annotation->enable);
             property_exists($instance, 'container') && $instance->container = $this->container;
+            $annotation->maxConsumption && $instance->setMaxConsumption($annotation->maxConsumption);
             $nums = $annotation->nums;
             $process = $this->createProcess($instance);
             $process->nums = (int) $nums;

--- a/src/amqp/src/Exception/MaxConsumptionException.php
+++ b/src/amqp/src/Exception/MaxConsumptionException.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\Amqp\Exception;
 
 use Exception;

--- a/src/amqp/src/Exception/MaxConsumptionException.php
+++ b/src/amqp/src/Exception/MaxConsumptionException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Amqp\Exception;
+
+use Exception;
+
+class MaxConsumptionException extends Exception
+{
+}

--- a/src/amqp/src/Message/ConsumerMessage.php
+++ b/src/amqp/src/Message/ConsumerMessage.php
@@ -48,6 +48,11 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
      */
     protected $enable = true;
 
+    /**
+     * @var int
+     */
+    protected $maxConsumption = 0;
+
     public function setQueue(string $queue): self
     {
         $this->queue = $queue;
@@ -95,6 +100,17 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
     public function setEnable(bool $enable): self
     {
         $this->enable = $enable;
+        return $this;
+    }
+
+    public function getMaxConsumption(): int
+    {
+        return $this->maxConsumption;
+    }
+
+    public function setMaxConsumption(int $maxConsumption)
+    {
+        $this->maxConsumption = $maxConsumption;
         return $this;
     }
 }

--- a/src/amqp/src/Message/ConsumerMessageInterface.php
+++ b/src/amqp/src/Message/ConsumerMessageInterface.php
@@ -32,4 +32,8 @@ interface ConsumerMessageInterface extends MessageInterface
     public function isEnable(): bool;
 
     public function setEnable(bool $enable);
+
+    public function getMaxConsumption(): int;
+
+    public function setMaxConsumption(int $maxConsumption);
 }

--- a/src/amqp/tests/ConsumerManagerTest.php
+++ b/src/amqp/tests/ConsumerManagerTest.php
@@ -40,6 +40,7 @@ class ConsumerManagerTest extends TestCase
             'routingKey' => $routingKey = uniqid(),
             'queue' => $queue = uniqid(),
             'nums' => $nums = rand(1, 10),
+            'maxConsumption' => $maxConsumption = rand(1, 10),
         ]));
 
         $manager = new ConsumerManager($container);
@@ -56,6 +57,7 @@ class ConsumerManagerTest extends TestCase
                 $this->assertSame($routingKey, $message->getRoutingKey());
                 $this->assertSame($queue, $message->getQueue());
                 $this->assertSame($nums, $item->nums);
+                $this->assertSame($maxConsumption, $this->getMaxConsumption());
                 break;
             }
         }

--- a/src/amqp/tests/ConsumerManagerTest.php
+++ b/src/amqp/tests/ConsumerManagerTest.php
@@ -57,7 +57,7 @@ class ConsumerManagerTest extends TestCase
                 $this->assertSame($routingKey, $message->getRoutingKey());
                 $this->assertSame($queue, $message->getQueue());
                 $this->assertSame($nums, $item->nums);
-                $this->assertSame($maxConsumption, $this->getMaxConsumption());
+                $this->assertSame($maxConsumption, $message->getMaxConsumption());
                 break;
             }
         }


### PR DESCRIPTION
增加一个最大消费数属性，让消费者进程重启，因为我实在找不出内存溢出的原因了。