### PR TITLE
Fixed: 修复路由注册使用闭包时导致报错

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1575](https://github.com/hyperf/hyperf/pull/1575) Added document of property with relation, scope and attributes.
 - [#1586](https://github.com/hyperf/hyperf/pull/1586) Added conflict of symfony/event-dispatcher which < 4.3.
+- [#1624](https://github.com/hyperf/hyperf/pull/1624) Fixed `describe:routes` when router handler is `Closure`.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - [#1575](https://github.com/hyperf/hyperf/pull/1575) Added document of property with relation, scope and attributes.
 - [#1586](https://github.com/hyperf/hyperf/pull/1586) Added conflict of symfony/event-dispatcher which < 4.3.
 - [#1597](https://github.com/hyperf/hyperf/pull/1597) Added `maxConsumption` for amqp consumer.
-- [#1624](https://github.com/hyperf/hyperf/pull/1624) Fixed `describe:routes` when router handler is `Closure`.
 
 ## Fixed
 
 - [#1553](https://github.com/hyperf/hyperf/pull/1553) Fixed the rpc client do not work, when jsonrpc server register the same service to consul with jsonrpc and jsonrpc-http protocol.
 - [#1589](https://github.com/hyperf/hyperf/pull/1589) Fixed unsafe file locks in coroutines.
 - [#1607](https://github.com/hyperf/hyperf/pull/1607) Fixed bug that the return value of function `go` is not adaptive with `swoole`.
+- [#1624](https://github.com/hyperf/hyperf/pull/1624) Fixed `describe:routes` failed when router handler is `Closure`.
 
 # v1.1.26 - 2020-04-16
 

--- a/src/devtool/src/Describe/RoutesCommand.php
+++ b/src/devtool/src/Describe/RoutesCommand.php
@@ -98,6 +98,8 @@ class RoutesCommand extends HyperfCommand
         }
         if (is_array($handler->callback)) {
             $action = $handler->callback[0] . '::' . $handler->callback[1];
+        } elseif (is_callable($handler->callback)) {
+            $action = 'Closure';
         } else {
             $action = $handler->callback;
         }


### PR DESCRIPTION
使用闭包注册路由的时候，`$handler->callback` 是一个 `Closure ` 而不是一个字符串，所以在展示的时候会报错。

修复完之后效果：
![image](https://user-images.githubusercontent.com/3191858/79972972-56562300-84c9-11ea-93d1-f1fbd030800e.png)
