### PR TITLE
测试中的出现异常不应该直接使用 exit 退出, 这样无法准确定位哪个测试没通过

### DIFF
--- a/src/testing/co-phpunit
+++ b/src/testing/co-phpunit
@@ -57,10 +57,7 @@
 
     require PHPUNIT_COMPOSER_INSTALL;
 
-    $code = PHPUnit\TextUI\Command::main(false);
-    if ($code > 0) {
-        exit($code);
-    }
+    PHPUnit\TextUI\Command::main(false);
 
     swoole_event_exit();
 });


### PR DESCRIPTION
Fixes #1628 