### PR TITLE
add batch create consumer  producer

### DIFF
--- a/src/nsq/publish/nsq.php
+++ b/src/nsq/publish/nsq.php
@@ -23,4 +23,24 @@ return [
             'max_idle_time' => 60.0,
         ],
     ],
+    'nsqlookup' => [
+        'debug' => "false",
+        'host' =>"127.0.0.1",
+        'port' => 4161,
+        'topic' =>"demoTopic",
+        'channel' =>"demoChannel",
+        'name' => "demoConsumer",
+        'nums' =>2,
+        'url' =>"/NODES",
+        'cache_ttl' => "3600",
+        'pool' =>[
+            'min_connections' => 1,
+            'max_connections' => 10,
+            'connect_timeout' => 10.0,
+            'wait_timeout' => 3.0,
+            'heartbeat' => -1,
+            'max_idle_time' => 60.0
+        ]
+
+    ],
 ];

--- a/src/nsq/src/Batch.php
+++ b/src/nsq/src/Batch.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author rock
+ * Date: 2020/4/26 11:47
+ */
+
+namespace Hyperf\Nsq;
+
+
+use App\Constants\ResponseCode;
+use App\Exception\CommonException;
+use GuzzleHttp\Client;
+use Hyperf\Contract\ConfigInterface;
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+class Batch
+{
+    public $ipList;
+
+    /**
+     * @var CacheInterface
+     */
+    protected $cache;
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
+
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    private $client;
+
+    /**
+     * @var Hyperf\Contract\StdoutLoggerInterface
+     */
+    private $loger;
+    public function __construct(ContainerInterface $container, CacheInterface $cache, ConfigInterface $config,StdoutLoggerInterface $loger)
+    {
+        $this->container = $container;
+        $this->config = $config->get('nsq');
+        $this->cache = $cache;
+        $this->loger = $loger;
+    }
+
+
+    public function getIpList($nsqlookup)
+    {
+        $options = [
+            'base_uri' => "http://{$nsqlookup['host']}:{$nsqlookup['port']}",
+            'timeout' => 2,
+            'query' => ['topic' => $nsqlookup['topic']],
+        ];
+
+        try {
+            $client = make(Client::class, ['config' => $options]);
+            $result = $client->get($nsqlookup['url']);
+        } catch (\Exception $exception) {
+          return  $this->loger->error( 'Nsqlookup did not connect ' . $exception->getMessage());
+
+        }
+        $content = $result->getBody()->getContents();
+        if (! empty($content)) {
+            return $content;
+        }
+
+        $this->loger->error( 'nsq is not run or config!');
+    }
+
+
+    public function getNsqIpList($nsqlookup)
+    {
+        $nsqIpList = $this->cache->get('nsqIpList');
+        if (empty($nsqIpList)) {
+            $nsqIpList = $this->getIpList($nsqlookup);
+            $nsqIpList = $this->handleConfig($nsqIpList);
+        } else {
+            $nsqIpList = json_decode($nsqIpList, true);
+        }
+
+        return $nsqIpList;
+    }
+
+
+    public function handleConfig($object)
+    {
+        $configArray = [];
+
+        $nsqData = json_decode($object);
+        if (! empty($nsqData->producers) && is_array($nsqData->producers)) {
+            foreach ($nsqData->producers as $key => $value) {
+                $configArray['pool' . $key]['host'] = $value->broadcast_address;
+                $configArray['pool' . $key]['port'] = $value->tcp_port;
+                $configArray['pool' . $key]['pool'] = $this->config['nsqlookup']['pool'];
+            }
+            $this->cache->set('nsqIpList', json_encode($configArray), 3600);
+            return $configArray;
+        }
+
+        $this->loger->error( 'nsq handleConfig is error! ');
+    }
+}

--- a/src/nsq/src/Nsq.php
+++ b/src/nsq/src/Nsq.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\Nsq;
 
 use Closure;
+use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Nsq\Exception\SocketSendException;
 use Hyperf\Nsq\Pool\NsqConnection;
@@ -19,7 +20,8 @@ use Hyperf\Nsq\Pool\NsqPoolFactory;
 use Hyperf\Pool\Exception\ConnectionException;
 use Psr\Container\ContainerInterface;
 use Swoole\Coroutine\Socket;
-
+use Psr\SimpleCache\CacheInterface;
+use Hyperf\Nsq\Batch;
 class Nsq
 {
     /**
@@ -47,18 +49,101 @@ class Nsq
      */
     protected $logger;
 
+    /**
+     * @var CacheInterface
+     */
+    protected $cache;
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
+
+    /**
+     * @var Hyperf\Nsq\Batch
+     */
+    private $batch;
+
+    /**
+     * @var nsqIpList
+     */
+    private $nsqIpList;
     public function __construct(ContainerInterface $container, string $pool = 'default')
     {
         $this->container = $container;
-        $this->pool = $container->get(NsqPoolFactory::class)->getPool($pool);
         $this->builder = $container->get(MessageBuilder::class);
         $this->logger = $container->get(StdoutLoggerInterface::class);
+        $this->cache = $container->get(CacheInterface::class);
+        $this->config = $container->get(ConfigInterface::class);
+        $this->batch = $container->get(Batch::class);
+
+
+        $nsqlookup=$this->config->get("nsq")['nsqlookup'];
+        if(!$nsqlookup['debug']){
+            $this->nsqIpList=$this->cache->get("producerNsqIpList");
+            if(empty($this->nsqIpList)){
+                $this->nsqIpList=$this->batch->getNsqIpList($nsqlookup);
+            }else{
+                $this->nsqIpList=json_decode($this->nsqIpList,true);
+            }
+            //reset config
+            $nsqConfig=$this->nsqIpList;
+            $nsqConfig['nsqlookup']=$nsqlookup;
+            $this->config->set("nsq",$nsqConfig);
+            $first_key = key($this->nsqIpList);
+            $this->pool = $container->get(NsqPoolFactory::class)->getPool($first_key);
+            //delete the pool
+            unset($this->nsqIpList[$first_key]);
+            $this->resetIpList($this->nsqIpList);
+        }else{
+            $this->pool = $container->get(NsqPoolFactory::class)->getPool($pool);
+        }
+
     }
 
-    /**
-     * @param string|string[] $message
-     * @throws \Throwable
+
+    public function batchPublish(string $topic, $message, float $deferTime = 0.0): bool
+    {
+        try {
+            return $this->publish($topic,$message,$deferTime);
+        } catch (\Throwable $throwable) {
+            $first_key = key($this->nsqIpList);
+            $this->pool = $this->container->get(NsqPoolFactory::class)->getPool($first_key);
+            return $this->publishDefer($topic,$message);
+        }
+    }
+
+    /**reset poll
+     * @param $nsqIpList
+     * @throws \Psr\SimpleCache\InvalidArgumentException
      */
+    public function resetIpList($nsqIpList)
+    {
+        if (count($nsqIpList) > 0) {
+            $this->cache->set('producerNsqIpList', json_encode($nsqIpList));
+        } else {
+            $this->cache->set('producerNsqIpList', '');
+        }
+    }
+
+
+    /** try again
+     * @param $topic
+     * @param $messages
+     * @param int $deferTime
+     * @return bool
+     */
+    public function publishDefer( $topic, $messages, $deferTime = 0.1)
+    {
+        try {
+            return $this->publish($topic, $messages, $deferTime);
+        } catch (\Throwable $throwable) {
+            $this->logger->error('send errorMessages:' . $throwable->getMessage());
+        }
+        return true;
+    }
+
+
     public function publish(string $topic, $message, float $deferTime = 0.0): bool
     {
         if (is_array($message)) {


### PR DESCRIPTION
增加批量创建消费者 跟批量创建生产者功能：
默认配置：
在nsq 增加 nsqlookup 相关配置文件  （nsqlookup是nsq的集群管理器）
'nsqlookup' => [
        'debug' => "false", //开启调式模式时 不会有日志消息队列进程启动,生产环境需要改为false
        'host' =>"127.0.0.1", //nsqlookup host地址
        'port' => 4161,
        'topic' =>"demoTopic",
        'channel' =>"demoChannel",
        'name' => "demoConsumer",
        'nums' =>2, //每个消费者开几个进程
        'url' =>"/NODES", //nsqlookup获取ip 地址的接口路径
        'cache_ttl' => "3600",//缓存时间， 单位为秒
        'pool' =>[
            'min_connections' => 1,
            'max_connections' => 10,
            'connect_timeout' => 10.0,
            'wait_timeout' => 3.0,
            'heartbeat' => -1,
            'max_idle_time' => 60.0
        ]

    ],

1、批量创建消费者  
 当配置nsqlookup debug模式为false 时， 默认会从nsqlookup 上读取到集群的ip 地址后批量启动consumer


2、生产者轮询负载写入
 当配置nsqlookup debug模式为false 时，默认会按照nsqlookup 上读取到集群的IP 轮询写入消息。

轮询策略 ： 轮询策略是通过redis 来完成，首先把所有IP 列表放入redis key中, 取出IP 列表，发布消息后将此IP从列表中移除， 列表完全清空后重新获取整个列表 再次开始轮询，该IP列表会缓存在redis里，默认是一个小时重新从nsqlookup 获取新的IP 地址
所以该扩展需要依赖Psr\SimpleCache\CacheInterface 组件

生产者跟消费者的创建方法跟原来写法一致 

