### PR TITLE
Fix "Expect: 100-Continue" header caused parsing response incorrectly

### DIFF
--- a/src/guzzle/src/CoroutineHandler.php
+++ b/src/guzzle/src/CoroutineHandler.php
@@ -93,8 +93,10 @@ class CoroutineHandler
             $headers['Authorization'] = sprintf('Basic %s', base64_encode($userInfo));
         }
 
-        // TODO: Unknown reason, it will cause 400 some time.
-        unset($headers['Content-Length']);
+        // TODO: Content-Length: Unknown reason, it will cause 400 some time.
+        // Expect header is not supported by \Swoole\Coroutine\Http\Client
+        unset($headers['Content-Length'], $headers['Expect']);
+        $client->setHeaders($headers);
         $client->setHeaders($headers);
     }
 


### PR DESCRIPTION
https://github.com/swoole/swoole-src/issues/3299 swoole 说不打算支持，正如链接中提到的，如果带上了请求会被阻塞，然后解析响应会失败，响应头也到了响应体