### PR TITLE
fix: fix base server start info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1734](https://github.com/hyperf/hyperf/pull/1734) Fixed the bug that the morph association is empty and cannot be queried.
 - [#1739](https://github.com/hyperf/hyperf/pull/1739) Fixed the wrong bitwise operator in oss hook.
 - [#1743](https://github.com/hyperf/hyperf/pull/1743) Fixed the wrong `refId` for `grafana.json`.
+- [#1754](https://github.com/hyperf/hyperf/pull/1754) Fixed the wrong start info for base server.
 
 # v1.1.31 - 2020-05-14
 

--- a/src/server/src/Listener/AfterWorkerStartListener.php
+++ b/src/server/src/Listener/AfterWorkerStartListener.php
@@ -51,10 +51,17 @@ class AfterWorkerStartListener implements ListenerInterface
             /** @var Port $server */
             foreach (ServerManager::list() as $name => [$type, $server]) {
                 $listen = $server->host . ':' . $server->port;
-                $type = value(function () use ($type) {
+                $sockType = $server->type;
+                $type = value(function () use ($type, $sockType) {
                     switch ($type) {
                         case Server::SERVER_BASE:
-                            return 'TCP';
+                            if (($sockType & SWOOLE_SOCK_TCP) || ($sockType & SWOOLE_SOCK_TCP6)) {
+                                return 'TCP';
+                            } else if (($sockType & SWOOLE_SOCK_UDP) || ($sockType & SWOOLE_SOCK_UDP6)) {
+                                return 'UDP';
+                            } else {
+                                return 'UNKNOWN';
+                            }
                             break;
                         case Server::SERVER_WEBSOCKET:
                             return 'WebSocket';

--- a/src/server/src/Listener/AfterWorkerStartListener.php
+++ b/src/server/src/Listener/AfterWorkerStartListener.php
@@ -55,9 +55,9 @@ class AfterWorkerStartListener implements ListenerInterface
                 $type = value(function () use ($type, $sockType) {
                     switch ($type) {
                         case Server::SERVER_BASE:
-                            if (($sockType & SWOOLE_SOCK_TCP) || ($sockType & SWOOLE_SOCK_TCP6)) {
+                            if (($sockType === SWOOLE_SOCK_TCP) || ($sockType === SWOOLE_SOCK_TCP6)) {
                                 return 'TCP';
-                            } else if (($sockType & SWOOLE_SOCK_UDP) || ($sockType & SWOOLE_SOCK_UDP6)) {
+                            } else if (($sockType === SWOOLE_SOCK_UDP) || ($sockType === SWOOLE_SOCK_UDP6)) {
                                 return 'UDP';
                             } else {
                                 return 'UNKNOWN';


### PR DESCRIPTION
修复服务器启动的时候，打印信息错误的问题。

例如如下配置：

```php
<?php
[
        'name' => 'dns',
        'type' => Server::SERVER_BASE,
        'host' => '0.0.0.0',
        'port' => (int) env('SERVER_DNS_PORT', 9553),
        'sock_type' => SWOOLE_SOCK_UDP,
        'callbacks' => [
            SwooleEvent::ON_PACKET => [App\Event\Packet::class, 'onPacket'],
        ],
],
```

服务器启动的时候，日志如下：

```bash
[INFO] HTTP Server listening at 0.0.0.0:9580
[INFO] TCP Server listening at 0.0.0.0:9553
```

修复后：

```bash
[INFO] HTTP Server listening at 0.0.0.0:9580
[INFO] UDP Server listening at 0.0.0.0:9553
```