### PR TITLE
fix: 🐛 修复日期验证规则被验证字段为null时报错

### DIFF
--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -1215,8 +1215,11 @@ trait ValidatesAttributes
      *
      * @return null|\DateTime
      */
-    protected function getDateTimeWithOptionalFormat(string $format, string $value)
+    protected function getDateTimeWithOptionalFormat(string $format, ?string $value)
     {
+        if (is_null($value)){
+            return null;
+        }
         if ($date = DateTime::createFromFormat('!' . $format, $value)) {
             return $date;
         }

--- a/src/validation/tests/Cases/ValidateAttributesTest.php
+++ b/src/validation/tests/Cases/ValidateAttributesTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace HyperfTest\Validation\Cases;
 
 use HyperfTest\Validation\Cases\Stub\ValidatesAttributesStub;
@@ -30,5 +31,23 @@ class ValidateAttributesTest extends TestCase
 
         $this->assertFalse($validator->validateAlphaNum('', 123.1));
         $this->assertFalse($validator->validateAlphaNum('', '123_f1'));
+    }
+
+    public function testValidateAfter()
+    {
+        $validator = new ValidatesAttributesStub();
+        $this->assertTrue($validator->validateAfter('', '2020-05-20', ['2020-05-19']));
+        $this->assertFalse($validator->validateAfter('', '2020-05-18', ['2020-05-19']));
+        $this->assertFalse($validator->validateAfter('', '', ['2020-05-19']));
+        $this->assertFalse($validator->validateAfter('', null, ['2020-05-19']));
+    }
+
+    public function testValidateBefore()
+    {
+        $validator = new ValidatesAttributesStub();
+        $this->assertFalse($validator->validateBefore('', '2020-05-20', ['2020-05-19']));
+        $this->assertTrue($validator->validateBefore('', '2020-05-18', ['2020-05-19']));
+        $this->assertFalse($validator->validateBefore('', '', ['2020-05-19']));
+        $this->assertFalse($validator->validateBefore('', null, ['2020-05-19']));
     }
 }


### PR DESCRIPTION
✅ Closes: #1538