### PR TITLE
fix: Upgrades zipkin-php-opentracing (#1685)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "guzzlehttp/guzzle": "^6.3",
         "influxdb/influxdb-php": "^1.15.0",
         "ircmaxell/random-lib": "^1.2",
-        "jcchavezs/zipkin-opentracing": "^0.1.4",
+        "jcchavezs/zipkin-opentracing": "^0.1.5",
         "jean85/pretty-package-versions": "^1.2",
         "jonahgeorge/jaeger-client-php": "^0.4.4",
         "laminas/laminas-mime": "^2.7",


### PR DESCRIPTION
This change makes it possible to propagate tracing context no matter span is noop or not.

Ping @Reasno 