### PR TITLE
Change conflict of symfony/event-dispatcher from "<4.3" to "<4.3|>=5.0"

### DIFF
--- a/src/framework/composer.json
+++ b/src/framework/composer.json
@@ -41,7 +41,7 @@
         "symfony/event-dispatcher": "Required to use symfony event dispatcher (^4.3)."
     },
     "conflict": {
-        "symfony/event-dispatcher": "<4.3"
+        "symfony/event-dispatcher": "<4.3|>=5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
5.0+  EventDispatcherInterface imcompatible