### PR TITLE
fix: 修复由于Prometheus打点label改变数量导致第三方依赖包遍历数量不匹配报错的bug && 新增支持redis集群模式的打点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [#1873](https://github.com/hyperf/hyperf/pull/1873) Make prometheus use redis to store data to support cluster mode
 
 ## Fixed
-- [#1873](https://github.com/hyperf/hyperf/pull/1873) Fixed when prometheus using the redis record, an error is reported during the rendering of x data due to the change in the number of label.
+- [#1873](https://github.com/hyperf/hyperf/pull/1873) Fixed when prometheus using the redis record, an error is reported during the rendering of data due to the change in the number of label.
 
 
 # v1.1.32 - 2020-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Optimized
 
 - [#1793](https://github.com/hyperf/hyperf/pull/1793) Socket.io server now only dispatch connect/disconnect events in onOpen and onClose. Also upgrade some class members from private to protected, so users can hack them.
+- [#1873](https://github.com/hyperf/hyperf/pull/1873) Make prometheus use redis to store data to support cluster mode
+
+## Fixed
+- [#1873](https://github.com/hyperf/hyperf/pull/1873) Fixed when prometheus using the redis record, an error is reported during the rendering of x data due to the change in the number of label.
+
 
 # v1.1.32 - 2020-05-21
 

--- a/src/metric/src/Adapter/Prometheus/Redis.php
+++ b/src/metric/src/Adapter/Prometheus/Redis.php
@@ -284,6 +284,9 @@ LUA
                 if ($d['b'] == 'sum') {
                     continue;
                 }
+                if (count($d['labelValues']) != count($histogram['labelNames'])) {
+                    continue;
+                }
                 $allLabelValues[] = $d['labelValues'];
             }
             // We need set semantics.
@@ -345,6 +348,9 @@ LUA
             unset($raw['__meta']);
             $gauge['samples'] = [];
             foreach ($raw as $k => $value) {
+                if (count($gauge['labelNames']) != count(json_decode($k, true))) {
+                    continue;
+                }
                 $gauge['samples'][] = [
                     'name' => $gauge['name'],
                     'labelNames' => [],
@@ -371,6 +377,9 @@ LUA
             unset($raw['__meta']);
             $counter['samples'] = [];
             foreach ($raw as $k => $value) {
+                if (count($counter['labelNames']) != count(json_decode($k, true))) {
+                    continue;
+                }
                 $counter['samples'][] = [
                     'name' => $counter['name'],
                     'labelNames' => [],

--- a/src/metric/src/Adapter/Prometheus/Redis.php
+++ b/src/metric/src/Adapter/Prometheus/Redis.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Metric\Adapter\Prometheus;
 
+use Exception;
 use InvalidArgumentException;
 use Prometheus\Counter;
 use Prometheus\Exception\StorageException;
@@ -150,8 +151,8 @@ end
 LUA
             ,
             [
-                $this->toMetricKey($data),
-                self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                $this->toMetricKey($data) . $this->getRedisTag(Histogram::TYPE),
+                self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Histogram::TYPE),
                 json_encode(['b' => 'sum', 'labelValues' => $data['labelValues']]),
                 json_encode(['b' => $bucketToIncrease, 'labelValues' => $data['labelValues']]),
                 $data['value'],
@@ -187,8 +188,8 @@ end
 LUA
             ,
             [
-                $this->toMetricKey($data),
-                self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                $this->toMetricKey($data) . $this->getRedisTag(Gauge::TYPE),
+                self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Gauge::TYPE),
                 $this->getRedisCommand($data['command']),
                 json_encode($data['labelValues']),
                 $data['value'],
@@ -218,8 +219,8 @@ return result
 LUA
             ,
             [
-                $this->toMetricKey($data),
-                self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                $this->toMetricKey($data) . $this->getRedisTag(Counter::TYPE),
+                self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Counter::TYPE),
                 $this->getRedisCommand($data['command']),
                 $data['value'],
                 json_encode($data['labelValues']),
@@ -268,7 +269,7 @@ LUA
 
     private function collectHistograms(): array
     {
-        $keys = $this->redis->sMembers(self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers($this->getMetricGatherKey(Histogram::TYPE));
         sort($keys);
         $histograms = [];
         foreach ($keys as $key) {
@@ -339,7 +340,7 @@ LUA
 
     private function collectGauges(): array
     {
-        $keys = $this->redis->sMembers(self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers($this->getMetricGatherKey(Gauge::TYPE));
         sort($keys);
         $gauges = [];
         foreach ($keys as $key) {
@@ -368,7 +369,7 @@ LUA
 
     private function collectCounters(): array
     {
-        $keys = $this->redis->sMembers(self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers($this->getMetricGatherKey(Counter::TYPE));
         sort($keys);
         $counters = [];
         foreach ($keys as $key) {
@@ -412,5 +413,46 @@ LUA
     private function toMetricKey(array $data): string
     {
         return implode(':', [self::$prefix, $data['type'], $data['name']]);
+    }
+
+    /**
+     * Adapt redis cluster get tag
+     *
+     * @return string
+     */
+    private function getRedisTag($metric_type): string
+    {
+        switch($metric_type)
+        {
+            case Counter::TYPE:
+                return "{counter}";
+            case Histogram::TYPE:
+                return "{histogram}";
+            case Gauge::TYPE:
+                return "{gauge}";
+            default:
+                return '';
+        }
+    }
+
+    /**
+     * Get the indicator collection key
+     *
+     * @return string
+     * @throws \Exception
+     */
+    private function getMetricGatherKey($metric_type): string
+    {
+        switch($metric_type)
+        {
+            case Counter::TYPE:
+                return self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Counter::TYPE);
+            case Histogram::TYPE:
+                return self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Histogram::TYPE);
+            case Gauge::TYPE:
+                return self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX . $this->getRedisTag(Gauge::TYPE);
+            default:
+                throw new Exception('Unknown metric type');
+        }
     }
 }


### PR DESCRIPTION
忽略历史打点数量，确保拉取得打点数量为最新的打点