### PR TITLE
Allows to run multiple coroutine servers at one process

### DIFF
--- a/src/di/src/ClassLoader.php
+++ b/src/di/src/ClassLoader.php
@@ -47,13 +47,10 @@ class ClassLoader
         // Scan by ScanConfig to generate the reflection class map
         $scanner = new Scanner($this, $config = ScanConfig::instance($configDir));
         $classLoader->addClassMap($config->getClassMap());
-        timepoint();
         $reflectionClassMap = $scanner->scan();
-        timepoint('Scan');
         // Get the class map of Composer loader
         $composerLoaderClassMap = $this->getComposerClassLoader()->getClassMap();
         $proxyManager = new ProxyManager($reflectionClassMap, $composerLoaderClassMap, $proxyFileDir);
-        timepoint('InitProxyManager');
         $this->proxies = $proxyManager->getProxies();
     }
 

--- a/src/process/src/Listener/BootProcessListener.php
+++ b/src/process/src/Listener/BootProcessListener.php
@@ -18,7 +18,7 @@ use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeMainServerStart;
 use Hyperf\Process\Annotation\Process;
 use Hyperf\Process\ProcessManager;
-use Hyperf\Server\Event\CoroutineServerStart;
+use Hyperf\Server\Event\MainCoroutineServerStart;
 use Psr\Container\ContainerInterface;
 
 class BootProcessListener implements ListenerInterface
@@ -46,7 +46,7 @@ class BootProcessListener implements ListenerInterface
     {
         return [
             BeforeMainServerStart::class,
-            CoroutineServerStart::class,
+            MainCoroutineServerStart::class,
         ];
     }
 

--- a/src/server/src/ConfigProvider.php
+++ b/src/server/src/ConfigProvider.php
@@ -14,6 +14,7 @@ namespace Hyperf\Server;
 use Hyperf\Server\Command\StartServer;
 use Hyperf\Server\Listener\AfterWorkerStartListener;
 use Hyperf\Server\Listener\InitProcessTitleListener;
+use Hyperf\Server\Listener\StoreServerNameListener;
 use Swoole\Server as SwooleServer;
 
 class ConfigProvider
@@ -25,6 +26,7 @@ class ConfigProvider
                 SwooleServer::class => SwooleServerFactory::class,
             ],
             'listeners' => [
+                StoreServerNameListener::class,
                 AfterWorkerStartListener::class,
                 InitProcessTitleListener::class,
             ],

--- a/src/server/src/CoroutineServer.php
+++ b/src/server/src/CoroutineServer.php
@@ -85,8 +85,8 @@ class CoroutineServer implements ServerInterface
             foreach ($servers as $name => [$type, $server]) {
                 Coroutine::create(function () use ($name, $server, $config) {
                     if (! $this->mainServerStarted) {
-                        $this->eventDispatcher->dispatch(new MainCoroutineServerStart($name, $server, $config));
                         $this->mainServerStarted = true;
+                        $this->eventDispatcher->dispatch(new MainCoroutineServerStart($name, $server, $config));
                     }
                     $this->eventDispatcher->dispatch(new CoroutineServerStart($name, $server, $config));
                     CoordinatorManager::until(Constants::WORKER_START)->resume();

--- a/src/server/src/Event/CoroutineServerStart.php
+++ b/src/server/src/Event/CoroutineServerStart.php
@@ -15,7 +15,6 @@ use Swoole\Coroutine\Server;
 
 class CoroutineServerStart
 {
-
     /**
      * @var string
      */

--- a/src/server/src/Event/CoroutineServerStart.php
+++ b/src/server/src/Event/CoroutineServerStart.php
@@ -15,6 +15,12 @@ use Swoole\Coroutine\Server;
 
 class CoroutineServerStart
 {
+
+    /**
+     * @var string
+     */
+    public $name = '';
+
     /**
      * @var object|Server
      */
@@ -25,8 +31,9 @@ class CoroutineServerStart
      */
     public $serverConfig;
 
-    public function __construct($server, array $serverConfig)
+    public function __construct(string $name, $server, array $serverConfig)
     {
+        $this->name = $name;
         $this->server = $server;
         $this->serverConfig = $serverConfig;
     }

--- a/src/server/src/Event/CoroutineServerStop.php
+++ b/src/server/src/Event/CoroutineServerStop.php
@@ -16,12 +16,18 @@ use Swoole\Coroutine\Server;
 class CoroutineServerStop
 {
     /**
+     * @var string
+     */
+    public $name = '';
+
+    /**
      * @var object|Server
      */
     public $server;
 
-    public function __construct($server)
+    public function __construct(string $name, $server)
     {
+        $this->name = $name;
         $this->server = $server;
     }
 }

--- a/src/server/src/Event/MainCoroutineServerStart.php
+++ b/src/server/src/Event/MainCoroutineServerStart.php
@@ -15,7 +15,6 @@ use Swoole\Coroutine\Server;
 
 class MainCoroutineServerStart
 {
-
     /**
      * @var string
      */

--- a/src/server/src/Event/MainCoroutineServerStart.php
+++ b/src/server/src/Event/MainCoroutineServerStart.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Server\Event;
+
+use Swoole\Coroutine\Server;
+
+class MainCoroutineServerStart
+{
+
+    /**
+     * @var string
+     */
+    public $name = '';
+
+    /**
+     * @var object|Server
+     */
+    public $server;
+
+    /**
+     * @var array
+     */
+    public $serverConfig;
+
+    public function __construct(string $name, $server, array $serverConfig)
+    {
+        $this->name = $name;
+        $this->server = $server;
+        $this->serverConfig = $serverConfig;
+    }
+}

--- a/src/server/src/Listener/AfterWorkerStartListener.php
+++ b/src/server/src/Listener/AfterWorkerStartListener.php
@@ -26,6 +26,8 @@ class AfterWorkerStartListener implements ListenerInterface
      */
     private $logger;
 
+    public static $output = false;
+
     public function __construct(StdoutLoggerInterface $logger)
     {
         $this->logger = $logger;
@@ -48,6 +50,9 @@ class AfterWorkerStartListener implements ListenerInterface
      */
     public function process(object $event)
     {
+        if (static::$output) {
+            return;
+        }
         /** @var AfterWorkerStart|CoroutineServerStart $event */
         $isCoroutineServer = $event instanceof CoroutineServerStart;
         if ($isCoroutineServer || $event->workerId === 0) {
@@ -74,6 +79,7 @@ class AfterWorkerStartListener implements ListenerInterface
                 });
                 $serverType = $isCoroutineServer ? ' Coroutine' : '';
                 $this->logger->info(sprintf('%s%s Server listening at %s', $type, $serverType, $listen));
+                static::$output = true;
             }
         }
     }

--- a/src/server/src/Listener/AfterWorkerStartListener.php
+++ b/src/server/src/Listener/AfterWorkerStartListener.php
@@ -72,8 +72,8 @@ class AfterWorkerStartListener implements ListenerInterface
                             return 'HTTP';
                     }
                 });
-                $serverType = $isCoroutineServer ? 'Coroutine' : '';
-                $this->logger->info(sprintf('%s %s Server listening at %s', $type, $serverType, $listen));
+                $serverType = $isCoroutineServer ? ' Coroutine' : '';
+                $this->logger->info(sprintf('%s%s Server listening at %s', $type, $serverType, $listen));
             }
         }
     }

--- a/src/server/src/Listener/AfterWorkerStartListener.php
+++ b/src/server/src/Listener/AfterWorkerStartListener.php
@@ -14,7 +14,7 @@ namespace Hyperf\Server\Listener;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\AfterWorkerStart;
-use Hyperf\Server\Event\CoroutineServerStart;
+use Hyperf\Server\Event\MainCoroutineServerStart;
 use Hyperf\Server\Server;
 use Hyperf\Server\ServerManager;
 use Swoole\Server\Port;
@@ -25,8 +25,6 @@ class AfterWorkerStartListener implements ListenerInterface
      * @var StdoutLoggerInterface
      */
     private $logger;
-
-    public static $output = false;
 
     public function __construct(StdoutLoggerInterface $logger)
     {
@@ -40,7 +38,7 @@ class AfterWorkerStartListener implements ListenerInterface
     {
         return [
             AfterWorkerStart::class,
-            CoroutineServerStart::class,
+            MainCoroutineServerStart::class,
         ];
     }
 
@@ -50,11 +48,8 @@ class AfterWorkerStartListener implements ListenerInterface
      */
     public function process(object $event)
     {
-        if (static::$output) {
-            return;
-        }
-        /** @var AfterWorkerStart|CoroutineServerStart $event */
-        $isCoroutineServer = $event instanceof CoroutineServerStart;
+        /** @var AfterWorkerStart|MainCoroutineServerStart $event */
+        $isCoroutineServer = $event instanceof MainCoroutineServerStart;
         if ($isCoroutineServer || $event->workerId === 0) {
             /** @var Port $server */
             foreach (ServerManager::list() as $name => [$type, $server]) {
@@ -79,7 +74,6 @@ class AfterWorkerStartListener implements ListenerInterface
                 });
                 $serverType = $isCoroutineServer ? ' Coroutine' : '';
                 $this->logger->info(sprintf('%s%s Server listening at %s', $type, $serverType, $listen));
-                static::$output = true;
             }
         }
     }

--- a/src/server/src/Listener/StoreServerNameListener.php
+++ b/src/server/src/Listener/StoreServerNameListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Server\Listener;
+
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Server\Event\CoroutineServerStart;
+use Hyperf\Utils\Context;
+
+class StoreServerNameListener implements ListenerInterface
+{
+    public function listen(): array
+    {
+        return [
+            CoroutineServerStart::class,
+        ];
+    }
+
+    /**
+     * @param CoroutineServerStart $event
+     */
+    public function process(object $event)
+    {
+        $serverName = $event->name;
+        if (! $serverName) {
+            return;
+        }
+        Context::set('__hyperf__.server.name', $serverName);
+    }
+}

--- a/src/signal/src/Listener/SignalRegisterListener.php
+++ b/src/signal/src/Listener/SignalRegisterListener.php
@@ -14,7 +14,7 @@ namespace Hyperf\Signal\Listener;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Process\Event\BeforeProcessHandle;
-use Hyperf\Server\Event\CoroutineServerStart;
+use Hyperf\Server\Event\MainCoroutineServerStart;
 use Hyperf\Signal\SignalHandlerInterface as SignalHandler;
 use Hyperf\Signal\SignalManager;
 use Psr\Container\ContainerInterface;
@@ -36,7 +36,7 @@ class SignalRegisterListener implements ListenerInterface
         return [
             BeforeWorkerStart::class,
             BeforeProcessHandle::class,
-            CoroutineServerStart::class,
+            MainCoroutineServerStart::class,
         ];
     }
 
@@ -46,7 +46,7 @@ class SignalRegisterListener implements ListenerInterface
 
         $manager->init();
         $manager->listen(value(function () use ($event) {
-            if ($event instanceof BeforeWorkerStart || $event instanceof CoroutineServerStart) {
+            if ($event instanceof BeforeWorkerStart || $event instanceof MainCoroutineServerStart) {
                 return SignalHandler::WORKER;
             }
 

--- a/src/utils/src/Coroutine.php
+++ b/src/utils/src/Coroutine.php
@@ -46,9 +46,13 @@ class Coroutine
      *
      * @see https://github.com/swoole/swoole-src/pull/2669/files#diff-3bdf726b0ac53be7e274b60d59e6ec80R940
      */
-    public static function parentId(): ?int
+    public static function parentId(?int $coroutineId = null): ?int
     {
-        $cid = SwooleCoroutine::getPcid();
+        if ($coroutineId) {
+            $cid = SwooleCoroutine::getPcid($coroutineId);
+        } else {
+            $cid = SwooleCoroutine::getPcid();
+        }
         if ($cid === false) {
             return null;
         }

--- a/src/utils/src/Functions.php
+++ b/src/utils/src/Functions.php
@@ -446,15 +446,3 @@ if (! function_exists('swoole_hook_flags')) {
         return defined('SWOOLE_HOOK_FLAGS') ? SWOOLE_HOOK_FLAGS : SWOOLE_HOOK_ALL;
     }
 }
-
-if (! function_exists('timepoint')) {
-    function timepoint(?string $key = null)
-    {
-        if (! isset($GLOBALS['__timepoint_beginTime__'])) {
-            $GLOBALS['__timepoint_beginTime__'] = microtime(true);
-            return;
-        }
-        echo '[DEBUG] Timepoint ' . $key . ': ' . round(microtime(true) - $GLOBALS['__timepoint_beginTime__'], 3) . 's' . PHP_EOL;
-        $GLOBALS['__timepoint_beginTime__'] = microtime(true);
-    }
-}

--- a/src/utils/src/Functions.php
+++ b/src/utils/src/Functions.php
@@ -421,8 +421,10 @@ if (! function_exists('make')) {
 if (! function_exists('run')) {
     /**
      * Run callable in non-coroutine environment, all hook functions by Swoole only available in the callable.
+     *
+     * @param array|callable $callbacks
      */
-    function run(callable $callback, int $flags = SWOOLE_HOOK_ALL): bool
+    function run($callbacks, int $flags = SWOOLE_HOOK_ALL): bool
     {
         if (Coroutine::inCoroutine()) {
             throw new RuntimeException('Function \'run\' only execute in non-coroutine environment.');
@@ -430,7 +432,7 @@ if (! function_exists('run')) {
 
         \Swoole\Runtime::enableCoroutine(true, $flags);
 
-        $result = \Swoole\Coroutine\Run($callback);
+        $result = \Swoole\Coroutine\Run(...(array) $callbacks);
 
         \Swoole\Runtime::enableCoroutine(false);
         return $result;


### PR DESCRIPTION
1. Allows to run multiple coroutine servers at one process
2. Removed `timepoint()` function
3. Added a `$coroutineId` parameter for `Hyperf\Utils\Coroutine::parnetId()` method
4. Allows pass a callbacks array to `run()` function
5. Added `Hyperf\Server\Event\MainCoroutineServerStart` event