### PR TITLE
Add describe:listeners command

### DIFF
--- a/src/devtool/src/ConfigProvider.php
+++ b/src/devtool/src/ConfigProvider.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  */
 namespace Hyperf\Devtool;
 
+use Hyperf\Devtool\Describe;
+
 class ConfigProvider
 {
     public function __invoke()
@@ -22,6 +24,9 @@ class ConfigProvider
                         __DIR__,
                     ],
                 ],
+            ],
+            'commands' => [
+                Describe\RoutesCommand::class,
             ],
             'publish' => [
                 [

--- a/src/devtool/src/Describe/ListenersCommand.php
+++ b/src/devtool/src/Describe/ListenersCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Devtool\Describe;
+
+use Hyperf\Command\Command as HyperfCommand;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Event\ListenerData;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListenersCommand extends HyperfCommand
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    public function __construct(ContainerInterface $container, ConfigInterface $config)
+    {
+        parent::__construct('describe:listeners');
+        $this->container = $container;
+        $this->config = $config;
+    }
+
+    public function handle()
+    {
+        $events = $this->input->getOption('events');
+        $events = $events ? explode(',', $events) : null;
+        $listeners = $this->input->getOption('listeners');
+        $listeners = $listeners ? explode(',', $listeners) : null;
+
+        $provider = $this->container->get(ListenerProviderInterface::class);
+        $this->show($this->handleData($provider, $events, $listeners), $this->output);
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Describe the events and listeners.')
+            ->addOption('events', 'e', InputOption::VALUE_OPTIONAL, 'Get the detail of the specified route information by path', null)
+            ->addOption('listeners', 'l', InputOption::VALUE_OPTIONAL, 'Which server you want to describe routes.', null);
+    }
+
+    protected function handleData(ListenerProviderInterface $provider, ?array $events, ?array $listeners): array
+    {
+        $data = [];
+        if (! property_exists($provider, 'listeners')) {
+            return $data;
+        }
+        foreach ($provider->listeners as $listener) {
+            if ($listener instanceof ListenerData) {
+                $event = $listener->event;
+                [$object, $method] = $listener->listener;
+                $listenerClassName = get_class($object);
+                if ($events && ! $this->isMatch($event, $events)) {
+                    continue;
+                }
+                if ($listeners && ! $this->isMatch($listenerClassName, $listeners)) {
+                    continue;
+                }
+                $data[$event]['events'] = $listener->event;
+                $data[$event]['listeners'] = array_merge($data[$event]['listeners'] ?? [], [
+                    implode('::', [
+                        $listenerClassName,
+                        $method,
+                    ]),
+                ]);
+            }
+        }
+        return $data;
+    }
+
+    protected function isMatch(string $target, array $keywords = [])
+    {
+        foreach ($keywords as $keyword) {
+            if (strpos($target, $keyword) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function show(array $data, OutputInterface $output)
+    {
+        $rows = [];
+        foreach ($data as $route) {
+            $route['listeners'] = implode(PHP_EOL, (array) $route['listeners']);
+            $rows[] = $route;
+            $rows[] = new TableSeparator();
+        }
+        $rows = array_slice($rows, 0, count($rows) - 1);
+        $table = new Table($output);
+        $table->setHeaders(['Events', 'Listeners'])->setRows($rows);
+        $table->render();
+    }
+}

--- a/src/devtool/src/Describe/ListenersCommand.php
+++ b/src/devtool/src/Describe/ListenersCommand.php
@@ -54,8 +54,8 @@ class ListenersCommand extends HyperfCommand
     protected function configure()
     {
         $this->setDescription('Describe the events and listeners.')
-            ->addOption('events', 'e', InputOption::VALUE_OPTIONAL, 'Get the detail of the specified route information by path', null)
-            ->addOption('listeners', 'l', InputOption::VALUE_OPTIONAL, 'Which server you want to describe routes.', null);
+            ->addOption('events', 'e', InputOption::VALUE_OPTIONAL, 'Get the detail of the specified information by events.', null)
+            ->addOption('listeners', 'l', InputOption::VALUE_OPTIONAL, 'Get the detail of the specified information by listeners.', null);
     }
 
     protected function handleData(ListenerProviderInterface $provider, ?array $events, ?array $listeners): array

--- a/src/devtool/src/Describe/RoutesCommand.php
+++ b/src/devtool/src/Describe/RoutesCommand.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  */
 namespace Hyperf\Devtool\Describe;
 
-use Hyperf\Command\Annotation\Command;
 use Hyperf\Command\Command as HyperfCommand;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\HttpServer\MiddlewareManager;
@@ -25,9 +24,6 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @Command
- */
 class RoutesCommand extends HyperfCommand
 {
     /**
@@ -58,8 +54,6 @@ class RoutesCommand extends HyperfCommand
             $this->analyzeRouter($server, $router, $path),
             $this->output
         );
-
-        $this->output->success('success.');
     }
 
     protected function configure()


### PR DESCRIPTION
#### Refer: #385
#### Detail:
Add `describe:listeners` command, the command has 2 options, `events` and `listeners`, use cases:
1. `php bin/hyperf.php describe:listeners` to describe all events and listeners.
2. `php bin/hyperf.php describe:listeners --events=Hyperf\\Framework\\Event\\AfterWorkerStart` to describe all listeners of the event, use `,` comma to separate multiple events. 
3. `php bin/hyperf.php describe:listeners --events=After` to describe the events that contains `After` keyword information. 
4. `--listeners` option has the same behavior with `--events`.