### PR TITLE
Mark CoordinatorManager::get() method as deprecated in v2.0

### DIFF
--- a/src/socketio-server/src/Room/RedisAdapter.php
+++ b/src/socketio-server/src/Room/RedisAdapter.php
@@ -143,7 +143,7 @@ class RedisAdapter implements AdapterInterface
     public function subscribe()
     {
         Coroutine::create(function () {
-            CoordinatorManager::get(Constants::ON_WORKER_START)->yield();
+            CoordinatorManager::until(Constants::ON_WORKER_START)->yield();
             retry(PHP_INT_MAX, function () {
                 $container = ApplicationContext::getContainer();
                 try {

--- a/src/utils/src/Coordinator/CoordinatorManager.php
+++ b/src/utils/src/Coordinator/CoordinatorManager.php
@@ -44,6 +44,7 @@ class CoordinatorManager
 
     /**
      * Alias of static::until.
+     * @deprecated v2.0
      */
     public static function get(string $identifier): Coordinator
     {


### PR DESCRIPTION
1. Mark CoordinatorManager::get() method as deprecated in v2.0
2. Use until method instead of get method 