### PR TITLE
[FEATURE] Migration 迁移需要表comment备注.

### DIFF
--- a/docs/zh-cn/db/migration.md
+++ b/docs/zh-cn/db/migration.md
@@ -501,3 +501,13 @@ Schema::enableForeignKeyConstraints();
 // 禁用外键约束
 Schema::disableForeignKeyConstraints();
 ```
+
+## 表注释
+
+您可以使用 `comment` 方法对表进行注释
+
+``` 
+Schema:table('users', function (Blueprint $table) {
+    $table->comment('用户表');
+});
+```

--- a/docs/zh-hk/db/migration.md
+++ b/docs/zh-hk/db/migration.md
@@ -501,3 +501,13 @@ Schema::enableForeignKeyConstraints();
 // 禁用外鍵約束
 Schema::disableForeignKeyConstraints();
 ```
+
+## 表註釋
+
+您可以使用 `comment` 方法對表進行註釋
+
+``` 
+Schema:table('users', function (Blueprint $table) {
+    $table->comment('用戶表');
+});
+```

--- a/docs/zh-tw/db/migration.md
+++ b/docs/zh-tw/db/migration.md
@@ -501,3 +501,13 @@ Schema::enableForeignKeyConstraints();
 // 禁用外來鍵約束
 Schema::disableForeignKeyConstraints();
 ```
+
+## 表註釋
+
+您可以使用 `comment` 方法對表進行註釋
+
+``` 
+Schema:table('users', function (Blueprint $table) {
+    $table->comment('用戶表');
+});
+```

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -80,7 +80,7 @@ class Blueprint
      *
      * @var string
      */
-    protected $tableComment;
+    protected $tableComment = '';
 
     /**
      * Create a new schema blueprint.

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -1101,9 +1101,9 @@ class Blueprint
     /**
      * Add this Table comment.
      *
-     * @param $tableName
+     * @param string $tableName
      */
-    public function comment($tableName)
+    public function comment(string $tableName)
     {
         $this->tableComment = $tableName;
     }
@@ -1194,11 +1194,11 @@ class Blueprint
     }
 
     /**
-     *  Get the table comment.
+     * Get the table comment.
      *
      * @return string
      */
-    public function getTableComment()
+    public function getTableComment() : string
     {
         return $this->tableComment;
     }

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -1101,7 +1101,6 @@ class Blueprint
     /**
      * Add this Table comment.
      *
-     * @param $tableName
      */
     public function comment(string $tableName)
     {

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -1101,7 +1101,7 @@ class Blueprint
     /**
      * Add this Table comment.
      *
-     * @param string $tableName
+     * @param $tableName
      */
     public function comment(string $tableName)
     {

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -76,6 +76,13 @@ class Blueprint
     protected $commands = [];
 
     /**
+     * The comment of the table.
+     *
+     * @var string
+     */
+    protected $tableComment;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param string $table
@@ -1092,6 +1099,16 @@ class Blueprint
     }
 
     /**
+     * Add this Table comment.
+     *
+     * @param $tableName
+     */
+    public function comment($tableName)
+    {
+        $this->tableComment = $tableName;
+    }
+
+    /**
      * Add a new column to the blueprint.
      *
      * @param string $type
@@ -1174,6 +1191,16 @@ class Blueprint
         return array_filter($this->columns, function ($column) {
             return (bool) $column->change;
         });
+    }
+
+    /**
+     *  Get the table comment.
+     *
+     * @return string
+     */
+    public function getTableComment()
+    {
+        return $this->tableComment;
     }
 
     /**

--- a/src/database/src/Schema/Grammars/MySqlGrammar.php
+++ b/src/database/src/Schema/Grammars/MySqlGrammar.php
@@ -478,7 +478,6 @@ class MySqlGrammar extends Grammar
      * Compile this table comment
      *
      * @param string $sql
-     * @param Connection $connection
      * @param Blueprint $blueprint
      * @return string
      */

--- a/src/database/src/Schema/Grammars/MySqlGrammar.php
+++ b/src/database/src/Schema/Grammars/MySqlGrammar.php
@@ -73,6 +73,12 @@ class MySqlGrammar extends Grammar
             $connection
         );
 
+        // Here's the new process, we comment the table.
+        $sql = $this->compileCreateComment(
+            $sql,
+            $blueprint
+        );
+
         // Once we have the primary SQL, we can add the encoding option to the SQL for
         // the table.  Then, we can check if a storage engine has been supplied for
         // the table. If so, we will add the engine declaration to the SQL query.
@@ -465,6 +471,22 @@ class MySqlGrammar extends Grammar
             return $sql . ' engine = ' . $engine;
         }
 
+        return $sql;
+    }
+
+    /**
+     * Compile this table comment
+     *
+     * @param string $sql
+     * @param Connection $connection
+     * @param Blueprint $blueprint
+     * @return string
+     */
+    private function compileCreateComment(string $sql, Blueprint $blueprint)
+    {
+        if (! is_null($blueprint->getTableComment())) {
+            $sql .= "comment = '" . $blueprint->getTableComment() . "'";
+        }
         return $sql;
     }
 

--- a/src/database/tests/DatabaseMigratorIntegrationTest.php
+++ b/src/database/tests/DatabaseMigratorIntegrationTest.php
@@ -171,4 +171,15 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertFalse($schema->hasTable('password_resets'));
         $this->assertFalse($schema->hasTable('flights'));
     }
+
+    public function testMigrationsTableCommentIsExist()
+    {
+        $schema = new Schema();
+        $this->migrator->run([__DIR__ . '/migrations/three']);
+        $this->assertTrue($schema->hasTable('comment'));
+        $this->assertTrue($schema->hasTable('not_comment'));
+        $this->migrator->rollback([__DIR__ . '/migrations/three']);
+        $this->assertFalse($schema->hasTable('comment'));
+        $this->assertFalse($schema->hasTable('not_comment'));
+    }
 }

--- a/src/database/tests/migrations/three/2016_01_01_300000_create_comment_table.php
+++ b/src/database/tests/migrations/three/2016_01_01_300000_create_comment_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+use Hyperf\Database\Migrations\Migration;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Schema\Schema;
+
+class CreateCommentTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('comment', function (Blueprint $table) {
+            $table->increments('id');
+            $table->comment('table comment');
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comment');
+    }
+}

--- a/src/database/tests/migrations/three/2016_01_01_400000_create_not_comment_table.php
+++ b/src/database/tests/migrations/three/2016_01_01_400000_create_not_comment_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+use Hyperf\Database\Migrations\Migration;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Schema\Schema;
+
+class CreateNotCommentTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('not_comment', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('not_comment');
+    }
+}


### PR DESCRIPTION
Fixes #1015

单元测试 `composer test -- --filter=testMigrationsTableCommentIsExist`

在单元测试里增加对建表语句是否包含 comment 会造成较多的修改，且可能会存在一些大修改产生的隐患。

所以在单元测试里，就针对 migration 存在 comment 和不存在 comment 进行运行验证，保证运行 run 和 rollback 成功。

![image](https://user-images.githubusercontent.com/7987563/86218953-13dd5080-bbb4-11ea-851f-047e64209fed.png)

有 comment 输出的 SQL
```
CREATE TABLE `comment` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='table comment';
```

没有 comment 输出的 SQL
```
CREATE TABLE `not_comment` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
```