### PR TITLE
rpc多协议共存修改

### DIFF
--- a/src/rpc-server/src/Annotation/RpcService.php
+++ b/src/rpc-server/src/Annotation/RpcService.php
@@ -15,7 +15,7 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
 
 /**
  * @Annotation
- * @Target({"CLASS"})
+ * @Target({"CLASS", "ANNOTATION"})
  */
 class RpcService extends AbstractAnnotation
 {

--- a/src/rpc-server/src/Annotation/RpcServices.php
+++ b/src/rpc-server/src/Annotation/RpcServices.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\RpcServer\Annotation;
+
+use Hyperf\Di\Annotation\AbstractAnnotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+class RpcServices extends AbstractAnnotation
+{
+    public $services = [];
+
+    public function __construct($value = null)
+    {
+        parent::__construct($value);
+        $this->bindMainProperty('services', $value);
+    }
+}

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -52,6 +52,11 @@ class DispatcherFactory
      */
     private $pathGenerator;
 
+    /**
+     * @var array
+     */
+    protected $routeAnnotations = [RpcService::class];
+
     public function __construct(EventDispatcherInterface $eventDispatcher, PathGeneratorInterface $pathGenerator)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -93,15 +98,17 @@ class DispatcherFactory
 
     protected function initAnnotationRoute(): void
     {
-        $rpcAnnotation = AnnotationCollector::getClassByAnnotation(RpcService::class);
-        foreach ($rpcAnnotation as $className => $annotation) {
-            $middlewaresAnnotation = AnnotationCollector::getClassAnnotation($className, Middlewares::class) ?? [];
-            $middlewareAnnotation = AnnotationCollector::getClassAnnotation($className, Middleware::class) ?? [];
-            $middlewares = $this->handleMiddleware([
-                Middlewares::class => $middlewaresAnnotation,
-                Middleware::class => $middlewareAnnotation,
-            ]);
-            $this->handleRpcService($className, $annotation, $middlewares);
+        foreach ($this->routeAnnotations as $routeAnnotation) {
+            $rpcAnnotation = AnnotationCollector::getClassByAnnotation($routeAnnotation);
+            foreach ($rpcAnnotation as $className => $annotation) {
+                $middlewaresAnnotation = AnnotationCollector::getClassAnnotation($className, Middlewares::class) ?? [];
+                $middlewareAnnotation = AnnotationCollector::getClassAnnotation($className, Middleware::class) ?? [];
+                $middlewares = $this->handleMiddleware([
+                    Middlewares::class => $middlewaresAnnotation,
+                    Middleware::class => $middlewareAnnotation,
+                ]);
+                $this->handleRpcService($className, $annotation, $middlewares);
+            }
         }
     }
 


### PR DESCRIPTION
1. 优化代码可读性；
2. 私有方法提升到protected级别， 方便子类继承修改；
3. 新增@RpcServices注解， 使服务可以支持多协议