### PR TITLE
关于命令行生成后，不生效的问题

### DIFF
--- a/docs/zh-cn/command.md
+++ b/docs/zh-cn/command.md
@@ -159,8 +159,8 @@ class FooCommand extends HyperfCommand
     }
 }
 ``` 
-
-执行 `php bin/hyperf.php foo:hello Hyperf` 我们就能看到输出了 `Hello Hyperf` 了。
+先执行 `composer dumpautoload` 更新下自动加载，使用命令行生效
+再执行 `php bin/hyperf.php foo:hello Hyperf` 我们就能看到输出了 `Hello Hyperf` 了。
 
 
 ## 命令常用配置介绍


### PR DESCRIPTION
通过`hyperf/devtool`命令行生成后的命令，由于composer没有进行自动加载该命令而出现该命令行找不到的情况