### PR TITLE
Fixed type error for command `vendor:publish`.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - [#2067](https://github.com/hyperf/hyperf/pull/2067) Fixed bug that syntax parse error will cause worker exceptions for `hyperf/watcher`.
 - [#2085](https://github.com/hyperf/hyperf/pull/2085) Fixed bug in RetryFalsy Annotation that leads to retrying truthy results.
 - [#2089](https://github.com/hyperf/hyperf/pull/2089) Fixed class of command won't be loaded after `gen:command`.
+- [#2093](https://github.com/hyperf/hyperf/pull/2093) Fixed type error for command `vendor:publish`.
 
 ## Added
 

--- a/src/devtool/src/VendorPublishCommand.php
+++ b/src/devtool/src/VendorPublishCommand.php
@@ -89,7 +89,8 @@ class VendorPublishCommand extends SymfonyCommand
             }));
 
             if (empty($item)) {
-                return $output->writeln(sprintf('<fg=red>No file can be published from [%s].</>', $id));
+                $output->writeln(sprintf('<fg=red>No file can be published from [%s].</>', $id));
+                return SIGTERM;
             }
 
             return $this->copy($package, $item);

--- a/src/devtool/src/VendorPublishCommand.php
+++ b/src/devtool/src/VendorPublishCommand.php
@@ -59,7 +59,8 @@ class VendorPublishCommand extends SymfonyCommand
 
         $extra = Composer::getMergedExtra()[$package] ?? null;
         if (empty($extra)) {
-            return $output->writeln(sprintf('<fg=red>package [%s] misses `extra` field in composer.json.</>', $package));
+            $output->writeln(sprintf('<fg=red>package [%s] misses `extra` field in composer.json.</>', $package));
+            return SIGTERM;
         }
 
         $provider = Arr::get($extra, 'hyperf.config');
@@ -67,7 +68,8 @@ class VendorPublishCommand extends SymfonyCommand
 
         $publish = Arr::get($config, 'publish');
         if (empty($publish)) {
-            return $output->writeln(sprintf('<fg=red>No file can be published from package [%s].</>', $package));
+            $output->writeln(sprintf('<fg=red>No file can be published from package [%s].</>', $package));
+            return SIGTERM;
         }
 
         if ($show) {

--- a/src/retry/tests/RetryFalsyTest.php
+++ b/src/retry/tests/RetryFalsyTest.php
@@ -1,12 +1,23 @@
 <?php
 
-
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://doc.hyperf.io
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
 namespace HyperfTest\Retry;
-
 
 use Hyperf\Retry\Annotation\RetryFalsy;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @coversNothing
+ */
 class RetryFalsyTest extends TestCase
 {
     public function testIsFalsy()
@@ -20,5 +31,4 @@ class RetryFalsyTest extends TestCase
         $this->assertFalse(RetryFalsy::isFalsy(true));
         $this->assertFalse(RetryFalsy::isFalsy(1));
     }
-
 }


### PR DESCRIPTION
Return value of "Hyperf\Devtool\VendorPublishCommand::execute()" must be of the type int, "null" returned.
