### PR TITLE
add ShellDriver to watch files

### DIFF
--- a/src/watcher/src/Driver/ShellDriver.php
+++ b/src/watcher/src/Driver/ShellDriver.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Watcher\Driver;
+
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Di\Annotation\Inject;
+use Hyperf\Utils\Str;
+use Hyperf\Watcher\Option;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\System;
+use Swoole\Timer;
+
+class ShellDriver implements DriverInterface
+{
+    /**
+     * @var Option
+     */
+    protected $option;
+
+    /**
+     * @Inject
+     * @var StdoutLoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Option $option)
+    {
+        $this->option = $option;
+    }
+
+    public function watch(Channel $channel): void
+    {
+        $ms = $this->option->getScanInterval() > 0 ? $this->option->getScanInterval() : 2000;
+        Timer::tick($ms, function () use ($channel, $ms) {
+            global $updateFiles;
+            if (is_null($updateFiles)) $updateFiles = [];
+
+            $ret = $this->shellWatch($updateFiles, $ms);
+            $updateFiles = $ret['update_files'];
+
+            foreach ($ret['push_files'] as $file) {
+                $channel->push($file);
+            }
+        });
+    }
+
+    protected function shellWatch($updateFiles, $ms): array
+    {
+        $pushFiles = [];
+        $dirs = $this->option->getWatchDir();
+        $files = $this->option->getWatchFile();
+        $ext = $this->option->getExt();
+
+        $dirs = array_map(function ($dir) {
+            return BASE_PATH . '/' . $dir;
+        }, $dirs);
+        $seconds = ceil(($ms + 1000) / 1000);
+
+        $minutes = sprintf("%.2f", $seconds / 60);
+        // scan directory files
+        $dest = implode(' ', $dirs);
+        $ret = System::exec('find ' . $dest . ' -mmin ' . $minutes . ' -type f -printf "%p %T+' . PHP_EOL . '"');
+        if ($ret['code'] === 0 && strlen($ret['output'])) {
+            $stdout = $ret['output'];
+
+            $lineArr = explode(PHP_EOL, $stdout);
+            foreach ($lineArr as $line) {
+                $fileArr = explode(' ', $line);
+                if (count($fileArr) == 2) {
+                    $pathName = $fileArr[0];
+                    $modifyTime = $fileArr[1];
+
+                    if (Str::endsWith($pathName, $ext)) {
+                        if (isset($updateFiles[$pathName]) && $updateFiles[$pathName] == $modifyTime) {
+                            continue;
+                        } else {
+                            $updateFiles[$pathName] = $modifyTime;
+                            $pushFiles[] = $pathName;
+                        }
+                    }
+                }
+            }
+        }
+        // scan specify files
+        $files = array_map(function ($file) {
+            return BASE_PATH . '/' . $file;
+        }, $files);
+        $dest = implode(' ', $files);
+        $ret = System::exec('find ' . $dest . ' -mmin ' . $minutes . ' -type f -printf "%p %T+' . PHP_EOL . '"');
+        if ($ret['code'] === 0 && strlen($ret['output'])) {
+            $stdout = $ret['output'];
+
+            $lineArr = explode(PHP_EOL, $stdout);
+            foreach ($lineArr as $line) {
+                $fileArr = explode(' ', $line);
+                if (count($fileArr) == 2) {
+                    $pathName = $fileArr[0];
+                    $modifyTime = $fileArr[1];
+
+                    if (isset($updateFiles[$pathName]) && $updateFiles[$pathName] == $modifyTime) {
+                        continue;
+                    } else {
+                        $updateFiles[$pathName] = $modifyTime;
+                        $pushFiles[] = $pathName;
+                    }
+                }
+            }
+        }
+
+        return [
+            'update_files' => $updateFiles,
+            'push_files' => $pushFiles,
+        ];
+    }
+}

--- a/src/watcher/tests/ShellDriverTest.php
+++ b/src/watcher/tests/ShellDriverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Watcher;
+
+use Hyperf\Config\Config;
+use Hyperf\Watcher\Driver\ShellDriver;
+use Hyperf\Watcher\Option;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ShellDriverTest extends TestCase
+{
+    public function testSpeed()
+    {
+        $config = new Config([
+            'watcher' => [
+                'driver' => ShellDriver::class,
+                'watch' => [
+                    'dir' => ['test', 'vendor'],
+                    'scan_interval' => 2000,
+                ],
+            ]
+        ]);
+
+        $option = new Option($config, [], []);
+        $this->assertSame(ShellDriver::class, $option->getDriver());
+
+        if ($option->getDriver() == ShellDriver::class) {
+            $driver = new ShellDriver($option);
+            $updateFiles = [];
+            // circle 100 times
+            $times = 100;
+
+            $filesystem = new \Hyperf\Utils\Filesystem\Filesystem();
+
+
+            $method = new \ReflectionMethod(ShellDriver::class, 'shellWatch');
+            $method->setAccessible(true);
+
+            while ($times--) {
+                $filesystem->append(BASE_PATH . '/test/watch01.php', 'watch01');
+                $filesystem->append(BASE_PATH . '/test/watch02.php', 'watch02');
+
+                $sTime = microtime(true);
+
+                $out = $method->invokeArgs($driver, [$updateFiles, $option->getScanInterval()]);
+
+                $execTime = microtime(true) - $sTime;
+
+                $this->assertLessThan(1, $execTime, 'more than 1 second');
+                $this->assertSame(2, count($out['update_files']));
+            }
+        }
+    }
+}

--- a/src/watcher/tests/ShellDriverTest.php
+++ b/src/watcher/tests/ShellDriverTest.php
@@ -16,6 +16,7 @@ use Hyperf\Config\Config;
 use Hyperf\Watcher\Driver\ShellDriver;
 use Hyperf\Watcher\Option;
 use PHPUnit\Framework\TestCase;
+use Hyperf\Utils\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -39,20 +40,23 @@ class ShellDriverTest extends TestCase
         $this->assertSame(ShellDriver::class, $option->getDriver());
 
         if ($option->getDriver() == ShellDriver::class) {
-            $driver = new ShellDriver($option);
-            $updateFiles = [];
-            // circle 100 times
-            $times = 100;
 
-            $filesystem = new \Hyperf\Utils\Filesystem\Filesystem();
 
+            $filesystem = new Filesystem();
+            $testDir = BASE_PATH . '/test';
+            $this->assertDirectoryExists($testDir);
 
             $method = new \ReflectionMethod(ShellDriver::class, 'shellWatch');
             $method->setAccessible(true);
 
+            $driver = new ShellDriver($option);
+            $updateFiles = [];
+            // circle 100 times
+            $times = 100;
             while ($times--) {
-                $filesystem->append(BASE_PATH . '/test/watch01.php', 'watch01');
-                $filesystem->append(BASE_PATH . '/test/watch02.php', 'watch02');
+
+                $filesystem->append($testDir . '/watch01.php', 'watch01');
+                $filesystem->append($testDir . '/watch02.php', 'watch02');
 
                 $sTime = microtime(true);
 


### PR DESCRIPTION
hyperf热更新watcher新增shell driver，它可以提高热更新的性能，本地环境测试后发现扫描vendor目录下的所有文件，提高100倍左右性能。并且增加ShellDriverTest单元测试。