### PR TITLE
完善FindDriver热更新

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # v2.0.5 - TBD
 
+## Optimized
+
+- [#2193](https://github.com/hyperf/hyperf/pull/2193) Optimized the scan accuracy for `Hyperf\Watcher\Driver\FindDriver`.
+
 # v2.0.4 - 2020-07-27
 
 ## Added

--- a/src/watcher/src/Driver/FindDriver.php
+++ b/src/watcher/src/Driver/FindDriver.php
@@ -56,7 +56,7 @@ class FindDriver implements DriverInterface
             }
 
             $seconds = ceil(($ms + 1000) / 1000);
-            $minutes = sprintf('%.2f', $seconds / 60);
+            $minutes = sprintf('-%.2f', $seconds / 60);
 
             [$fileModifyTimes, $changedFiles] = $this->scan($fileModifyTimes, $minutes);
 
@@ -70,6 +70,10 @@ class FindDriver implements DriverInterface
     {
         $changedFiles = [];
         $dest = implode(' ', $targets);
+        /**
+         * In linux system, you can use command below
+         * find app -mmin -0.05 -type f -printf "%p %T+\n"
+         */
         $ret = System::exec($this->getBin() . ' ' . $dest . ' -mmin ' . $minutes . ' -type f -printf "%p %T+' . PHP_EOL . '"');
         if ($ret['code'] === 0 && strlen($ret['output'])) {
             $stdout = $ret['output'];


### PR DESCRIPTION
之前热更新执行命令是find app -mmin 2 -type f -printf "%p %T+\n"，它的意思是，从第2分钟前到第1分钟前，这一分钟内扫描出哪些文件更新过。find app -mmin -2 -type f -printf "%p %T+\n"，它的意思是指，从第2分钟前到现在，这两分钟扫描出哪些文件更新过。所以加负号，更为准确。