### PR TITLE
Fixed context won't be destroyed when accept keepalive connection for co server.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - [#2210](https://github.com/hyperf/hyperf/pull/2210) Fixed bug that open event won't be executed after handshake right now.
 - [#2214](https://github.com/hyperf/hyperf/pull/2214) Fixed bug that close event won't be executed when close the connection by websocket server.
 - [#2218](https://github.com/hyperf/hyperf/pull/2218) Fixed bug that sender does not works for coroutine server.
+- [#2227](https://github.com/hyperf/hyperf/pull/2227) Fixed context won't be destroyed when accept keepalive connection for co server.
 
 ## Optimized
 

--- a/src/server/src/CoroutineServer.php
+++ b/src/server/src/CoroutineServer.php
@@ -145,7 +145,11 @@ class CoroutineServer implements ServerInterface
                         $handler->initCoreMiddleware($name);
                     }
                     if ($this->server instanceof \Swoole\Coroutine\Http\Server) {
-                        $this->server->handle('/', [$handler, $method]);
+                        $this->server->handle('/', function ($request, $response) use ($handler, $method) {
+                            Coroutine::create(static function () use ($request, $response, $handler, $method) {
+                                $handler->{$method}($request, $response);
+                            });
+                        });
                     }
                 }
                 return;

--- a/src/server/src/CoroutineServer.php
+++ b/src/server/src/CoroutineServer.php
@@ -145,7 +145,7 @@ class CoroutineServer implements ServerInterface
                         $handler->initCoreMiddleware($name);
                     }
                     if ($this->server instanceof \Swoole\Coroutine\Http\Server) {
-                        $this->server->handle('/', function ($request, $response) use ($handler, $method) {
+                        $this->server->handle('/', static function ($request, $response) use ($handler, $method) {
                             Coroutine::create(static function () use ($request, $response, $handler, $method) {
                                 $handler->{$method}($request, $response);
                             });


### PR DESCRIPTION
修复以下 case

```
$client = new Client('127.0.0.1', 9501);
$client->get('/?user=limx');
$this->assertSame('limx', Json::decode($client->getBody())['data']['user']);

$client->get('/?user=Agnes');
$this->assertSame('Agnes', Json::decode($client->getBody())['data']['user']);
```

swoole的协程server，当http 客户端支持 keepalive 的时候，会循环 accepct，导致 协程不会重新创建。【这是个 feature】

所以 handler 这里，需要自己开启 协程