### PR TITLE
修复调用表单验证类后，错误消息中文显示乱码问题

### DIFF
--- a/src/validation/src/ValidationExceptionHandler.php
+++ b/src/validation/src/ValidationExceptionHandler.php
@@ -23,7 +23,7 @@ class ValidationExceptionHandler extends ExceptionHandler
         $this->stopPropagation();
         /** @var \Hyperf\Validation\ValidationException $throwable */
         $body = $throwable->validator->errors()->first();
-        return $response->withStatus($throwable->status)->withBody(new SwooleStream($body));
+        return $response->withStatus($throwable->status)->withBody(new SwooleStream($body))->withHeader("Content-Type","text/html; charset=utf-8");
     }
 
     public function isValid(Throwable $throwable): bool


### PR DESCRIPTION
创建一个自定义表单验证类后，当自定义 messages() 存在中文，或者 validation.php 中的中文提示，在输出错误信息时会产生乱码。
通过输出错误信息语句中指定编码后，此问题得以修复。