### PR TITLE
Feature/nacos optz

### DIFF
--- a/docs/zh-cn/nacos.md
+++ b/docs/zh-cn/nacos.md
@@ -42,6 +42,8 @@ return [
     // 配置中心
     'config' => [
         'enable' => true, // 是否启用配置中心
+        // 是否使用独立进程来拉取config，如果否则将在worker内以协程方式拉取
+        'use_standalone_process' => true,
         'reload_interval' => 3, //配置刷新周期
         'listener_config' => [
             [

--- a/src/nacos/publish/nacos.php
+++ b/src/nacos/publish/nacos.php
@@ -13,39 +13,38 @@ return [
     // The nacos host info
     'host' => '127.0.0.1',
     'port' => 8848,
-    // The service info.
+
     'service' => [
-        'service_name' => 'hyperf',
-        'group_name' => 'api',
+        'enable' => true,
         'namespace_id' => 'namespace_id',
-        'protect_threshold' => 0.5,
-    ],
-    // The client info.
-    'client' => [
-        'service_name' => 'hyperf',
         'group_name' => 'api',
-        'weight' => 80,
+        'service_name' => 'hyperf',
+        'protect_threshold' => 0.5,
         'cluster' => 'DEFAULT',
+        'weight' => 80,
         'ephemeral' => true,
         'beat_enable' => true,
         'beat_interval' => 5,
-        'namespace_id' => 'namespace_id', // It must be equal with service.namespaceId.
+        'remove_node_when_server_shutdown' => true,
+        'load_balancer' => 'random',
     ],
-    'remove_node_when_server_shutdown' => true,
-    'config_reload_interval' => 3,
-    'config_append_node' => 'nacos_config',
-    'listener_config' => [
-        // dataId, group, tenant, type, content
-        //[
-        //    'tenant' => 'tenant', // corresponding with service.namespaceId
-        //    'data_id' => 'hyperf-service-config',
-        //    'group' => 'DEFAULT_GROUP',
-        //],
-        //[
-        //    'data_id' => 'hyperf-service-config-yml',
-        //    'group' => 'DEFAULT_GROUP',
-        //    'type' => 'yml',
-        //],
-    ],
-    'load_balancer' => 'random',
+
+    'config' => [
+        'enable' => true,
+        'reload_interval' => 3,
+        'listener_config' => [
+            [
+                'tenant' => 'namespace_id',
+                'group' => 'DEFAULT_GROUP',
+                'data_id' => 'hyperf-service-config',
+                'mapping_path' => 'xxx.yyy',
+            ],
+            [
+                'tenant' => 'namespace_id',
+                'group' => 'DEFAULT_GROUP',
+                'data_id' => 'hyperf-service-config-yml',
+                'type' => 'yml',
+            ]
+        ]
+    ]
 ];

--- a/src/nacos/publish/nacos.php
+++ b/src/nacos/publish/nacos.php
@@ -45,7 +45,7 @@ return [
                 'group' => 'DEFAULT_GROUP',
                 'data_id' => 'hyperf-service-config-yml',
                 'type' => 'yml',
-            ]
-        ]
-    ]
+            ],
+        ],
+    ],
 ];

--- a/src/nacos/publish/nacos.php
+++ b/src/nacos/publish/nacos.php
@@ -31,6 +31,7 @@ return [
 
     'config' => [
         'enable' => true,
+        'use_standalone_process' => true,
         'reload_interval' => 3,
         'listener_config' => [
             [

--- a/src/nacos/src/Api/AbstractNacos.php
+++ b/src/nacos/src/Api/AbstractNacos.php
@@ -16,6 +16,7 @@ use GuzzleHttp\RequestOptions;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\ContainerInterface;
 use Hyperf\Guzzle\ClientFactory;
+use Hyperf\Nacos\Contract\LoggerInterface;
 
 abstract class AbstractNacos
 {
@@ -33,11 +34,19 @@ abstract class AbstractNacos
     {
         $this->container = $container;
         $this->config = $container->get(ConfigInterface::class);
+        $this->logger = $container->get(LoggerInterface::class);
     }
 
     public function request($method, $uri, array $options = [])
     {
-        return $this->client()->request($method, $uri, $options);
+        try {
+            return $this->client()->request($method, $uri, $options);
+        } catch (\Throwable $throwable) {
+            $message = printf("request nacos server error: %s", $throwable->getMessage());
+            $this->logger->error($message);
+            return null;
+        }
+
     }
 
     public function getServerUri(): string

--- a/src/nacos/src/Api/AbstractNacos.php
+++ b/src/nacos/src/Api/AbstractNacos.php
@@ -42,11 +42,10 @@ abstract class AbstractNacos
         try {
             return $this->client()->request($method, $uri, $options);
         } catch (\Throwable $throwable) {
-            $message = printf("request nacos server error: %s", $throwable->getMessage());
+            $message = printf('request nacos server error: %s', $throwable->getMessage());
             $this->logger->error($message);
             return null;
         }
-
     }
 
     public function getServerUri(): string

--- a/src/nacos/src/Api/NacosConfig.php
+++ b/src/nacos/src/Api/NacosConfig.php
@@ -14,6 +14,7 @@ namespace Hyperf\Nacos\Api;
 use GuzzleHttp\RequestOptions;
 use Hyperf\Nacos\Model\ConfigModel;
 use Hyperf\Utils\Codec\Json;
+use Psr\Http\Message\ResponseInterface;
 
 class NacosConfig extends AbstractNacos
 {
@@ -22,6 +23,10 @@ class NacosConfig extends AbstractNacos
         $response = $this->request('GET', '/nacos/v1/cs/configs', [
             RequestOptions::QUERY => $configModel->toArray(),
         ]);
+        
+        if (!$response instanceof ResponseInterface) {
+            return [];
+        }
 
         return $configModel->parse($response->getBody()->getContents());
     }

--- a/src/nacos/src/Api/NacosConfig.php
+++ b/src/nacos/src/Api/NacosConfig.php
@@ -23,8 +23,8 @@ class NacosConfig extends AbstractNacos
         $response = $this->request('GET', '/nacos/v1/cs/configs', [
             RequestOptions::QUERY => $configModel->toArray(),
         ]);
-        
-        if (!$response instanceof ResponseInterface) {
+
+        if (! $response instanceof ResponseInterface) {
             return [];
         }
 

--- a/src/nacos/src/Api/NacosInstance.php
+++ b/src/nacos/src/Api/NacosInstance.php
@@ -109,9 +109,7 @@ class NacosInstance extends AbstractNacos
             RequestOptions::QUERY => $params,
         ]);
 
-        $rs =  Json::decode($response->getBody()->getContents());
-
-        return $rs;
+        return Json::decode($response->getBody()->getContents());
     }
 
     public function updateHealth(InstanceModel $instanceModel): bool

--- a/src/nacos/src/Api/NacosInstance.php
+++ b/src/nacos/src/Api/NacosInstance.php
@@ -80,7 +80,7 @@ class NacosInstance extends AbstractNacos
             return $item['enabled'];
         });
 
-        $tactics = strtolower($this->config->get('nacos.load_balancer', 'random'));
+        $tactics = strtolower($this->config->get('nacos.service.load_balancer', 'random'));
 
         return $this->loadBalancer($enabled, $tactics);
     }
@@ -109,7 +109,9 @@ class NacosInstance extends AbstractNacos
             RequestOptions::QUERY => $params,
         ]);
 
-        return Json::decode($response->getBody()->getContents());
+        $rs =  Json::decode($response->getBody()->getContents());
+
+        return $rs;
     }
 
     public function updateHealth(InstanceModel $instanceModel): bool

--- a/src/nacos/src/Api/NacosService.php
+++ b/src/nacos/src/Api/NacosService.php
@@ -14,6 +14,7 @@ namespace Hyperf\Nacos\Api;
 use GuzzleHttp\RequestOptions;
 use Hyperf\Nacos\Model\ServiceModel;
 use Hyperf\Utils\Codec\Json;
+use Psr\Http\Message\ResponseInterface;
 
 class NacosService extends AbstractNacos
 {
@@ -49,6 +50,10 @@ class NacosService extends AbstractNacos
         $response = $this->request('GET', '/nacos/v1/ns/service', [
             RequestOptions::QUERY => $serviceModel->toArray(),
         ]);
+
+        if (!$response instanceof ResponseInterface) {
+            return [];
+        }
 
         return Json::decode($response->getBody()->getContents());
     }

--- a/src/nacos/src/Api/NacosService.php
+++ b/src/nacos/src/Api/NacosService.php
@@ -51,7 +51,7 @@ class NacosService extends AbstractNacos
             RequestOptions::QUERY => $serviceModel->toArray(),
         ]);
 
-        if (!$response instanceof ResponseInterface) {
+        if (! $response instanceof ResponseInterface) {
             return [];
         }
 

--- a/src/nacos/src/Config/Client.php
+++ b/src/nacos/src/Config/Client.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos;
+namespace Hyperf\Nacos\Config;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Api\NacosConfig;
@@ -42,13 +42,14 @@ class Client
 
     public function pull(): array
     {
-        $listener = $this->config->get('nacos.listener_config', []);
+        $listenerConfig = $this->config->get('nacos.config.listener_config', []);
 
         $config = [];
-        foreach ($listener as $item) {
+        foreach ($listenerConfig as $item) {
             $model = new ConfigModel($item);
             if ($content = $this->client->get($model)) {
-                $config = array_merge_recursive($config, $model->parse($content));
+                $configKey = ($item['mapping_path'] ?? '') ?: $item['data_id'];
+                $config[$configKey] = $model->parse($content);
             }
         }
 

--- a/src/nacos/src/Config/Listener/BootProcessListener.php
+++ b/src/nacos/src/Config/Listener/BootProcessListener.php
@@ -11,18 +11,17 @@ declare(strict_types=1);
  */
 namespace Hyperf\Nacos\Config\Listener;
 
+use Hyperf\Command\Event\BeforeHandle;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
-use Hyperf\Framework\Event\MainWorkerStart;
+use Hyperf\Framework\Event\BeforeWorkerStart;
 use Hyperf\Nacos\Config\Client;
+use Hyperf\Process\Event\BeforeProcessHandle;
 use Hyperf\Utils\Coordinator\Constants;
 use Hyperf\Utils\Coordinator\CoordinatorManager;
 use Hyperf\Utils\Coroutine;
 use Psr\Container\ContainerInterface;
-use Hyperf\Command\Event\BeforeHandle;
-use Hyperf\Framework\Event\BeforeWorkerStart;
-use Hyperf\Process\Event\BeforeProcessHandle;
 
 class BootProcessListener implements ListenerInterface
 {

--- a/src/nacos/src/Config/Listener/MainWorkerStartListener.php
+++ b/src/nacos/src/Config/Listener/MainWorkerStartListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Nacos\Config\Listener;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\MainWorkerStart;
+use Hyperf\Nacos\Config\Client;
+use Psr\Container\ContainerInterface;
+use Hyperf\Command\Event\BeforeHandle;
+use Hyperf\Framework\Event\BeforeWorkerStart;
+use Hyperf\Process\Event\BeforeProcessHandle;
+
+class MainWorkerStartListener implements ListenerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var StdoutLoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->logger = $container->get(StdoutLoggerInterface::class);
+        $this->config = $container->get(ConfigInterface::class);
+    }
+
+    public function listen(): array
+    {
+        return [
+            BeforeWorkerStart::class,
+            BeforeProcessHandle::class,
+            BeforeHandle::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        if (! $this->config->get('nacos.config.enable', false)) {
+            return;
+        }
+
+        $client = $this->container->get(Client::class);
+        foreach ($client->pull() as $key => $conf) {
+            $this->config->set($key, $conf);
+        }
+    }
+}

--- a/src/nacos/src/Config/Listener/OnPipeMessageListener.php
+++ b/src/nacos/src/Config/Listener/OnPipeMessageListener.php
@@ -15,9 +15,9 @@ use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\OnPipeMessage;
+use Hyperf\Nacos\Config\PipeMessage;
 use Hyperf\Process\Event\PipeMessage as UserProcessPipMessage;
 use Psr\Container\ContainerInterface;
-use Hyperf\Nacos\Config\PipeMessage;
 
 class OnPipeMessageListener implements ListenerInterface
 {

--- a/src/nacos/src/Config/Listener/OnPipeMessageListener.php
+++ b/src/nacos/src/Config/Listener/OnPipeMessageListener.php
@@ -9,13 +9,15 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos\Config;
+namespace Hyperf\Nacos\Config\Listener;
 
 use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\OnPipeMessage;
 use Hyperf\Process\Event\PipeMessage as UserProcessPipMessage;
 use Psr\Container\ContainerInterface;
+use Hyperf\Nacos\Config\PipeMessage;
 
 class OnPipeMessageListener implements ListenerInterface
 {
@@ -27,6 +29,7 @@ class OnPipeMessageListener implements ListenerInterface
     public function __construct(ContainerInterface $container)
     {
         $this->config = $container->get(ConfigInterface::class);
+        $this->logger = $container->get(StdoutLoggerInterface::class);
     }
 
     /**
@@ -46,10 +49,18 @@ class OnPipeMessageListener implements ListenerInterface
      */
     public function process(object $event)
     {
+        if (! $this->config->get('nacos.config.enable', false)) {
+            return;
+        }
+
         if (property_exists($event, 'data') && $event->data instanceof PipeMessage) {
-            $root = $this->config->get('nacos.config_append_node');
-            foreach ($event->data->configurations ?? [] as $key => $conf) {
-                $this->config->set($root ? $root . '.' . $key : $key, $conf);
+            /** @var PipeMessage $data */
+            $data = $event->data;
+
+            /** @var KV $kv */
+            foreach ($data->configurations ?? [] as $k => $v) {
+                $this->config->set($k, $v);
+                $this->logger->debug(sprintf('Config [%s] is updated', $k));
             }
         }
     }

--- a/src/nacos/src/Config/Process/FetchConfigProcess.php
+++ b/src/nacos/src/Config/Process/FetchConfigProcess.php
@@ -9,14 +9,15 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos\Config;
+namespace Hyperf\Nacos\Config\Process;
 
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Nacos\Client;
+use Hyperf\Nacos\Config\Client;
 use Hyperf\Process\AbstractProcess;
 use Hyperf\Process\ProcessCollector;
 use Swoole\Coroutine\Server as CoServer;
 use Swoole\Server;
+use Hyperf\Nacos\Config\PipeMessage;
 
 class FetchConfigProcess extends AbstractProcess
 {
@@ -61,13 +62,13 @@ class FetchConfigProcess extends AbstractProcess
 
                 $cache = $remoteConfig;
             }
-            sleep((int) $config->get('nacos.config_reload_interval', 3));
+            sleep((int) $config->get('nacos.config.reload_interval', 3));
         }
     }
 
     public function isEnable($server): bool
     {
         $config = $this->container->get(ConfigInterface::class);
-        return $server instanceof Server && (bool) $config->get('nacos.config_reload_interval', false);
+        return $server instanceof Server && (bool) $config->get('nacos.config.enable', false);
     }
 }

--- a/src/nacos/src/Config/Process/FetchConfigProcess.php
+++ b/src/nacos/src/Config/Process/FetchConfigProcess.php
@@ -68,7 +68,10 @@ class FetchConfigProcess extends AbstractProcess
 
     public function isEnable($server): bool
     {
+
         $config = $this->container->get(ConfigInterface::class);
-        return $server instanceof Server && (bool) $config->get('nacos.config.enable', false);
+        return $server instanceof Server
+            && (bool) $config->get('nacos.config.enable', false)
+            && (bool) $config->get('nacos.config.use_standalone_process', true);
     }
 }

--- a/src/nacos/src/Config/Process/FetchConfigProcess.php
+++ b/src/nacos/src/Config/Process/FetchConfigProcess.php
@@ -13,11 +13,11 @@ namespace Hyperf\Nacos\Config\Process;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Config\Client;
+use Hyperf\Nacos\Config\PipeMessage;
 use Hyperf\Process\AbstractProcess;
 use Hyperf\Process\ProcessCollector;
 use Swoole\Coroutine\Server as CoServer;
 use Swoole\Server;
-use Hyperf\Nacos\Config\PipeMessage;
 
 class FetchConfigProcess extends AbstractProcess
 {
@@ -68,7 +68,6 @@ class FetchConfigProcess extends AbstractProcess
 
     public function isEnable($server): bool
     {
-
         $config = $this->container->get(ConfigInterface::class);
         return $server instanceof Server
             && (bool) $config->get('nacos.config.enable', false)

--- a/src/nacos/src/ConfigProvider.php
+++ b/src/nacos/src/ConfigProvider.php
@@ -12,26 +12,23 @@ declare(strict_types=1);
 namespace Hyperf\Nacos;
 
 use Hyperf\Framework\Logger\StdoutLogger;
-use Hyperf\Nacos\Config\FetchConfigProcess;
-use Hyperf\Nacos\Config\OnPipeMessageListener;
 use Hyperf\Nacos\Contract\LoggerInterface;
-use Hyperf\Nacos\Listener\MainWorkerStartListener;
-use Hyperf\Nacos\Listener\OnShutdownListener;
-use Hyperf\Nacos\Process\InstanceBeatProcess;
 
 class ConfigProvider
 {
     public function __invoke(): array
     {
+
         return [
             'listeners' => [
-                MainWorkerStartListener::class,
-                OnShutdownListener::class,
-                OnPipeMessageListener::class,
+                Service\Listener\MainWorkerStartListener::class,
+                Service\Listener\OnShutdownListener::class,
+                Config\Listener\MainWorkerStartListener::class,
+                Config\Listener\OnPipeMessageListener::class,
             ],
             'processes' => [
-                InstanceBeatProcess::class,
-                FetchConfigProcess::class,
+                Service\Process\InstanceBeatProcess::class,
+                Config\Process\FetchConfigProcess::class,
             ],
             'dependencies' => [
                 LoggerInterface::class => StdoutLogger::class,

--- a/src/nacos/src/ConfigProvider.php
+++ b/src/nacos/src/ConfigProvider.php
@@ -23,7 +23,7 @@ class ConfigProvider
             'listeners' => [
                 Service\Listener\MainWorkerStartListener::class,
                 Service\Listener\OnShutdownListener::class,
-                Config\Listener\MainWorkerStartListener::class,
+                Config\Listener\BootProcessListener::class,
                 Config\Listener\OnPipeMessageListener::class,
             ],
             'processes' => [

--- a/src/nacos/src/ConfigProvider.php
+++ b/src/nacos/src/ConfigProvider.php
@@ -18,7 +18,6 @@ class ConfigProvider
 {
     public function __invoke(): array
     {
-
         return [
             'listeners' => [
                 Service\Listener\MainWorkerStartListener::class,

--- a/src/nacos/src/Service/Instance.php
+++ b/src/nacos/src/Service/Instance.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos;
+namespace Hyperf\Nacos\Service;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Exception\InvalidArgumentException;
@@ -20,18 +20,14 @@ class Instance extends InstanceModel
 {
     public function __construct(ConfigInterface $config)
     {
-        $client = $config->get('nacos.client', []);
-        if (! isset($client['service_name'])) {
-            throw new InvalidArgumentException('nacos.client.service_name is required');
+        $serviceConfig = $config->get('nacos.service', []);
+        if (! isset($serviceConfig['service_name'])) {
+            throw new InvalidArgumentException('nacos.service.service_name is required');
         }
 
-        foreach ($client as $key => $val) {
-            $key = Str::camel($key);
-            if (property_exists($this, $key)) {
-                $this->{$key} = $val;
-            }
-        }
+        parent::__construct($serviceConfig);
 
+        $this->ephemeral = $serviceConfig['ephemeral'] ? "true" : "false";
         $this->ip = current(swoole_get_local_ip());
         $this->port = $config->get('server.servers.0.port');
     }

--- a/src/nacos/src/Service/Instance.php
+++ b/src/nacos/src/Service/Instance.php
@@ -14,7 +14,6 @@ namespace Hyperf\Nacos\Service;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Exception\InvalidArgumentException;
 use Hyperf\Nacos\Model\InstanceModel;
-use Hyperf\Utils\Str;
 
 class Instance extends InstanceModel
 {
@@ -27,7 +26,7 @@ class Instance extends InstanceModel
 
         parent::__construct($serviceConfig);
 
-        $this->ephemeral = $serviceConfig['ephemeral'] ? "true" : "false";
+        $this->ephemeral = $serviceConfig['ephemeral'] ? 'true' : 'false';
         $this->ip = current(swoole_get_local_ip());
         $this->port = $config->get('server.servers.0.port');
     }

--- a/src/nacos/src/Service/Listener/MainWorkerStartListener.php
+++ b/src/nacos/src/Service/Listener/MainWorkerStartListener.php
@@ -17,7 +17,6 @@ use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\MainWorkerStart;
 use Hyperf\Nacos\Api\NacosInstance as NacosInstanceApi;
 use Hyperf\Nacos\Api\NacosService as NacosServiceApi;
-use Hyperf\Nacos\Config\Client;
 use Hyperf\Nacos\Exception\RuntimeException;
 use Hyperf\Nacos\Service\Instance;
 use Hyperf\Nacos\Service\Service;

--- a/src/nacos/src/Service/Listener/OnShutdownListener.php
+++ b/src/nacos/src/Service/Listener/OnShutdownListener.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos\Listener;
+namespace Hyperf\Nacos\Service\Listener;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Event\Contract\ListenerInterface;
@@ -17,8 +17,8 @@ use Hyperf\Framework\Event\OnShutdown;
 use Hyperf\Nacos\Api\NacosInstance;
 use Hyperf\Nacos\Api\NacosService;
 use Hyperf\Nacos\Contract\LoggerInterface;
-use Hyperf\Nacos\Instance;
-use Hyperf\Nacos\Service;
+use Hyperf\Nacos\Service\Instance;
+use Hyperf\Nacos\Service\Service;
 use Psr\Container\ContainerInterface;
 
 class OnShutdownListener implements ListenerInterface
@@ -43,21 +43,11 @@ class OnShutdownListener implements ListenerInterface
     public function process(object $event)
     {
         $config = $this->container->get(ConfigInterface::class);
-        if (! $config->get('nacos.remove_node_when_server_shutdown', false)) {
+        if (! $config->get('nacos.service.remove_node_when_server_shutdown', false)) {
             return;
         }
 
         $logger = $this->container->get(LoggerInterface::class);
-        /** @var NacosService $nacosService */
-        $nacosService = $this->container->get(NacosService::class);
-        $service = $this->container->get(Service::class);
-        $deleted = $nacosService->delete($service);
-
-        if ($deleted) {
-            $logger && $logger->info('nacos service delete success.');
-        } else {
-            $logger && $logger->erro('nacos service delete fail when shutdown.');
-        }
 
         $instance = $this->container->get(Instance::class);
         /** @var NacosInstance $nacosInstance */

--- a/src/nacos/src/Service/Listener/OnShutdownListener.php
+++ b/src/nacos/src/Service/Listener/OnShutdownListener.php
@@ -15,10 +15,8 @@ use Hyperf\Contract\ConfigInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\OnShutdown;
 use Hyperf\Nacos\Api\NacosInstance;
-use Hyperf\Nacos\Api\NacosService;
 use Hyperf\Nacos\Contract\LoggerInterface;
 use Hyperf\Nacos\Service\Instance;
-use Hyperf\Nacos\Service\Service;
 use Psr\Container\ContainerInterface;
 
 class OnShutdownListener implements ListenerInterface

--- a/src/nacos/src/Service/Process/InstanceBeatProcess.php
+++ b/src/nacos/src/Service/Process/InstanceBeatProcess.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos\Process;
+namespace Hyperf\Nacos\Service\Process;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Api\NacosInstance;
 use Hyperf\Nacos\Contract\LoggerInterface;
-use Hyperf\Nacos\Instance;
-use Hyperf\Nacos\Service;
+use Hyperf\Nacos\Service\Instance;
+use Hyperf\Nacos\Service\Service;
 use Hyperf\Process\AbstractProcess;
 
 class InstanceBeatProcess extends AbstractProcess
@@ -34,7 +34,7 @@ class InstanceBeatProcess extends AbstractProcess
         $config = $this->container->get(ConfigInterface::class);
         $logger = $this->container->get(LoggerInterface::class);
         while (true) {
-            sleep($config->get('nacos.client.beat_interval', 5));
+            sleep($config->get('nacos.service.beat_interval', 5));
             $send = $nacosInstance->beat($service, $instance);
             if ($send) {
                 $logger && $logger->info('nacos send beat success!', compact('instance'));
@@ -47,6 +47,6 @@ class InstanceBeatProcess extends AbstractProcess
     public function isEnable($server): bool
     {
         $config = $this->container->get(ConfigInterface::class);
-        return $config->get('nacos.client.beat_enable', false);
+        return $config->get('nacos.service.enable', false) && $config->get('nacos.service.beat_enable', false);
     }
 }

--- a/src/nacos/src/Service/Service.php
+++ b/src/nacos/src/Service/Service.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\Nacos;
+namespace Hyperf\Nacos\Service;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Nacos\Model\ServiceModel;
@@ -18,7 +18,7 @@ class Service extends ServiceModel
 {
     public function __construct(ConfigInterface $config)
     {
-        $config = $config->get('nacos.service', []);
-        parent::__construct($config);
+        $serviceConfig = $config->get('nacos.service', []);
+        parent::__construct($serviceConfig);
     }
 }


### PR DESCRIPTION
打算用nacos配置中心替换项目中使用的etcd配置中心，但是在接入的过程中发现了如下问题，所以做了些调整：

- 使用配置中心时服务注册相关的逻辑必定执行，没法单独使用配置中心。
- 配置中心支持多配置，但是多配置中相同的key会互相覆盖。
- 不支持以协程的方式拉取配置。
- nacos server api接口404或500时，hyperf进程会崩溃，如有人删除了使用中配置或者要注册服务不存在（这个有待商榷，我倾向于服务稳定）。

**由于配置文件格式改动较大，如果这个合并被接受，那么会影响已经使用了这个组件的用户。**

本来还打算结合`hyperf/service-governance`组件，以nacos作为注册中心，但发现service-governance与consul耦合在了一起，不好改，先放弃。