### PR TITLE
feat: detect circular dependencies

### DIFF
--- a/src/di/src/Exception/CircularDependencyException.php
+++ b/src/di/src/Exception/CircularDependencyException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Di\Exception;
+
+class CircularDependencyException extends \RuntimeException
+{
+    protected $list = [];
+
+    protected $sealed = false;
+
+    public function addDefinitionName(string $name)
+    {
+        if ($this->sealed) {
+            return;
+        }
+
+        if (count($this->list) > 1 && in_array($name, $this->list)) {
+            $this->sealed = true;
+        }
+
+        $this->updateMessage($name);
+    }
+
+    private function updateMessage(string $name)
+    {
+        array_unshift($this->list, $name);
+        $listAsString = implode('->', $this->list);
+        $this->message = "dependency depth limit reached due to the following dependencies: {$listAsString}";
+    }
+}

--- a/src/di/src/Resolver/DepthGuard.php
+++ b/src/di/src/Resolver/DepthGuard.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Di\Resolver;
+
+use Hyperf\Di\Exception\CircularDependencyException;
+use Hyperf\Utils\Context;
+
+/**
+ * Class DepthGuard aborts the resolver after
+ * reaching a predefined depth limit. This is
+ * useful to detect circular dependencies.
+ */
+class DepthGuard
+{
+    /**
+     * @var int
+     */
+    protected $depthLimit = 500;
+
+    /**
+     * @var DepthGuard
+     */
+    private static $instance;
+
+    public static function getInstance()
+    {
+        if (! self::$instance) {
+            self::$instance = new static();
+        }
+        return self::$instance;
+    }
+
+    public function increment()
+    {
+        Context::override('di.depth', function ($depth) {
+            $depth = $depth ?? 0;
+            if ($depth++ > $this->depthLimit) {
+                throw new CircularDependencyException();
+            }
+            return $depth;
+        });
+    }
+
+    public function decrement()
+    {
+        Context::override('di.depth', function ($depth) {
+            return --$depth;
+        });
+    }
+}

--- a/src/di/src/Resolver/ResolverDispatcher.php
+++ b/src/di/src/Resolver/ResolverDispatcher.php
@@ -15,6 +15,7 @@ use Hyperf\Di\Definition\DefinitionInterface;
 use Hyperf\Di\Definition\FactoryDefinition;
 use Hyperf\Di\Definition\ObjectDefinition;
 use Hyperf\Di\Definition\SelfResolvingDefinitionInterface;
+use Hyperf\Di\Exception\CircularDependencyException;
 use Hyperf\Di\Exception\InvalidDefinitionException;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
@@ -55,8 +56,20 @@ class ResolverDispatcher implements ResolverInterface
             return $definition->resolve($this->container);
         }
 
-        $resolver = $this->getDefinitionResolver($definition);
-        return $resolver->resolve($definition, $parameters);
+        $guard = DepthGuard::getInstance();
+
+        try {
+            $guard->increment();
+            $resolver = $this->getDefinitionResolver($definition);
+            $result = $resolver->resolve($definition, $parameters);
+        } catch (CircularDependencyException $e) {
+            $e->addDefinitionName($definition->getName());
+            throw $e;
+        } finally {
+            $guard->decrement();
+        }
+
+        return $result;
     }
 
     /**
@@ -71,8 +84,20 @@ class ResolverDispatcher implements ResolverInterface
             return $definition->isResolvable($this->container);
         }
 
-        $resolver = $this->getDefinitionResolver($definition);
-        return $resolver->isResolvable($definition, $parameters);
+        $guard = DepthGuard::getInstance();
+
+        try {
+            $guard->increment();
+            $resolver = $this->getDefinitionResolver($definition);
+            $result = $resolver->isResolvable($definition, $parameters);
+        } catch (CircularDependencyException $e) {
+            $e->addDefinitionName($definition->getName());
+            throw $e;
+        } finally {
+            $guard->decrement();
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
目前使用的是最简单的搜索深度检测：每个协程设置一个最大深度。当DI搜索达到这个深度时抛出异常，并收集stack上的类，寻找循环依赖。

问题：

* 不依赖config组件的情况下，如何配置最大深度？目前是写死的500。
* 错误信息怎么写最合适？

解决这些问题以后补测试。

目前效果：

```bash
Fatal error: Uncaught Hyperf\Di\Exception\CircularDependencyException: dependency depth limit reached due to the following dependencies: App\Logic\B->App\Logic\A->App\Logic\B in /Users/donew/src/hyperf/src/di/src/Resolver/DepthGuard.php:38
Stack trace:
#0 /Users/donew/src/test-hyperf/vendor/hyperf/utils/src/Context.php(83): Hyperf\Di\Resolver\DepthGuard->Hyperf\Di\Resolver\{closure}(502)
#1 /Users/donew/src/hyperf/src/di/src/Resolver/DepthGuard.php(41): Hyperf\Utils\Context::override('di.depth', Object(Closure))
#2 /Users/donew/src/hyperf/src/di/src/Resolver/ResolverDispatcher.php(62): Hyperf\Di\Resolver\DepthGuard->increment()
#3 /Users/donew/src/hyperf/src/di/src/Container.php(182): Hyperf\Di\Resolver\ResolverDispatcher->resolve(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#4 /Users/donew/src/hyperf/src/di/src/Container.php(82): Hyperf\Di\Container->resolveDefinition(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#5 /Users/donew/src/hyperf/src/di/src/Container.php(117): Hyperf\Di\Container->make('App\\Lo in /Users/donew/src/hyperf/src/di/src/Resolver/DepthGuard.php on line 38
```
