### PR TITLE
Fix `__FUNCTION__` and `__METHOD__` magic constants does work in closure of aop proxy class

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,10 @@
 
 - [#2335](https://github.com/hyperf/hyperf/pull/2335) Added `Hyperf/Utils/Optional`.
 
+## Fixed
+
+- [#2340](https://github.com/hyperf/hyperf/pull/2340) Fixed `__FUNCTION__` and `__METHOD__` magic constants does work in closure of aop proxy class
+
 ## Optimized
 
 - [#2319](https://github.com/hyperf/hyperf/pull/2319) Optimized the `ResolverDispatcher` which is friendly for circular dependencies.

--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -103,11 +103,9 @@ class ProxyCallVisitor extends NodeVisitorAbstract
             case $node instanceof MagicConstFunction:
                 // Rewrite __FUNCTION__ to $__function__ variable.
                 return new Variable('__function__');
-                break;
             case $node instanceof MagicConstMethod:
                 // Rewrite __METHOD__ to $__method__ variable.
                 return new Variable('__method__');
-                break;
         }
         return null;
     }

--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -5,20 +5,25 @@ declare(strict_types=1);
  * This file is part of Hyperf.
  *
  * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
+ * @document https://doc.hyperf.io
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
 namespace Hyperf\Di\Aop;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\MagicConst\Class_ as MagicConstClass;
 use PhpParser\Node\Scalar\MagicConst\Function_ as MagicConstFunction;
+use PhpParser\Node\Scalar\MagicConst\Method as MagicConstMethod;
+use PhpParser\Node\Scalar\MagicConst\Trait_ as MagicConstTrait;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -85,7 +90,7 @@ class ProxyCallVisitor extends NodeVisitorAbstract
                 if (! $this->clouldUseSameTrait()) {
                     return $node;
                 }
-                // no break; If the node is trait and php version >= 7.3, it can `use ProxyTrait` like class.
+            // no break; If the node is trait and php version >= 7.3, it can `use ProxyTrait` like class.
             case $node instanceof Class_ && ! $node->isAnonymous():
                 // Add use proxy traits.
                 $stmts = $node->stmts;
@@ -95,6 +100,14 @@ class ProxyCallVisitor extends NodeVisitorAbstract
                 $node->stmts = $stmts;
                 unset($stmts);
                 return $node;
+            case $node instanceof MagicConstFunction:
+                // Rewrite __FUNCTION__ to $__function__ variable.
+                return new Variable('__function__');
+                break;
+            case $node instanceof MagicConstMethod:
+                // Rewrite __METHOD__ to $__method__ variable.
+                return new Variable('__method__');
+                break;
         }
         return null;
     }
@@ -142,17 +155,17 @@ class ProxyCallVisitor extends NodeVisitorAbstract
         }
         $staticCall = new StaticCall(new Name('self'), '__proxyCall', [
             // __CLASS__
-            new Node\Arg($this->getMagicConst()),
+            new Arg($this->getMagicConst()),
             // __FUNCTION__
-            new Node\Arg(new MagicConstFunction()),
+            new Arg(new MagicConstFunction()),
             // self::getParamMap(OriginalClass::class, __FUNCTION, func_get_args())
-            new Node\Arg(new StaticCall(new Name('self'), '__getParamsMap', [
-                new Node\Arg(new Node\Scalar\MagicConst\Class_()),
-                new Node\Arg(new MagicConstFunction()),
-                new Node\Arg(new FuncCall(new Name('func_get_args'))),
+            new Arg(new StaticCall(new Name('self'), '__getParamsMap', [
+                new Arg(new MagicConstClass()),
+                new Arg(new MagicConstFunction()),
+                new Arg(new FuncCall(new Name('func_get_args'))),
             ])),
             // A closure that wrapped original method code.
-            new Node\Arg(new Closure([
+            new Arg(new Closure([
                 'params' => value(function () use ($node) {
                     // Transfer the variadic variable to normal variable at closure argument. ...$params => $parms
                     $params = $node->getParams();
@@ -165,18 +178,25 @@ class ProxyCallVisitor extends NodeVisitorAbstract
                     }
                     return $params;
                 }),
+                'uses' => [
+                    new Variable('__function__'),
+                    new Variable('__method__'),
+                ],
                 'stmts' => $node->stmts,
             ])),
         ]);
+        $magicConstFunction = new Expression(new Assign(new Variable('__function__'), new MagicConstFunction()));
+        $magicConstMethod = new Expression(new Assign(new Variable('__method__'), new MagicConstMethod()));
+        $stmts = [
+            $magicConstFunction,
+            $magicConstMethod,
+        ];
         if ($shouldReturn) {
-            $node->stmts = [
-                new Return_($staticCall),
-            ];
+            $stmts[] = new Return_($staticCall);
         } else {
-            $node->stmts = [
-                new Expression($staticCall),
-            ];
+            $stmts[] = new Expression($staticCall);
         }
+        $node->stmts = $stmts;
         return $node;
     }
 
@@ -184,10 +204,10 @@ class ProxyCallVisitor extends NodeVisitorAbstract
     {
         switch ($this->visitorMetadata->classLike) {
             case Trait_::class:
-                return new Node\Scalar\MagicConst\Trait_();
+                return new MagicConstTrait();
             case Class_::class:
             default:
-                return new Node\Scalar\MagicConst\Class_();
+                return new MagicConstClass();
         }
     }
 

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -117,9 +117,7 @@ class Bar4
     }
     public function toMethodString() : string
     {
-        $__function__ = __FUNCTION__;
-        $__method__ = __METHOD__;
-        return $__method__;
+        return __METHOD__;
     }
     public function toRewriteMethodString() : string
     {

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -33,14 +33,7 @@ class AstTest extends TestCase
         BetterReflectionManager::clear();
     }
 
-    public function testAstProxy()
-    {
-        BetterReflectionManager::initClassReflector([__DIR__ . '/Stub']);
-
-        $ast = new Ast();
-        $code = $ast->proxy(Foo::class);
-
-        $this->assertEquals('<?php
+    protected $license = '<?php
 
 declare (strict_types=1);
 /**
@@ -50,7 +43,16 @@ declare (strict_types=1);
  * @document https://hyperf.wiki
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+ */';
+
+    public function testAstProxy()
+    {
+        BetterReflectionManager::initClassReflector([__DIR__ . '/Stub']);
+
+        $ast = new Ast();
+        $code = $ast->proxy(Foo::class);
+
+        $this->assertEquals($this->license . '
 namespace HyperfTest\Di\Stub\Ast;
 
 class Foo
@@ -70,17 +72,7 @@ class Foo
 
         $ast = new Ast();
         $code = $ast->proxy(Bar2::class);
-        $this->assertEquals('<?php
-
-declare (strict_types=1);
-/**
- * This file is part of Hyperf.
- *
- * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
- * @contact  group@hyperf.io
- * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+        $this->assertEquals($this->license . '
 namespace HyperfTest\Di\Stub\Ast;
 
 class Bar2 extends Bar
@@ -114,17 +106,7 @@ class Bar2 extends Bar
         $ast = new Ast();
         $code = $ast->proxy(Bar3::class);
 
-        $this->assertEquals('<?php
-
-declare (strict_types=1);
-/**
- * This file is part of Hyperf.
- *
- * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
- * @contact  group@hyperf.io
- * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+        $this->assertEquals($this->license . '
 namespace HyperfTest\Di\Stub\Ast;
 
 class Bar3 extends Bar
@@ -140,7 +122,9 @@ class Bar3 extends Bar
     }
     public function getId() : int
     {
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
             return parent::getId();
         });
     }
@@ -148,17 +132,7 @@ class Bar3 extends Bar
 
         $code = $ast->proxy(FooTrait::class);
         if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
-            $this->assertSame('<?php
-
-declare (strict_types=1);
-/**
- * This file is part of Hyperf.
- *
- * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
- * @contact  group@hyperf.io
- * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+            $this->assertSame($this->license . '
 namespace HyperfTest\\Di\\Stub\\Ast;
 
 trait FooTrait
@@ -166,30 +140,24 @@ trait FooTrait
     use \\Hyperf\\Di\\Aop\\ProxyTrait;
     public function getString() : string
     {
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
             return uniqid();
         });
     }
 }', $code);
         } else {
-            $this->assertSame('<?php
-
-declare (strict_types=1);
-/**
- * This file is part of Hyperf.
- *
- * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
- * @contact  group@hyperf.io
- * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+            $this->assertSame($this->license . '
 namespace HyperfTest\\Di\\Stub\\Ast;
 
 trait FooTrait
 {
     public function getString() : string
     {
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
             return uniqid();
         });
     }
@@ -197,17 +165,7 @@ trait FooTrait
         }
 
         $code = $ast->proxy(BarInterface::class);
-        $this->assertSame('<?php
-
-declare (strict_types=1);
-/**
- * This file is part of Hyperf.
- *
- * @link     https://www.hyperf.io
- * @document https://hyperf.wiki
- * @contact  group@hyperf.io
- * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
- */
+        $this->assertSame($this->license . '
 namespace HyperfTest\Di\Stub\Ast;
 
 interface BarInterface

--- a/src/di/tests/Stub/Ast/Bar4.php
+++ b/src/di/tests/Stub/Ast/Bar4.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Di\Stub\Ast;
+
+class Bar4
+{
+    public function toMethodString(): string
+    {
+        return __METHOD__;
+    }
+
+    public function toRewriteMethodString(): string
+    {
+        return __METHOD__;
+    }
+}


### PR DESCRIPTION
fixed #2279