### PR TITLE
Fixed `server:start` failed, when the config of pid_file changed.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 ## Fixed
 
 - [#2331](https://github.com/hyperf/hyperf/pull/2331) Fixed exception thrown when the service or config was not found for nacos.
+- [#2356](https://github.com/hyperf/hyperf/pull/2356) Fixed `server:start` failed, when the config of pid_file changed.
 
 # v2.0.8 - 2020-08-24
 

--- a/src/watcher/src/Watcher.php
+++ b/src/watcher/src/Watcher.php
@@ -146,7 +146,7 @@ class Watcher
 
     public function restart($isStart = true)
     {
-        $file = BASE_PATH . '/runtime/hyperf.pid';
+        $file = config('server.settings.pid_file');
         if (! $isStart && $this->filesystem->exists($file)) {
             $pid = $this->filesystem->get($file);
             try {

--- a/src/watcher/src/Watcher.php
+++ b/src/watcher/src/Watcher.php
@@ -16,6 +16,7 @@ use Hyperf\Di\Annotation\ScanConfig;
 use Hyperf\Di\ClassLoader;
 use Hyperf\Utils\Codec\Json;
 use Hyperf\Utils\Coroutine;
+use Hyperf\Utils\Filesystem\FileNotFoundException;
 use Hyperf\Utils\Filesystem\Filesystem;
 use Hyperf\Watcher\Driver\DriverInterface;
 use PhpParser\PrettyPrinter\Standard;
@@ -147,6 +148,9 @@ class Watcher
     public function restart($isStart = true)
     {
         $file = config('server.settings.pid_file');
+        if (empty($file)) {
+            throw new FileNotFoundException('pid_file is not found.');
+        }
         if (! $isStart && $this->filesystem->exists($file)) {
             $pid = $this->filesystem->get($file);
             try {


### PR DESCRIPTION
兼容开发者修改pid路径之后，导致热重载无法生效的问题