### PR TITLE
[feature] 使用事件监听机制替换session中间件, 保证在请求的任何位置都可以设置session

### DIFF
--- a/src/http-server/src/Event/OnRequestEnd.php
+++ b/src/http-server/src/Event/OnRequestEnd.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\HttpServer\Event;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class OnRequestEnd
+{
+    /**
+     * @var ServerRequestInterface
+     */
+    public $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    public $response;
+
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $this->request = $request;
+        $this->response = $response;
+    }
+}

--- a/src/http-server/src/Event/OnRequestStart.php
+++ b/src/http-server/src/Event/OnRequestStart.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\HttpServer\Event;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class OnRequestStart
+{
+    /**
+     * @var ServerRequestInterface
+     */
+    public $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    public $response;
+
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $this->request = $request;
+        $this->response = $response;
+    }
+}

--- a/src/session/src/Listener/SessionEnd.php
+++ b/src/session/src/Listener/SessionEnd.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Session\Listener;
+
+use Carbon\Carbon;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\SessionInterface;
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\HttpMessage\Cookie\Cookie;
+use Hyperf\HttpServer\Event\OnRequestEnd;
+use Hyperf\Session\SessionManager;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @Listener
+ */
+class SessionEnd implements ListenerInterface
+{
+    /**
+     * @var SessionManager
+     */
+    protected $sessionManager;
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
+
+    public function __construct(SessionManager $sessionManager, ConfigInterface $config)
+    {
+        $this->sessionManager = $sessionManager;
+        $this->config = $config;
+    }
+
+    public function listen(): array
+    {
+        return [
+            OnRequestEnd::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        if ($this->isSessionAvailable()) {
+            /* @var OnRequestEnd $event */
+            $this->storeCurrentUrl($event->request, $session = $this->sessionManager->getSession());
+            $this->sessionManager->end($session);
+            $this->addCookieToResponse($event->request, $event->response, $session);
+        }
+    }
+
+    protected function isSessionAvailable(): bool
+    {
+        return $this->config->has('session.handler');
+    }
+
+    /**
+     * Get the URL (no query string) for the request.
+     */
+    protected function url(RequestInterface $request): string
+    {
+        return rtrim(preg_replace('/\?.*/', '', (string) $request->getUri()));
+    }
+
+    /**
+     * Store the current URL for the request if necessary.
+     */
+    protected function storeCurrentUrl(RequestInterface $request, SessionInterface $session)
+    {
+        if ($request->getMethod() === 'GET') {
+            $session->setPreviousUrl($this->fullUrl($request));
+        }
+    }
+
+    /**
+     * Get the session lifetime in seconds.
+     */
+    protected function getCookieExpirationDate(): int
+    {
+        if ($this->config->get('session.options.expire_on_close')) {
+            $expirationDate = 0;
+        } else {
+            $expirationDate = Carbon::now()->addMinutes(5 * 60)->getTimestamp();
+        }
+        return $expirationDate;
+    }
+
+    /**
+     * Add the session cookie to the response·.
+     */
+    protected function addCookieToResponse(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        SessionInterface $session
+    ): ResponseInterface {
+        $uri = $request->getUri();
+        $path = '/';
+        $secure = strtolower($uri->getScheme()) === 'https';
+        $httpOnly = true;
+
+        $domain = $this->config->get('session.options.domain') ?? $uri->getHost();
+
+        $cookie = new Cookie($session->getName(), $session->getId(), $this->getCookieExpirationDate(), $path, $domain, $secure, $httpOnly);
+        if (! method_exists($response, 'withCookie')) {
+            return $response->withHeader('Set-Cookie', (string) $cookie);
+        }
+        /* @var \Hyperf\HttpMessage\Server\Response $response */
+        return $response->withCookie($cookie);
+    }
+
+    /**
+     * Get the full URL for the request.
+     */
+    protected function fullUrl(RequestInterface $request): string
+    {
+        $uri = $request->getUri();
+        $query = $uri->getQuery();
+        $question = $uri->getHost() . $uri->getPath() == '/' ? '/?' : '?';
+        return $query ? $this->url($request) . $question . $query : $this->url($request);
+    }
+}

--- a/src/session/src/Listener/SessionStart.php
+++ b/src/session/src/Listener/SessionStart.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Session\Listener;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\HttpServer\Event\OnRequestStart;
+use Hyperf\Session\SessionManager;
+
+/**
+ * @Listener
+ */
+class SessionStart implements ListenerInterface
+{
+    /**
+     * @var SessionManager
+     */
+    protected $sessionManager;
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
+
+    public function __construct(SessionManager $sessionManager, ConfigInterface $config)
+    {
+        $this->sessionManager = $sessionManager;
+        $this->config = $config;
+    }
+
+    public function listen(): array
+    {
+        return [
+            OnRequestStart::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        if ($this->isSessionAvailable()) {
+            /* @var OnRequestStart $event */
+            $this->sessionManager->start($event->request);
+        }
+    }
+
+    protected function isSessionAvailable(): bool
+    {
+        return $this->config->has('session.handler');
+    }
+}


### PR DESCRIPTION
### 问题

在异常中设置 session 的时候, 由于异常捕捉的问题, 导致程序直接跳出中间件的逻辑层面, 使得 session 无法自动保存上.

### 解决方法

在请求发起和结束时, 触发 `OnRequestStart` 和 `OnRequestEnd` 事件, 通过监听这两个事件, 设置和保存 session.