### PR TITLE
Fixed model event dispatcher does not works for Pivot and MorphPivot.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,10 @@
 - [#2411](https://github.com/hyperf/hyperf/pull/2411) Added method `Hyperf\Database\Query\Builder::forPageBeforeId` for database.
 - [#2420](https://github.com/hyperf/hyperf/pull/2420) [#2426](https://github.com/hyperf/hyperf/pull/2426) Added option `enable-event-dispatcher` to initialize EventDispatcher for command.
 
+## Fixed
+
+- [#2427](https://github.com/hyperf/hyperf/pull/2427) Fixed model event dispatcher not works for `Pivot` and `MorphPivot`.
+
 ## Optimized
 
 - [#2429](https://github.com/hyperf/hyperf/pull/2429) Optimized error message when does not set the value of `@var` for `@Inject`.

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,7 +7,7 @@
 
 ## Fixed
 
-- [#2427](https://github.com/hyperf/hyperf/pull/2427) Fixed model event dispatcher not works for `Pivot` and `MorphPivot`.
+- [#2427](https://github.com/hyperf/hyperf/pull/2427) Fixed model event dispatcher does not works for `Pivot` and `MorphPivot`.
 
 ## Optimized
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,7 +35,7 @@ parameters:
     - '#Unsafe usage of new static#'
     - '#Method Hyperf\\Contract\\Sendable::send#'
     - '#Variable .* in PHPDoc tag @var does not exist#'
-    - '#Call to an undefined method Hyperf\\DbConnection\\Model\\Model::hydrate#'
+    - '#Call to an undefined method Hyperf\\Database\\Model\\Model::hydrate#'
     - '#PHPDoc tag @param has invalid value#'
     - '#Static call to instance method Hyperf\\RpcServer\\Router\\Router::#'
     - '#Method Hyperf\\Utils\\Serializer\\ScalarNormalizer::denormalize\(\) should return array\|object but returns#'

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -11,9 +11,12 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Database;
 
+use Carbon\Carbon;
 use Hyperf\Database\Events\QueryExecuted;
 use HyperfTest\Database\Stubs\ContainerStub;
 use HyperfTest\Database\Stubs\Model\User;
+use HyperfTest\Database\Stubs\Model\UserRole;
+use HyperfTest\Database\Stubs\Model\UserRolePivot;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -38,6 +41,26 @@ class ModelRealBuilderTest extends TestCase
     protected function tearDown()
     {
         Mockery::close();
+    }
+
+    public function testPivot()
+    {
+        $this->getContainer();
+
+        $user = User::query()->find(1);
+        $role = $user->roles->first();
+        $this->assertSame(1, $role->id);
+        $this->assertSame('author', $role->name);
+
+        $this->assertInstanceOf(UserRolePivot::class, $role->pivot);
+        $this->assertSame(1, $role->pivot->user_id);
+        $this->assertSame(1, $role->pivot->role_id);
+
+        $role->pivot->updated_at = $now = Carbon::now()->toDateTimeString();
+        $role->pivot->save();
+
+        $pivot = UserRole::query()->find(1);
+        $this->assertSame($now, $pivot->updated_at->toDateTimeString());
     }
 
     public function testForPageBeforeId()

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -13,6 +13,7 @@ namespace HyperfTest\Database;
 
 use Carbon\Carbon;
 use Hyperf\Database\Events\QueryExecuted;
+use Hyperf\Database\Model\Events\Saved;
 use HyperfTest\Database\Stubs\ContainerStub;
 use HyperfTest\Database\Stubs\Model\User;
 use HyperfTest\Database\Stubs\Model\UserRole;
@@ -61,6 +62,15 @@ class ModelRealBuilderTest extends TestCase
 
         $pivot = UserRole::query()->find(1);
         $this->assertSame($now, $pivot->updated_at->toDateTimeString());
+
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof Saved) {
+                $this->assertSame($event->getModel(), $role->pivot);
+                $hit = true;
+            }
+        }
+
+        $this->assertTrue($hit);
     }
 
     public function testForPageBeforeId()

--- a/src/database/tests/Stubs/ContainerStub.php
+++ b/src/database/tests/Stubs/ContainerStub.php
@@ -32,7 +32,7 @@ class ContainerStub
 
         $dbConfig = [
             'driver' => 'mysql',
-            'host' => 'localhost',
+            'host' => '127.0.0.1',
             'database' => 'hyperf',
             'username' => 'root',
             'password' => '',

--- a/src/database/tests/Stubs/Model/User.php
+++ b/src/database/tests/Stubs/Model/User.php
@@ -57,4 +57,11 @@ class User extends Model
     {
         return $this->morphOne(Image::class, 'imageable');
     }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class, 'user_role', 'user_id', 'role_id', 'id', 'id')
+            ->using(UserRolePivot::class)->as('pivot')
+            ->withTimestamps();
+    }
 }

--- a/src/database/tests/Stubs/Model/UserRolePivot.php
+++ b/src/database/tests/Stubs/Model/UserRolePivot.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database\Stubs\Model;
+
+use Hyperf\DbConnection\Model\Relations\Pivot;
+
+class UserRolePivot extends Pivot
+{
+}

--- a/src/db-connection/src/Model/Model.php
+++ b/src/db-connection/src/Model/Model.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 namespace Hyperf\DbConnection\Model;
 
 use Hyperf\Database\Model\Model as BaseModel;
-use Hyperf\DbConnection\Traits\Repository;
+use Hyperf\DbConnection\Traits\HasContainer;
+use Hyperf\DbConnection\Traits\HasRepository;
 
 class Model extends BaseModel
 {
-    use Repository;
+    use HasContainer;
+    use HasRepository;
 }

--- a/src/db-connection/src/Model/Relations/MorphPivot.php
+++ b/src/db-connection/src/Model/Relations/MorphPivot.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\DbConnection\Model;
 
-use Hyperf\Database\Model\Model as BaseModel;
+namespace Hyperf\DbConnection\Model\Relations;
+
+
+use Hyperf\Database\Model\Relations\MorphPivot as BaseMorphPivot;
 use Hyperf\DbConnection\Traits\Repository;
 
-class Model extends BaseModel
+class MorphPivot extends BaseMorphPivot
 {
     use Repository;
 }

--- a/src/db-connection/src/Model/Relations/MorphPivot.php
+++ b/src/db-connection/src/Model/Relations/MorphPivot.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Hyperf\DbConnection\Model\Relations;
 
 use Hyperf\Database\Model\Relations\MorphPivot as BaseMorphPivot;
-use Hyperf\DbConnection\Traits\Repository;
+use Hyperf\DbConnection\Traits\HasContainer;
 
 class MorphPivot extends BaseMorphPivot
 {
-    use Repository;
+    use HasContainer;
 }

--- a/src/db-connection/src/Model/Relations/MorphPivot.php
+++ b/src/db-connection/src/Model/Relations/MorphPivot.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\DbConnection\Model\Relations;
-
 
 use Hyperf\Database\Model\Relations\MorphPivot as BaseMorphPivot;
 use Hyperf\DbConnection\Traits\Repository;

--- a/src/db-connection/src/Model/Relations/Pivot.php
+++ b/src/db-connection/src/Model/Relations/Pivot.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\DbConnection\Model;
 
-use Hyperf\Database\Model\Model as BaseModel;
+namespace Hyperf\DbConnection\Model\Relations;
+
+use Hyperf\Database\Model\Relations\Pivot as BasePivot;
 use Hyperf\DbConnection\Traits\Repository;
 
-class Model extends BaseModel
+class Pivot extends BasePivot
 {
     use Repository;
 }

--- a/src/db-connection/src/Model/Relations/Pivot.php
+++ b/src/db-connection/src/Model/Relations/Pivot.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Hyperf\DbConnection\Model\Relations;
 
 use Hyperf\Database\Model\Relations\Pivot as BasePivot;
-use Hyperf\DbConnection\Traits\Repository;
+use Hyperf\DbConnection\Traits\HasContainer;
 
 class Pivot extends BasePivot
 {
-    use Repository;
+    use HasContainer;
 }

--- a/src/db-connection/src/Model/Relations/Pivot.php
+++ b/src/db-connection/src/Model/Relations/Pivot.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\DbConnection\Model\Relations;
 
 use Hyperf\Database\Model\Relations\Pivot as BasePivot;

--- a/src/db-connection/src/Traits/HasContainer.php
+++ b/src/db-connection/src/Traits/HasContainer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\DbConnection\Traits;
+
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\ConnectionResolverInterface;
+use Hyperf\Utils\ApplicationContext;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+trait HasContainer
+{
+    /**
+     * Get the database connection for the model.
+     */
+    public function getConnection(): ConnectionInterface
+    {
+        $connectionName = $this->getConnectionName();
+        $resolver = $this->getContainer()->get(ConnectionResolverInterface::class);
+        return $resolver->connection($connectionName);
+    }
+
+    public function getEventDispatcher(): ?EventDispatcherInterface
+    {
+        return $this->getContainer()->get(EventDispatcherInterface::class);
+    }
+
+    protected function getContainer(): ContainerInterface
+    {
+        return ApplicationContext::getContainer();
+    }
+}

--- a/src/db-connection/src/Traits/HasRepository.php
+++ b/src/db-connection/src/Traits/HasRepository.php
@@ -11,36 +11,15 @@ declare(strict_types=1);
  */
 namespace Hyperf\DbConnection\Traits;
 
-use Hyperf\Database\ConnectionInterface;
-use Hyperf\Database\ConnectionResolverInterface;
 use Hyperf\Database\Model\Model;
-use Hyperf\Utils\ApplicationContext;
-use Psr\Container\ContainerInterface;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use RuntimeException;
 
-/** @mixin Model */
-trait Repository
+trait HasRepository
 {
     /**
      * @var string the full namespace of repository class
      */
     protected $repository;
-
-    /**
-     * Get the database connection for the model.
-     */
-    public function getConnection(): ConnectionInterface
-    {
-        $connectionName = $this->getConnectionName();
-        $resolver = $this->getContainer()->get(ConnectionResolverInterface::class);
-        return $resolver->connection($connectionName);
-    }
-
-    public function getEventDispatcher(): ?EventDispatcherInterface
-    {
-        return $this->getContainer()->get(EventDispatcherInterface::class);
-    }
 
     /**
      * @throws RuntimeException when the model does not define the repository class
@@ -51,10 +30,5 @@ trait Repository
             throw new RuntimeException(sprintf('Cannot detect the repository of %s', static::class));
         }
         return $this->getContainer()->get($this->repository);
-    }
-
-    protected function getContainer(): ContainerInterface
-    {
-        return ApplicationContext::getContainer();
     }
 }

--- a/src/db-connection/src/Traits/Repository.php
+++ b/src/db-connection/src/Traits/Repository.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\DbConnection\Traits;
-
 
 use Hyperf\Database\ConnectionInterface;
 use Hyperf\Database\ConnectionResolverInterface;
@@ -39,11 +37,6 @@ trait Repository
         return $resolver->connection($connectionName);
     }
 
-    protected function getContainer(): ContainerInterface
-    {
-        return ApplicationContext::getContainer();
-    }
-
     public function getEventDispatcher(): ?EventDispatcherInterface
     {
         return $this->getContainer()->get(EventDispatcherInterface::class);
@@ -54,9 +47,14 @@ trait Repository
      */
     public function getRepository()
     {
-        if (!$this->repository || !class_exists($this->repository) && !interface_exists($this->repository)) {
+        if (! $this->repository || ! class_exists($this->repository) && ! interface_exists($this->repository)) {
             throw new RuntimeException(sprintf('Cannot detect the repository of %s', static::class));
         }
         return $this->getContainer()->get($this->repository);
+    }
+
+    protected function getContainer(): ContainerInterface
+    {
+        return ApplicationContext::getContainer();
     }
 }

--- a/src/db-connection/src/Traits/Repository.php
+++ b/src/db-connection/src/Traits/Repository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\DbConnection\Traits;
+
+
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\ConnectionResolverInterface;
+use Hyperf\Database\Model\Model;
+use Hyperf\Utils\ApplicationContext;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use RuntimeException;
+
+/** @mixin Model */
+trait Repository
+{
+    /**
+     * @var string the full namespace of repository class
+     */
+    protected $repository;
+
+    /**
+     * Get the database connection for the model.
+     */
+    public function getConnection(): ConnectionInterface
+    {
+        $connectionName = $this->getConnectionName();
+        $resolver = $this->getContainer()->get(ConnectionResolverInterface::class);
+        return $resolver->connection($connectionName);
+    }
+
+    protected function getContainer(): ContainerInterface
+    {
+        return ApplicationContext::getContainer();
+    }
+
+    public function getEventDispatcher(): ?EventDispatcherInterface
+    {
+        return $this->getContainer()->get(EventDispatcherInterface::class);
+    }
+
+    /**
+     * @throws RuntimeException when the model does not define the repository class
+     */
+    public function getRepository()
+    {
+        if (!$this->repository || !class_exists($this->repository) && !interface_exists($this->repository)) {
+            throw new RuntimeException(sprintf('Cannot detect the repository of %s', static::class));
+        }
+        return $this->getContainer()->get($this->repository);
+    }
+}

--- a/src/model-cache/src/Manager.php
+++ b/src/model-cache/src/Manager.php
@@ -14,10 +14,11 @@ namespace Hyperf\ModelCache;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Database\Model\Collection;
+use Hyperf\Database\Model\Model;
 use Hyperf\DbConnection\Collector\TableCollector;
-use Hyperf\DbConnection\Model\Model;
 use Hyperf\ModelCache\Handler\HandlerInterface;
 use Hyperf\ModelCache\Handler\RedisHandler;
+use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 
 class Manager
@@ -50,7 +51,7 @@ class Manager
 
         $config = $container->get(ConfigInterface::class);
         if (! $config->has('databases')) {
-            throw new \InvalidArgumentException('config databases is not exist!');
+            throw new InvalidArgumentException('config databases is not exist!');
         }
 
         foreach ($config->get('databases') as $key => $item) {

--- a/src/model-cache/tests/Stub/ManagerStub.php
+++ b/src/model-cache/tests/Stub/ManagerStub.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 namespace HyperfTest\ModelCache\Stub;
 
-use Hyperf\DbConnection\Model\Model;
+use Hyperf\Database\Model\Model;
 
 class ManagerStub extends \Hyperf\ModelCache\Manager
 {


### PR DESCRIPTION
For example :
```php
<?php


namespace App\Model\Test;

use Hyperf\DbConnection\Model\Relations\Pivot;
use Hyperf\DbConnection\Model\Model;
use Hyperf\ModelCache\CacheableInterface;
use Hyperf\ModelCache\Cacheable;

//用户
class User extends Model implements CacheableInterface
{
    use Cacheable;

    public function members()
    {
        $this->hasMany(Group::class);
    }
    public function groups()
    {
        $this->belongsToMany(Group::class, 'group_member')
            ->using(GroupMember::class)->as('member')
            ->withTimestamps();
    }
}

//群
class Group extends Model implements CacheableInterface
{
    use Cacheable;

    public function members()
    {
        $this->hasMany(GroupMember::class);
    }
    public function users()
    {
        $this->belongsToMany(User::class,'group_member')
            ->using(GroupMember::class)->as('member')
            ->withTimestamps();
    }
}


//群成员
class GroupMember extends Pivot implements CacheableInterface
{
    use Cacheable;

    public function user()
    {
        $this->belongsTo(GroupMember::class);
    }

    public function group()
    {
        $this->belongsTo(Group::class);
    }
}

//通过群成员ID查询成员
GroupMember::findFromCache(1);
```