### PR TITLE
Whoops exception class returns json format to support trace error det…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ sudo: required
 matrix:
   include:
     - php: 7.2
-      env: SW_VERSION="4.5.3"
+      env: SW_VERSION="4.5.4"
     - php: 7.3
-      env: SW_VERSION="4.5.3"
+      env: SW_VERSION="4.5.4"
     - php: 7.4
-      env: SW_VERSION="4.5.3"
+      env: SW_VERSION="4.5.4"
 
 services:
   - mysql

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # v2.0.13 - TBD
 
+## Added
+
+- [#2445](https://github.com/hyperf/hyperf/pull/2445) Added trace info for `WhoopsExceptionHandler` when the header `accept` is `application/json`.
+
 ## Fixed
 
 - [#2559](https://github.com/hyperf/hyperf/pull/2559) Fixed the event does not works which caused by connecting with `query` for socketio-server.

--- a/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
+++ b/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
@@ -41,6 +41,9 @@ class WhoopsExceptionHandler extends ExceptionHandler
         $whoops->pushHandler($handler);
         $whoops->allowQuit(false);
         ob_start();
+        if ($handler instanceof JsonResponseHandler) {
+            $handler->addTraceToOutput(true);
+        }
         $whoops->{Run::EXCEPTION_HANDLER}($throwable);
         $content = ob_get_clean();
         return $response

--- a/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
+++ b/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
@@ -41,9 +41,6 @@ class WhoopsExceptionHandler extends ExceptionHandler
         $whoops->pushHandler($handler);
         $whoops->allowQuit(false);
         ob_start();
-        if ($handler instanceof JsonResponseHandler) {
-            $handler->addTraceToOutput(true);
-        }
         $whoops->{Run::EXCEPTION_HANDLER}($throwable);
         $content = ob_get_clean();
         return $response
@@ -57,7 +54,7 @@ class WhoopsExceptionHandler extends ExceptionHandler
         return env('APP_ENV') !== 'prod' && class_exists(Run::class);
     }
 
-    private function negotiateHandler()
+    protected function negotiateHandler()
     {
         /** @var ServerRequestInterface $request */
         $request = Context::get(ServerRequestInterface::class);
@@ -70,7 +67,7 @@ class WhoopsExceptionHandler extends ExceptionHandler
         return [new PlainTextHandler(),  'text/plain'];
     }
 
-    private function setupHandler($handler)
+    protected function setupHandler($handler)
     {
         if ($handler instanceof PrettyPageHandler) {
             $handler->handleUnconditionally(true);
@@ -91,6 +88,8 @@ class WhoopsExceptionHandler extends ExceptionHandler
             if ($session) {
                 $handler->addDataTableCallback('Hyperf Session', [$session, 'all']);
             }
+        } elseif ($handler instanceof JsonResponseHandler) {
+            $handler->addTraceToOutput(true);
         }
 
         return $handler;

--- a/src/exception-handler/tests/WhoopsExceptionHandlerTest.php
+++ b/src/exception-handler/tests/WhoopsExceptionHandlerTest.php
@@ -58,6 +58,8 @@ class WhoopsExceptionHandlerTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('application/json', $response->getHeader('Content-Type')[0]);
+        $arr = \json_decode($response->getBody()->__toString(), true);
+        $this->assertArrayHasKey('trace', $arr['error']);
     }
 
     public function testXmlWhoops()


### PR DESCRIPTION
[FEATURE] whoops插件 json 格式支持 trace 错误详情 
https://github.com/hyperf/hyperf/issues/2418

Whoops exception class returns json format to support trace error details.(#2418)

fix https://github.com/hyperf/hyperf/issues/2418