### PR TITLE
Fixed method `fill` does not works for camel case model.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,10 @@
 - [#2455](https://github.com/hyperf/hyperf/pull/2455) Added method `Socket::getRequest` to retrieve psr7 request from socket for socketio-server.
 - [#2459](https://github.com/hyperf/hyperf/pull/2459) Added `ReloadChannelListener` to reload timeout or failed channels automatically for async-queue.
 
+## Fixed
+
+- [#2464](https://github.com/hyperf/hyperf/pull/2464) Fixed method `fill` does not works for camel case model.
+
 # v2.0.10 - 2020-09-07
 
 ## Added

--- a/src/database/src/Model/Concerns/CamelCase.php
+++ b/src/database/src/Model/Concerns/CamelCase.php
@@ -66,4 +66,13 @@ trait CamelCase
         }
         return $attributes;
     }
+
+    public function getFillable()
+    {
+        $fillable = [];
+        foreach (parent::getFillable() as $key) {
+            $fillable[] = $this->keyTransform($key);
+        }
+        return $fillable;
+    }
 }


### PR DESCRIPTION
使用CamelCase驼峰执行模型fill方法时如果key是驼峰同时模型$fillable数组内是蛇形,导致无法批量赋值