### PR TITLE
Added `throwbale` to the end of arguments of fallback for `retry` component.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - [#2455](https://github.com/hyperf/hyperf/pull/2455) Added method `Socket::getRequest` to retrieve psr7 request from socket for socketio-server.
 - [#2459](https://github.com/hyperf/hyperf/pull/2459) Added `ReloadChannelListener` to reload timeout or failed channels automatically for async-queue.
 - [#2643](https://github.com/hyperf/hyperf/pull/2463) Added optional visitor `ModelRewriteGetterSetterVisitor` for `gen:model`.
+- [#2475](https://github.com/hyperf/hyperf/pull/2475) Added `throwbale` to the end of arguments of fallback for `retry` component.
 
 ## Fixed
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,7 +4,7 @@
 
 - [#2455](https://github.com/hyperf/hyperf/pull/2455) Added method `Socket::getRequest` to retrieve psr7 request from socket for socketio-server.
 - [#2459](https://github.com/hyperf/hyperf/pull/2459) Added `ReloadChannelListener` to reload timeout or failed channels automatically for async-queue.
-- [#2643](https://github.com/hyperf/hyperf/pull/2463) Added optional visitor `ModelRewriteGetterSetterVisitor` for `gen:model`.
+- [#2463](https://github.com/hyperf/hyperf/pull/2463) Added optional visitor `ModelRewriteGetterSetterVisitor` for `gen:model`.
 - [#2475](https://github.com/hyperf/hyperf/pull/2475) Added `throwbale` to the end of arguments of fallback for `retry` component.
 
 ## Fixed

--- a/src/retry/src/Policy/FallbackRetryPolicy.php
+++ b/src/retry/src/Policy/FallbackRetryPolicy.php
@@ -41,12 +41,15 @@ class FallbackRetryPolicy extends BaseRetryPolicy implements RetryPolicyInterfac
         if (! is_callable($fallback)) {
             return false;
         }
+        $throwable = $retryContext['lastThrowable'] ?? null;
         $retryContext['lastThrowable'] = $retryContext['lastResult'] = null;
         if (isset($retryContext['proceedingJoinPoint'])) {
             $arguments = $retryContext['proceedingJoinPoint']->getArguments();
         } else {
             $arguments = [];
         }
+
+        $arguments[] = $throwable;
 
         try {
             $retryContext['lastResult'] = call_user_func($fallback, ...$arguments);

--- a/src/retry/tests/RetryTest.php
+++ b/src/retry/tests/RetryTest.php
@@ -115,8 +115,18 @@ class RetryTest extends TestCase
         });
         $this->assertEquals(10, $result);
 
-        $this->assertTrue(is_callable('Hyperf\\Utils\\Arr::accessible'));
         $this->assertTrue(is_callable(Foo::class . '::fallback'));
         $this->assertTrue(is_callable(Foo::class . '::staticCall'));
+    }
+
+    public function testThrowableInFallback()
+    {
+        $instance = Mockery::mock(Foo::class);
+        $instance->shouldReceive('test')->twice()->andThrowExceptions([new \RuntimeException()]);
+        Retry::whenThrows()->max(2)->fallback(function ($throwable) {
+            $this->assertInstanceOf(\RuntimeException::class, $throwable);
+        })->call(function () use ($instance) {
+            return $instance->test();
+        });
     }
 }

--- a/src/retry/tests/Stub/Foo.php
+++ b/src/retry/tests/Stub/Foo.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Retry\Stub;
 
+use Throwable;
+
 class Foo
 {
     public function fallback()
@@ -21,5 +23,10 @@ class Foo
     public static function staticCall()
     {
         return 10;
+    }
+
+    public function fallbackWithThrowable(string $string, ?Throwable $throwable = null)
+    {
+        return $string . ':' . $throwable->getMessage();
     }
 }


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/2466