### PR TITLE
Fixed mutated attributes do not work in camel case

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,10 @@
 
 - [#2512](https://github.com/hyperf/hyperf/pull/2512) Added `column_type` for `MySqlGrammar::compileColumnListing`.
 
+## Fixed
+
+- [#2509](https://github.com/hyperf/hyperf/pull/2509) Fixed mutated attributes do not work in camel case for `hyperf/database`.
+
 # v2.0.11 - 2020-09-14
 
 ## Added

--- a/src/database/src/Model/Concerns/CamelCase.php
+++ b/src/database/src/Model/Concerns/CamelCase.php
@@ -61,18 +61,4 @@ trait CamelCase
     {
         return Str::camel($key);
     }
-
-    protected function addMutatedAttributesToArray(array $attributes, array $mutatedAttributes)
-    {
-        foreach ($mutatedAttributes as $key) {
-            if (! array_key_exists($this->keyTransform($key), $attributes)) {
-                continue;
-            }
-            $attributes[$this->keyTransform($key)] = $this->mutateAttributeForArray(
-                $this->keyTransform($key),
-                $attributes[$this->keyTransform($key)]
-            );
-        }
-        return $attributes;
-    }
 }

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -122,6 +122,8 @@ class ModelRealBuilderTest extends TestCase
         $ext = UserExtCamel::query()->find(1);
         $this->assertArrayHasKey('floatNum', $ext->toArray());
         $this->assertArrayHasKey('createdAt', $ext->toArray());
+        $this->assertIsString($ext->updatedAt);
+        $this->assertIsString($ext->toArray()['updatedAt']);
 
         $this->assertIsString($number = $ext->floatNum);
 
@@ -131,7 +133,7 @@ class ModelRealBuilderTest extends TestCase
         $this->assertSame($ext->floatNum, $model->floatNum);
 
         $model->fill([
-            'floatNum' => '1.20'
+            'floatNum' => '1.20',
         ]);
         $model->save();
 

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -16,6 +16,7 @@ use Hyperf\Database\Events\QueryExecuted;
 use Hyperf\Database\Model\Events\Saved;
 use HyperfTest\Database\Stubs\ContainerStub;
 use HyperfTest\Database\Stubs\Model\User;
+use HyperfTest\Database\Stubs\Model\UserExtCamel;
 use HyperfTest\Database\Stubs\Model\UserRole;
 use HyperfTest\Database\Stubs\Model\UserRolePivot;
 use Mockery;
@@ -109,6 +110,40 @@ class ModelRealBuilderTest extends TestCase
         while ($event = $this->channel->pop(0.001)) {
             if ($event instanceof QueryExecuted) {
                 $this->assertSame([$event->sql, $event->bindings], array_shift($sqls));
+            }
+        }
+    }
+
+    public function testCamelCaseGetModel()
+    {
+        $this->getContainer();
+
+        /** @var UserExtCamel $ext */
+        $ext = UserExtCamel::query()->find(1);
+        $this->assertArrayHasKey('floatNum', $ext->toArray());
+        $this->assertArrayHasKey('createdAt', $ext->toArray());
+
+        $this->assertIsString($number = $ext->floatNum);
+
+        $ext->increment('float_num', 1);
+
+        $model = UserExtCamel::query()->find(1);
+        $this->assertSame($ext->floatNum, $model->floatNum);
+
+        $model->fill([
+            'floatNum' => '1.20'
+        ]);
+        $model->save();
+
+        $sqls = [
+            'select * from `user_ext` where `user_ext`.`id` = ? limit 1',
+            'update `user_ext` set `float_num` = `float_num` + 1, `user_ext`.`updated_at` = ? where `id` = ?',
+            'select * from `user_ext` where `user_ext`.`id` = ? limit 1',
+            'update `user_ext` set `float_num` = ?, `user_ext`.`updated_at` = ? where `id` = ?',
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame($event->sql, array_shift($sqls));
             }
         }
     }

--- a/src/database/tests/Stubs/Model/UserExtCamel.php
+++ b/src/database/tests/Stubs/Model/UserExtCamel.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database\Stubs\Model;
+
+use Hyperf\Database\Model\Concerns\CamelCase;
+
+/**
+ * @property int $id
+ * @property int $count
+ * @property string $floatNum
+ * @property string $str
+ * @property string $json
+ * @property \Carbon\Carbon $createdAt
+ * @property \Carbon\Carbon $updatedAt
+ */
+class UserExtCamel extends Model
+{
+    use CamelCase;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'user_ext';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['id', 'count', 'float_num', 'str', 'json', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = ['id' => 'integer', 'count' => 'integer', 'float_num' => 'decimal:2', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+}

--- a/src/database/tests/Stubs/Model/UserExtCamel.php
+++ b/src/database/tests/Stubs/Model/UserExtCamel.php
@@ -46,4 +46,9 @@ class UserExtCamel extends Model
      * @var array
      */
     protected $casts = ['id' => 'integer', 'count' => 'integer', 'float_num' => 'decimal:2', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    public function getUpdatedAtAttribute(): string
+    {
+        return (string) $this->getAttributes()['updated_at'];
+    }
 }


### PR DESCRIPTION
当 model 里使用 use CamelCase;  同时自定义一个 访问器： getXxxAttribute 的时候，查询结果再 toArray ，其中的 Xxx 属性值没有被改变。

原因： use CamelCase;  里重写了方法 addMutatedAttributesToArray ， 而这个方法判断的时候把 key 都转成了驼峰，导致 array_key_exists 始终为 false，也就是看起来这个函数没有用了。

