### PR TITLE
Added `column_type` for `MySqlGrammar::compileColumnListing`.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # v2.0.12 - TBD
 
+## Added
+
+- [#2512](https://github.com/hyperf/hyperf/pull/2512) Added `column_type` for `MySqlGrammar::compileColumnListing`.
+
 # v2.0.11 - 2020-09-14
 
 ## Added

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -228,9 +228,6 @@ class ModelCommand extends Command
 
         foreach ($columns as $key => $value) {
             $columns[$key]['cast'] = $casts[$value['column_name']] ?? null;
-            if ($value['column_type'] == 'tinyint(1)') {
-                $columns[$key]['data_type'] = 'boolean';
-            }
         }
 
         return $columns;

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -228,6 +228,9 @@ class ModelCommand extends Command
 
         foreach ($columns as $key => $value) {
             $columns[$key]['cast'] = $casts[$value['column_name']] ?? null;
+            if ($value['column_type'] == 'tinyint(1)') {
+                $columns[$key]['data_type'] = 'boolean';
+            }
         }
 
         return $columns;

--- a/src/database/src/Schema/Grammars/MySqlGrammar.php
+++ b/src/database/src/Schema/Grammars/MySqlGrammar.php
@@ -49,7 +49,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumnListing(): string
     {
-        return 'select `column_key`, `column_name`, `data_type`, `column_comment`, `extra` from information_schema.columns where `table_schema` = ? and `table_name` = ? order by ORDINAL_POSITION';
+        return 'select `column_key`, `column_name`, `data_type`, `column_comment`, `extra`, `column_type` from information_schema.columns where `table_schema` = ? and `table_name` = ? order by ORDINAL_POSITION';
     }
 
     /**
@@ -57,7 +57,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumns(): string
     {
-        return 'select `table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `column_comment` from information_schema.columns where `table_schema` = ? order by ORDINAL_POSITION';
+        return 'select `table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `column_comment`, `column_type` from information_schema.columns where `table_schema` = ? order by ORDINAL_POSITION';
     }
 
     /**

--- a/src/database/src/Schema/Grammars/MySqlGrammar.php
+++ b/src/database/src/Schema/Grammars/MySqlGrammar.php
@@ -57,7 +57,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumns(): string
     {
-        return 'select `table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `column_comment`, `column_type` from information_schema.columns where `table_schema` = ? order by ORDINAL_POSITION';
+        return 'select `table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `column_comment` from information_schema.columns where `table_schema` = ? order by ORDINAL_POSITION';
     }
 
     /**


### PR DESCRIPTION
优化创建模型的命令 增加mysql的column_type字段获取布尔类型tinyint(1)字段 转boolean类型