### PR TITLE
request->all() 没有获取上传的文件数组，导致 validation验证不通过

### DIFF
--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -121,7 +121,8 @@ class Request implements RequestInterface
     public function all(): array
     {
         $data = $this->getInputData();
-        return $data ?? [];
+        $files = $this->getUploadedFiles();
+        return array_replace_recursive($data ?? [],$files);
     }
 
     /**

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -78,6 +78,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['id' => 1]);
         $psrRequest->shouldReceive('getQueryParams')->andReturn(['name' => 'Hyperf']);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
 
         $psrRequest = new Request();

--- a/src/super-globals/tests/ProxyTest.php
+++ b/src/super-globals/tests/ProxyTest.php
@@ -98,6 +98,7 @@ class ProxyTest extends TestCase
         $request->shouldReceive('getParsedBody')->andReturn([
             'name' => $name = 'Hyperf' . uniqid(),
         ]);
+        $request->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $request);
         $proxy = new Request();
 

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -139,7 +139,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function validationData(): array
     {
-        return array_merge_recursive($this->all(), $this->getUploadedFiles());
+        return $this->all();
     }
 
     /**


### PR DESCRIPTION
在 hyperf 里 request->all() 函数获取的是 getInputData 进一步查看定义是整合了 post 和 get 数据，但是没有 files 数据

测试代码：（参考 hyperf官方文档 ： https://hyperf.wiki/2.0/#/zh-cn/validation?id=%e6%89%8b%e5%8a%a8%e5%88%9b%e5%bb%ba%e9%aa%8c%e8%af%81%e5%99%a8）
controller里：

```
public function upload(RequestInterface $request)
{
	$validator = $this->validationFactory->make(
		$request->all(),
		[
			'type' => 'required|string',
			'file' => 'required|file',
		]
	);

	$errorMessage = 'no error';
	if ($validator->fails()) {
		$errorMessage = $validator->errors()->first();
		var_dump('error');
		var_dump($errorMessage);
	}

	$type = $request->input('type','image');
	$file = $request->file('file');

	var_dump('result');
	var_dump($request->all());
	var_dump($file);
	return $errorMessage;
}
```
curl 结果参考：

```
root@docker:/tmp# curl -v "http://127.0.0.1:9501/adminapi/upload" --form 'type=image' --form 'file=@/tmp/1.jpg'
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 9501 (#0)
> POST /adminapi/upload HTTP/1.1
> Host: 127.0.0.1:9501
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Length: 281
> Expect: 100-continue
> Content-Type: multipart/form-data; boundary=------------------------baaa01ed9c1bf3bf
>
* Done waiting for 100-continue
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: DNT,Keep-Alive,User-Agent,Cache-Control,Content-Type,Authorization
< Content-Type: text/plain
< Server: Hyperf
< Connection: keep-alive
< Date: Thu, 17 Sep 2020 02:17:29 GMT
< Content-Length: 23
<
* Connection #0 to host 127.0.0.1 left intact
file 字段是必须的root@docker:/tmp#

```
控制台输出结果：(file 能获取到，但是 验证的地方不通过)

```
/hyperf-skeleton/xxxx/AdminapiController.php:115:
string(5) "error"
/hyperf-skeleton/xxxx/AdminapiController.php:116:
string(23) "file 字段是必须的"
/hyperf-skeleton/xxxx/AdminapiController.php:122:
string(6) "result"
/hyperf-skeleton/xxxx/AdminapiController.php:123:
array(1) {
  'type' =>
  string(5) "image"
}
/hyperf-skeleton/xxxx/AdminapiController.php:124:
class Hyperf\HttpMessage\Upload\UploadedFile#1686 (9) {
  private $clientFilename =>
  string(5) "1.jpg"
  private $clientMediaType =>
  string(10) "image/jpeg"
  private $error =>
  int(0)
  private $tmpFile =>
  string(25) "/tmp/swoole.upfile.CNOBbk"
  private $moved =>
  bool(false)
  private $size =>
  int(0)
  private $mimeType =>
  NULL
  private $pathName =>
  string(25) "/tmp/swoole.upfile.CNOBbk"
  private $fileName =>
  string(20) "swoole.upfile.CNOBbk"
}

```

所以参考 laravel 的 request->all()

```
 public function all($keys = null)
    {
        $input = array_replace_recursive($this->input(), $this->allFiles());

        if (! $keys) {
            return $input;
        }

        $results = [];

        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
            Arr::set($results, $key, Arr::get($input, $key));
        }

        return $results;
    }
```
做出了类似修改。看下是否可行~
