### PR TITLE
Fixed `@property` of mutated attribute will be replaced by morphTo for `gen:model`.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 ## Fixed
 
 - [#2509](https://github.com/hyperf/hyperf/pull/2509) Fixed mutated attributes do not work in camel case for `hyperf/database`.
+- [#2535](https://github.com/hyperf/hyperf/pull/2535) Fixed `@property` of mutated attribute will be replaced by morphTo for `gen:model`.
 
 # v2.0.11 - 2020-09-14
 

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -211,7 +211,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
                 $name = Str::snake(substr($method->getName(), 3, -9));
                 if (! empty($name)) {
                     $type = BetterReflectionManager::getReturnFinder()->__invoke($method, $namespace);
-                    $this->setProperty($name, $type, true, null);
+                    $this->setProperty($name, $type, true, null,'',false,1);
                 }
                 continue;
             }
@@ -298,7 +298,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
         }
     }
 
-    protected function setProperty(string $name, array $type = null, bool $read = null, bool $write = null, string $comment = '', bool $nullable = false)
+    protected function setProperty(string $name, array $type = null, bool $read = null, bool $write = null, string $comment = '', bool $nullable = false,int $priority = 0)
     {
         if (! isset($this->properties[$name])) {
             $this->properties[$name] = [];
@@ -306,6 +306,10 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
             $this->properties[$name]['read'] = false;
             $this->properties[$name]['write'] = false;
             $this->properties[$name]['comment'] = (string) $comment;
+            $this->properties[$name]['priority'] = 0;
+        }
+        if($this->properties[$name]['priority'] > $priority) {
+            return;
         }
         if ($type !== null) {
             if ($nullable) {
@@ -319,6 +323,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
         if ($write !== null) {
             $this->properties[$name]['write'] = $write;
         }
+        $this->properties[$name]['priority'] = $priority;
     }
 
     protected function setMethod(string $name, array $type = [], array $arguments = [])

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -211,7 +211,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
                 $name = Str::snake(substr($method->getName(), 3, -9));
                 if (! empty($name)) {
                     $type = BetterReflectionManager::getReturnFinder()->__invoke($method, $namespace);
-                    $this->setProperty($name, $type, true, null,'',false,1);
+                    $this->setProperty($name, $type, true, null, '', false, 1);
                 }
                 continue;
             }
@@ -298,7 +298,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
         }
     }
 
-    protected function setProperty(string $name, array $type = null, bool $read = null, bool $write = null, string $comment = '', bool $nullable = false,int $priority = 0)
+    protected function setProperty(string $name, array $type = null, bool $read = null, bool $write = null, string $comment = '', bool $nullable = false, int $priority = 0)
     {
         if (! isset($this->properties[$name])) {
             $this->properties[$name] = [];
@@ -308,7 +308,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
             $this->properties[$name]['comment'] = (string) $comment;
             $this->properties[$name]['priority'] = 0;
         }
-        if($this->properties[$name]['priority'] > $priority) {
+        if ($this->properties[$name]['priority'] > $priority) {
             return;
         }
         if ($type !== null) {


### PR DESCRIPTION
```php
<?php
namespace App\Model;
use Hyperf\Database\Model\Relations\MorphTo;
use Hyperf\DbConnection\Model\Model;
/**
 * Class Comment
 * @package App\Model
 * 这是期望出现的属性注释
 * @property-read \App\Model\User|\App\Model\Admin|\App\Model\Guest|\App\Model\Member $creator 这是期望出现的属性注释
 * 这是出现的属性注解(getAttribute / morphTo 谁排序到后面，就会覆盖前者的注释，getAttribute 优先级应该比 morphTo 高)
 * @property-read \Hyperf\Database\Model\Model $creator
 */
class Comment extends Model
{
    /**
     * @return MorphTo
     */
    public function creator() :MorphTo
    {
        return $this->morphTo();
    }

    /**
     * @return User | Admin | Guest | Member
     */
    public function getCreatorAttribute()
    {
        return $this->loadMissing('creator')->getAttribute('creator');
    }
}
```
gen:model 命令生成的model注释，可能会覆盖，Model->getAttribute的魔法方法应该是最高优先级
