### PR TITLE
当value为空时字符串空

### DIFF
--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -981,7 +981,7 @@ trait HasAttributes
     {
         $castType = $this->getCastType($key);
 
-        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
+        if (empty($value) && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 


### PR DESCRIPTION
在模型
```
protected $casts = [
'id' => 'integer',
'created_at' => 'datetime:Y-m-d H:i:s',
'updated_at' => 'datetime:Y-m-d H:i:s',
'deleted_at' => 'datetime:Y-m-d H:i:s',
];
```
数据库记录为 null,
findFromCache($id)->toArray();
从cache返回的字段值为字符串 空 '',
此处代码 未处理当字段为字符串空时。会造成以下错误
```
[ERROR] Data missing[640] in /opt/www/cms/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php
[ERROR] #0 /opt/www/cms/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php(663): Carbon\Carbon::rawCreateFromFormat('U', NULL, NULL)
#1 /opt/www/cms/vendor/hyperf/database/src/Model/Concerns/HasAttributes.php(1286): Carbon\Carbon::createFromFormat('U', '')
#2 /opt/www/cms/vendor/hyperf/database/src/Model/Concerns/HasAttributes.php(1014): Hyperf\Database\Model\Model->asDateTime('')
#3 /opt/www/cms/vendor/hyperf/database/src/Model/Concerns/HasAttributes.php(827): Hyperf\Database\Model\Model->castAttribute('deleted_at', '')
#4 /opt/www/cms/vendor/hyperf/database/src/Model/Concerns/HasAttributes.php(150): Hyperf\Database\Model\Model->addCastAttributesToArray(Array, Array)
#5 /opt/www/cms/vendor/hyperf/database/src/Model/Model.php(821): Hyperf\Database\Model\Model->attributesToArray()
#6 /opt/www/cms/runtime/container/proxy/App_Controller_Admin_ConfigController.proxy.php(756): Hyperf\Database\Model\Model->toArray()
#7 /opt/www/cms/vendor/hyperf/http-server/src/CoreMiddleware.php(161): App\Controller\Admin\ConfigController->rolePut()
#8 /opt/www/cms/vendor/hyperf/http-server/src/CoreMiddleware.php(113): Hyperf\HttpServer\CoreMiddleware->handleFound(Object(Hyperf\HttpServer\Router\Dispatched), Object(Hyperf\HttpMessage\Server\Request))
#9 /opt/www/cms/vendor/hyperf/dispatcher/src/AbstractRequestHandler.php(65): Hyperf\HttpServer\CoreMiddleware->process(Object(Hyperf\HttpMessage\Server\Request), Object(Hyperf\Dispatcher\HttpRequestHandler))
```