### PR TITLE
feat: add context switch event

### DIFF
--- a/src/utils/src/Event/ContextSwitchEvent.php
+++ b/src/utils/src/Event/ContextSwitchEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Utils\Event;
+
+class ContextSwitchEvent
+{
+}


### PR DESCRIPTION
主要用途：传递协程上下文信息。

用户故事：

一个接口，需要并行请求两个api然后进行数据合并。因为新启动了两个协程，因此丢失上下文信息，无法分布式追踪。

加入这个事件后，可以主动复制tracer.root到子协程。