### PR TITLE
Fixed proxy class generate keyword `parent::class` but the class scope has on parent.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - [#2559](https://github.com/hyperf/hyperf/pull/2559) Fixed the event does not works which caused by connecting with `query` for socketio-server.
 - [#2561](https://github.com/hyperf/hyperf/pull/2561) Optimized error message when close amqp connection failed.
+- [#2565](https://github.com/hyperf/hyperf/pull/2565) Fixed proxy class generate keyword `parent::class` but the class scope has on parent.
 
 # v2.0.12 - 2020-09-21
 

--- a/src/di/src/Aop/PropertyHandlerVisitor.php
+++ b/src/di/src/Aop/PropertyHandlerVisitor.php
@@ -41,8 +41,12 @@ class PropertyHandlerVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\Class_) {
-            if ($node->extends) {
-                $this->visitorMetadata->hasExtends = true;
+            if ($this->visitorMetadata->hasExtends === null) {
+                if ($node->extends) {
+                    $this->visitorMetadata->hasExtends = true;
+                } else {
+                    $this->visitorMetadata->hasExtends = false;
+                }
             }
         }
         if ($node instanceof Node\Stmt\ClassMethod) {

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -17,6 +17,7 @@ use HyperfTest\Di\Stub\AspectCollector;
 use HyperfTest\Di\Stub\Ast\Bar2;
 use HyperfTest\Di\Stub\Ast\Bar3;
 use HyperfTest\Di\Stub\Ast\Bar4;
+use HyperfTest\Di\Stub\Ast\Bar5;
 use HyperfTest\Di\Stub\Ast\BarAspect;
 use HyperfTest\Di\Stub\Ast\BarInterface;
 use HyperfTest\Di\Stub\Ast\Foo;
@@ -88,6 +89,33 @@ class Bar2 extends Bar
     public static function build()
     {
         return parent::$items;
+    }
+}', $code);
+    }
+
+    public function testParentConstructor()
+    {
+        BetterReflectionManager::initClassReflector([__DIR__ . '/Stub']);
+
+        $ast = new Ast();
+        $code = $ast->proxy(Bar5::class);
+        $this->assertEquals($this->license . '
+namespace HyperfTest\Di\Stub\Ast;
+
+class Bar5
+{
+    use \Hyperf\Di\Aop\ProxyTrait;
+    use \Hyperf\Di\Aop\PropertyHandlerTrait;
+    public function getBar() : Bar
+    {
+        return new class extends Bar
+        {
+            public function __construct()
+            {
+                self::__handlePropertyHandler(__CLASS__);
+                $this->id = 9501;
+            }
+        };
     }
 }', $code);
     }

--- a/src/di/tests/Stub/Ast/Bar5.php
+++ b/src/di/tests/Stub/Ast/Bar5.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Di\Stub\Ast;
+
+class Bar5
+{
+    public function getBar(): Bar
+    {
+        return new class() extends Bar {
+            public function __construct()
+            {
+                $this->id = 9501;
+            }
+        };
+    }
+}


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/2560