### PR TITLE
Fixed event `AfterProcessHandle` won't be dispatched when throw exception in process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_script:
 script:
   - composer analyse src
   - composer test -- --exclude-group NonCoroutine
+  - composer test src/guzzle -- --exclude-group NonCoroutine
   - vendor/bin/phpunit --group NonCoroutine
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ before_script:
 
 script:
   - composer analyse src
-  - composer test -- --exclude-group NonCoroutine
-  - composer test src/guzzle -- --exclude-group NonCoroutine
+  - composer test -- --exclude-group NonCoroutine --exclude-group NonAsyncIO
+  - composer test -- --group NonAsyncIO
   - vendor/bin/phpunit --group NonCoroutine
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ before_script:
 
 script:
   - composer analyse src
-  - composer test -- --exclude-group NonCoroutine --exclude-group NonAsyncIO
-  - composer test -- --group NonAsyncIO
+  - composer test -- --exclude-group NonCoroutine
   - vendor/bin/phpunit --group NonCoroutine
 
 notifications:

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - [#2559](https://github.com/hyperf/hyperf/pull/2559) Fixed the event does not works which caused by connecting with `query` for socketio-server.
 - [#2561](https://github.com/hyperf/hyperf/pull/2561) Optimized error message when close amqp connection failed.
 - [#2565](https://github.com/hyperf/hyperf/pull/2565) Fixed proxy class generate keyword `parent::class` but the class scope has on parent.
+- [#2578](https://github.com/hyperf/hyperf/pull/2578) Fixed event `AfterProcessHandle` won't be dispatched when throw exception in process.
 
 # v2.0.12 - 2020-09-21
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,7 @@
             <directory suffix="Test.php">./src/framework/tests</directory>
             <directory suffix="Test.php">./src/grpc-client/tests</directory>
             <directory suffix="Test.php">./src/grpc-server/tests</directory>
+            <directory suffix="Test.php">./src/guzzle/tests</directory>
             <directory suffix="Test.php">./src/http-message/tests</directory>
             <directory suffix="Test.php">./src/http-server/tests</directory>
             <directory suffix="Test.php">./src/json-rpc/tests</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,7 +31,6 @@
             <directory suffix="Test.php">./src/framework/tests</directory>
             <directory suffix="Test.php">./src/grpc-client/tests</directory>
             <directory suffix="Test.php">./src/grpc-server/tests</directory>
-            <directory suffix="Test.php">./src/guzzle/tests</directory>
             <directory suffix="Test.php">./src/http-message/tests</directory>
             <directory suffix="Test.php">./src/http-server/tests</directory>
             <directory suffix="Test.php">./src/json-rpc/tests</directory>
@@ -40,6 +39,7 @@
             <directory suffix="Test.php">./src/model-cache/tests</directory>
             <directory suffix="Test.php">./src/paginator/tests</directory>
             <directory suffix="Test.php">./src/pool/tests</directory>
+            <directory suffix="Test.php">./src/process/tests</directory>
             <directory suffix="Test.php">./src/protocol/tests</directory>
             <directory suffix="Test.php">./src/rate-limit/tests</directory>
             <directory suffix="Test.php">./src/redis/tests</directory>

--- a/src/process/src/AbstractProcess.php
+++ b/src/process/src/AbstractProcess.php
@@ -132,11 +132,10 @@ abstract class AbstractProcess implements ProcessInterface
                         $this->listen($quit);
                     }
                     $this->handle();
-
-                    $this->event && $this->event->dispatch(new AfterProcessHandle($this, $i));
                 } catch (\Throwable $throwable) {
                     $this->logThrowable($throwable);
                 } finally {
+                    $this->event && $this->event->dispatch(new AfterProcessHandle($this, $i));
                     if (isset($quit)) {
                         $quit->push(true);
                     }

--- a/src/process/tests/BootProcessListenerTest.php
+++ b/src/process/tests/BootProcessListenerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Process;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Di\Annotation\AnnotationCollector;
+use Hyperf\Process\Annotation\Process;
+use Hyperf\Process\Listener\BootProcessListener;
+use HyperfTest\Process\Stub\FooProcess;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class BootProcessListenerTest extends TestCase
+{
+    protected function tearDown()
+    {
+        Mockery::close();
+        AnnotationCollector::clear();
+    }
+
+    public function testGetAnnotationProcesses()
+    {
+        $annotation = new Process([
+            'name' => 'foo',
+        ]);
+        $annotation->collectClass(FooProcess::class);
+        $listener = new BootProcessListener(Mockery::mock(ContainerInterface::class), Mockery::mock(ConfigInterface::class));
+        $ref = new \ReflectionClass($listener);
+        $method = $ref->getMethod('getAnnotationProcesses');
+        $method->setAccessible(true);
+        $res = $method->invoke($listener);
+        foreach ($res as $class => $annotation) {
+            $this->assertSame(FooProcess::class, $class);
+            $this->assertInstanceOf(Process::class, $annotation);
+        }
+    }
+}

--- a/src/process/tests/ProcessTest.php
+++ b/src/process/tests/ProcessTest.php
@@ -35,7 +35,7 @@ class ProcessTest extends TestCase
     }
 
     /**
-     * @group NonAsyncIO
+     * @group NonCoroutine
      */
     public function testEventWhenThrowExceptionInProcess()
     {

--- a/src/process/tests/ProcessTest.php
+++ b/src/process/tests/ProcessTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Process;
+
+use Hyperf\Process\Event\AfterProcessHandle;
+use Hyperf\Process\Event\BeforeProcessHandle;
+use Hyperf\Utils\ApplicationContext;
+use HyperfTest\Process\Stub\FooProcess;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ProcessTest extends TestCase
+{
+    public static $dispatched = [];
+
+    protected function tearDown()
+    {
+        Mockery::close();
+        self::$dispatched = [];
+    }
+
+    public function testEventWhenThrowExceptionInProcess()
+    {
+        $container = $this->getContainer();
+        $process = new FooProcess($container);
+        $process->bind($this->getServer());
+
+        $this->assertInstanceOf(BeforeProcessHandle::class, self::$dispatched[0]);
+        $this->assertInstanceOf(AfterProcessHandle::class, self::$dispatched[1]);
+    }
+
+    protected function getContainer()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+
+        $container->shouldReceive('has')->with(EventDispatcherInterface::class)->andReturn(true);
+        $container->shouldReceive('get')->with(EventDispatcherInterface::class)->andReturnUsing(function () {
+            $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+            $dispatcher->shouldReceive('dispatch')->withAnyArgs()->andReturnUsing(function ($event) {
+                self::$dispatched[] = $event;
+            });
+            return $dispatcher;
+        });
+
+        return $container;
+    }
+
+    protected function getServer()
+    {
+        $server = Mockery::mock(\Swoole\Server::class);
+        $server->shouldReceive('addProcess')->withAnyArgs()->andReturnUsing(function ($process) {
+            $ref = new \ReflectionClass($process);
+            $property = $ref->getProperty('callback');
+            $property->setAccessible(true);
+            $callback = $property->getValue($process);
+            $callback($process);
+        });
+        return $server;
+    }
+}

--- a/src/process/tests/ProcessTest.php
+++ b/src/process/tests/ProcessTest.php
@@ -34,6 +34,9 @@ class ProcessTest extends TestCase
         self::$dispatched = [];
     }
 
+    /**
+     * @group NonAsyncIO
+     */
     public function testEventWhenThrowExceptionInProcess()
     {
         $container = $this->getContainer();

--- a/src/process/tests/Stub/FooProcess.php
+++ b/src/process/tests/Stub/FooProcess.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Process\Stub;
+
+use Hyperf\Process\AbstractProcess;
+
+class FooProcess extends AbstractProcess
+{
+    public $enableCoroutine = false;
+
+    public $restartInterval = 0;
+
+    public static $handled = false;
+
+    public function handle(): void
+    {
+        static::$handled = true;
+    }
+}


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/2577