### PR TITLE
Fixed bug that `RedisSecondMetaGenerator` will generate the same meta.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # v2.0.15 - TBD
 
+## Fixed
+
+- [#2634](https://github.com/hyperf/hyperf/pull/2634) Fixed bug that `RedisSecondMetaGenerator` will generate the same meta.
+
 # v2.0.14 - 2020-10-12
 
 ## Added

--- a/src/snowflake/src/MetaGenerator/RedisSecondMetaGenerator.php
+++ b/src/snowflake/src/MetaGenerator/RedisSecondMetaGenerator.php
@@ -28,10 +28,12 @@ class RedisSecondMetaGenerator extends RedisMetaGenerator
 
     public function getNextTimestamp(): int
     {
-        return $this->lastTimestamp + 1;
-    }
+        $timestamp = $this->getTimestamp();
+        while ($timestamp <= $this->lastTimestamp) {
+            usleep(1000);
+            $timestamp = $this->getTimestamp();
+        }
 
-    protected function clockMovedBackwards($timestamp, $lastTimestamp)
-    {
+        return $timestamp;
     }
 }

--- a/src/snowflake/tests/RedisMetaGeneratorTest.php
+++ b/src/snowflake/tests/RedisMetaGeneratorTest.php
@@ -137,6 +137,19 @@ class RedisMetaGeneratorTest extends TestCase
         $this->assertSame($meta->getWorkerId(), $userId % 31);
     }
 
+    public function testGetNextTimestamp()
+    {
+        $container = $this->getContainer();
+        $hConfig = $container->get(ConfigInterface::class);
+        $config = new SnowflakeConfig();
+        $metaGenerator = new RedisSecondMetaGenerator($config, MetaGeneratorInterface::DEFAULT_BEGIN_SECOND, $hConfig);
+
+        $time = $metaGenerator->getTimestamp();
+        $nextTime = $metaGenerator->getNextTimestamp();
+        $this->assertSame($time + 1, $nextTime);
+        $this->assertSame(time(), $nextTime);
+    }
+
     protected function getContainer()
     {
         $config = new Config([


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/2622