### PR TITLE
fix: broken interface binding in retry annotation

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -12,7 +12,7 @@
 
 - [#2594](https://github.com/hyperf/hyperf/pull/2594) Fixed crontab does not stops when using signal.
 - [#2601](https://github.com/hyperf/hyperf/pull/2601) Fixed `@property` will be replaced by `@property-read` when the property has `getter` and `setter` at the same time.
-- [#2607](https://github.com/hyperf/hyperf/pull/2607) Fixed memory leak in `RetryAnnotationAspect`.
+- [#2607](https://github.com/hyperf/hyperf/pull/2607) [#2637](https://github.com/hyperf/hyperf/pull/2637) Fixed memory leak in `RetryAnnotationAspect`.
 - [#2624](https://github.com/hyperf/hyperf/pull/2624) Fixed http client does not works when using guzzle 7.0 and curl hook for `hyperf/testing`.
 - [#2632](https://github.com/hyperf/hyperf/pull/2632) [#2635](https://github.com/hyperf/hyperf/pull/2635) Fixed redis cluster does not support password.
 

--- a/docs/zh-cn/changelog.md
+++ b/docs/zh-cn/changelog.md
@@ -12,7 +12,7 @@
 
 - [#2594](https://github.com/hyperf/hyperf/pull/2594) 修复 `hyperf/crontab` 组件因为无法正常响应 `hyperf/signal`，导致无法停止的问题。
 - [#2601](https://github.com/hyperf/hyperf/pull/2601) 修复命令 `gen:model` 因为 `getter` 和 `setter` 同时存在时，注释 `@property` 会被 `@property-read` 覆盖的问题。
-- [#2607](https://github.com/hyperf/hyperf/pull/2607) 修复使用 `RetryAnnotationAspect` 时，会有一定程度内存泄露的问题。
+- [#2607](https://github.com/hyperf/hyperf/pull/2607) [#2637](https://github.com/hyperf/hyperf/pull/2637) 修复使用 `RetryAnnotationAspect` 时，会有一定程度内存泄露的问题。
 - [#2624](https://github.com/hyperf/hyperf/pull/2624) 修复组件 `hyperf/testing` 因使用了 `guzzle 7.0` 和 `CURL HOOK` 导致无法正常工作的问题。
 - [#2632](https://github.com/hyperf/hyperf/pull/2632) [#2635](https://github.com/hyperf/hyperf/pull/2635) 修复 `hyperf\redis` 组件集群模式，无法设置密码的问题。
 

--- a/src/retry/src/Annotation/Retry.php
+++ b/src/retry/src/Annotation/Retry.php
@@ -17,7 +17,7 @@ use Hyperf\Retry\Policy\ClassifierRetryPolicy;
 use Hyperf\Retry\Policy\FallbackRetryPolicy;
 use Hyperf\Retry\Policy\MaxAttemptsRetryPolicy;
 use Hyperf\Retry\Policy\SleepRetryPolicy;
-use Hyperf\Retry\RetryBudgetInterface;
+use Hyperf\Retry\RetryBudget;
 use Hyperf\Retry\SleepStrategyInterface;
 
 /**
@@ -115,6 +115,6 @@ class Retry extends AbstractRetry
     public function __construct($value = null)
     {
         parent::__construct($value);
-        $this->retryBudget = make(RetryBudgetInterface::class, $this->retryBudget);
+        $this->retryBudget = make(RetryBudget::class, $this->retryBudget);
     }
 }

--- a/src/retry/src/Annotation/Retry.php
+++ b/src/retry/src/Annotation/Retry.php
@@ -18,6 +18,7 @@ use Hyperf\Retry\Policy\FallbackRetryPolicy;
 use Hyperf\Retry\Policy\MaxAttemptsRetryPolicy;
 use Hyperf\Retry\Policy\SleepRetryPolicy;
 use Hyperf\Retry\RetryBudget;
+use Hyperf\Retry\RetryBudgetInterface;
 use Hyperf\Retry\SleepStrategyInterface;
 
 /**

--- a/src/retry/tests/RetryAnnotationAspectTest.php
+++ b/src/retry/tests/RetryAnnotationAspectTest.php
@@ -27,6 +27,7 @@ use Hyperf\Retry\BackoffStrategy;
 use Hyperf\Retry\FlatStrategy;
 use Hyperf\Retry\NoOpRetryBudget;
 use Hyperf\Retry\Policy\TimeoutRetryPolicy;
+use Hyperf\Retry\RetryBudget;
 use Hyperf\Retry\RetryBudgetInterface;
 use Hyperf\Utils\ApplicationContext;
 use HyperfTest\Retry\Stub\Foo;

--- a/src/retry/tests/RetryAnnotationAspectTest.php
+++ b/src/retry/tests/RetryAnnotationAspectTest.php
@@ -45,6 +45,7 @@ class RetryAnnotationAspectTest extends TestCase
     {
         $container = new Container(new DefinitionSource([
             RetryBudgetInterface::class => NoOpRetryBudget::class,
+            RetryBudget::class => NoOpRetryBudget::class,
             SleepStrategyInterface::class => flatStrategy::class,
         ], new ScanConfig()));
         ApplicationContext::setContainer($container);


### PR DESCRIPTION
 Di interface bindings are not available at the time of annotation parsing.