### PR TITLE
Fixed unexpected behavior in retry budget for `hyperf/retry`.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,7 +8,7 @@
 
 - [#2680](https://github.com/hyperf/hyperf/pull/2680) Fixed Type error for `CastsValue`, because `$isSynchronized` don't have default value.
 - [#2680](https://github.com/hyperf/hyperf/pull/2680) Fixed default value in `$items` will be replaced by `__construct` for `CastsValue`.
-- [#2693](https://github.com/hyperf/hyperf/pull/2693) Fixed the wrong overflow algorithm of budget for `hyperf/retry`.
+- [#2693](https://github.com/hyperf/hyperf/pull/2693) Fixed unexpected behavior in retry budget for `hyperf/retry`.
 
 ## Optimized
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,6 +8,7 @@
 
 - [#2680](https://github.com/hyperf/hyperf/pull/2680) Fixed Type error for `CastsValue`, because `$isSynchronized` don't have default value.
 - [#2680](https://github.com/hyperf/hyperf/pull/2680) Fixed default value in `$items` will be replaced by `__construct` for `CastsValue`.
+- [#2693](https://github.com/hyperf/hyperf/pull/2693) Fixed the wrong overflow algorithm of budget for `hyperf/retry`.
 
 ## Optimized
 

--- a/src/retry/src/RetryBudget.php
+++ b/src/retry/src/RetryBudget.php
@@ -42,11 +42,17 @@ class RetryBudget implements RetryBudgetInterface
      */
     private $timerId;
 
+    /**
+     * @var float|int
+     */
+    private $maxToken;
+
     public function __construct(int $ttl, int $minRetriesPerSec, float $percentCanRetry)
     {
         $this->ttl = $ttl;
         $this->minRetriesPerSec = $minRetriesPerSec;
         $this->percentCanRetry = $percentCanRetry;
+        $this->maxToken = ($this->minRetriesPerSec / $this->percentCanRetry) * $this->ttl;
         $this->budget = new SplQueue();
     }
 
@@ -102,6 +108,6 @@ class RetryBudget implements RetryBudgetInterface
     public function hasOverflown(): bool
     {
         return (! $this->budget->isEmpty() && $this->budget->bottom() <= microtime(true))
-            || $this->budget->count() > ($this->minRetriesPerSec / $this->percentCanRetry) * $this->ttl;
+            || $this->budget->count() > $this->maxToken;
     }
 }

--- a/src/retry/src/RetryBudget.php
+++ b/src/retry/src/RetryBudget.php
@@ -70,8 +70,8 @@ class RetryBudget implements RetryBudgetInterface
             for ($i = 0; $i < $this->minRetriesPerSec / $this->percentCanRetry; ++$i) {
                 $this->produce();
             }
-            while (! $this->budget->isEmpty()
-                && $this->budget->bottom() <= microtime(true)
+            while (
+                $this->hasOverflown()
             ) {
                 $this->budget->dequeue();
             }
@@ -97,5 +97,11 @@ class RetryBudget implements RetryBudgetInterface
     {
         $t = microtime(true) + $this->ttl;
         $this->budget->push($t);
+    }
+
+    public function hasOverflown(): bool
+    {
+        return (! $this->budget->isEmpty() && $this->budget->bottom() <= microtime(true))
+            || $this->budget->count() > ($this->minRetriesPerSec / $this->percentCanRetry) * $this->ttl;
     }
 }

--- a/src/retry/src/RetryBudget.php
+++ b/src/retry/src/RetryBudget.php
@@ -76,9 +76,7 @@ class RetryBudget implements RetryBudgetInterface
             for ($i = 0; $i < $this->minRetriesPerSec / $this->percentCanRetry; ++$i) {
                 $this->produce();
             }
-            while (
-                $this->hasOverflown()
-            ) {
+            while ($this->hasOverflown()) {
                 $this->budget->dequeue();
             }
         });

--- a/src/retry/src/RetryBudget.php
+++ b/src/retry/src/RetryBudget.php
@@ -71,7 +71,7 @@ class RetryBudget implements RetryBudgetInterface
                 $this->produce();
             }
             while (! $this->budget->isEmpty()
-                && $this->budget->top() <= microtime(true)
+                && $this->budget->bottom() <= microtime(true)
             ) {
                 $this->budget->dequeue();
             }

--- a/src/retry/tests/RetryBudgetTest.php
+++ b/src/retry/tests/RetryBudgetTest.php
@@ -68,5 +68,20 @@ class RetryBudgetTest extends TestCase
         $this->assertTrue($budget->consume());
         $this->assertTrue($budget->consume());
         $this->assertTrue(! $budget->consume());
+
+        // Retry budget should never has more than 1 token in this test
+        $budget = new RetryBudget(
+            1,
+            1,
+            1
+        );
+        $budget->init();
+        $ref = new \ReflectionClass(RetryBudget::class);
+        $prop = $ref->getProperty('budget');
+        $prop->setAccessible(true);
+        System::sleep(1.2);
+        $this->assertLessThanOrEqual(1, $prop->getValue($budget)->count());
+        System::sleep(1.2);
+        $this->assertLessThanOrEqual(1, $prop->getValue($budget)->count());
     }
 }

--- a/src/retry/tests/RetryBudgetTest.php
+++ b/src/retry/tests/RetryBudgetTest.php
@@ -69,7 +69,7 @@ class RetryBudgetTest extends TestCase
         $this->assertTrue($budget->consume());
         $this->assertTrue(! $budget->consume());
 
-        // Retry budget should never has more than 1 token in this test
+        // Retry budget should never have more than 1 token in this test
         $budget = new RetryBudget(
             1,
             1,


### PR DESCRIPTION
这个也是醉了 php splQueue里，top是从对队尾取，bottom是从队首取。

之前写反了，太迷惑了。