### PR TITLE
The methods with prefix `__` will not be registered into service for `rpc-server`.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,10 @@
 - [#2719](https://github.com/hyperf/hyperf/pull/2719) Fixed method `Arr::merge` does not works when `array1` does not constains the `$key`.
 - [#2723](https://github.com/hyperf/hyperf/pull/2723) Fixed `Paginator::resolveCurrentPath` deos not works.
 
+## Changed
+
+- [#2728](https://github.com/hyperf/hyperf/pull/2728) The methods with prefix `__` will not be registered into service for `rpc-server`.
+
 # v2.0.16 - 2020-10-26
 
 ## Added

--- a/composer.json
+++ b/composer.json
@@ -286,6 +286,7 @@
             "HyperfTest\\ResourceGrpc\\": "src/resource-grpc/tests/",
             "HyperfTest\\Resource\\": "src/resource/tests/",
             "HyperfTest\\Retry\\": "src/retry/tests/",
+            "HyperfTest\\RpcServer\\": "src/rpc-server/tests/",
             "HyperfTest\\Rpc\\": "src/rpc/tests/",
             "HyperfTest\\Scout\\": "src/scout/tests/",
             "HyperfTest\\Server\\": "src/server/tests/",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -46,6 +46,7 @@
             <directory suffix="Test.php">./src/redis/tests</directory>
             <directory suffix="Test.php">./src/retry/tests</directory>
             <directory suffix="Test.php">./src/rpc/tests</directory>
+            <directory suffix="Test.php">./src/rpc-server/tests</directory>
             <directory suffix="Test.php">./src/server/tests</directory>
             <directory suffix="Test.php">./src/service-governance/tests</directory>
             <directory suffix="Test.php">./src/session/tests</directory>

--- a/src/rpc-server/composer.json
+++ b/src/rpc-server/composer.json
@@ -37,6 +37,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "HyperfTest\\RpcServer\\": "tests/"
         }
     },
     "config": {

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -50,6 +50,10 @@ class DispatcherFactory
      * @var PathGeneratorInterface
      */
     private $pathGenerator;
+    /**
+     * @var string[] 
+     */
+    private $filterMethod = ['__construct'];
 
     public function __construct(EventDispatcherInterface $eventDispatcher, PathGeneratorInterface $pathGenerator)
     {
@@ -116,6 +120,9 @@ class DispatcherFactory
 
         foreach ($publicMethods as $reflectionMethod) {
             $methodName = $reflectionMethod->getName();
+            if (in_array($methodName, $this->filterMethod)) {
+                continue;
+            }
             $path = $this->pathGenerator->generate($prefix, $methodName);
             $router->addRoute($path, [
                 $className,

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -24,6 +24,7 @@ use Hyperf\HttpServer\MiddlewareManager;
 use Hyperf\Rpc\Contract\PathGeneratorInterface;
 use Hyperf\RpcServer\Annotation\RpcService;
 use Hyperf\RpcServer\Event\AfterPathRegister;
+use Hyperf\Utils\Str;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionMethod;
 
@@ -50,10 +51,6 @@ class DispatcherFactory
      * @var PathGeneratorInterface
      */
     private $pathGenerator;
-    /**
-     * @var string[] 
-     */
-    private $filterMethod = ['__construct'];
 
     public function __construct(EventDispatcherInterface $eventDispatcher, PathGeneratorInterface $pathGenerator)
     {
@@ -120,7 +117,7 @@ class DispatcherFactory
 
         foreach ($publicMethods as $reflectionMethod) {
             $methodName = $reflectionMethod->getName();
-            if (in_array($methodName, $this->filterMethod)) {
+            if (Str::startsWith($methodName, '__')) {
                 continue;
             }
             $path = $this->pathGenerator->generate($prefix, $methodName);

--- a/src/rpc-server/tests/RouterDispatcherFactoryTest.php
+++ b/src/rpc-server/tests/RouterDispatcherFactoryTest.php
@@ -11,7 +11,16 @@ declare(strict_types=1);
  */
 namespace HyperfTest\RpcServer;
 
+use Hyperf\Rpc\Contract\PathGeneratorInterface;
+use Hyperf\Rpc\PathGenerator\PathGenerator;
+use Hyperf\RpcServer\Annotation\RpcService;
+use Hyperf\RpcServer\Event\AfterPathRegister;
+use Hyperf\RpcServer\Router\DispatcherFactory;
+use HyperfTest\RpcServer\Stub\ContainerStub;
+use HyperfTest\RpcServer\Stub\IdGeneratorStub;
+use Mockery;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -19,8 +28,31 @@ use PHPUnit\Framework\TestCase;
  */
 class RouterDispatcherFactoryTest extends TestCase
 {
+    protected function tearDown()
+    {
+        Mockery::close();
+    }
+
     public function testHandleRpcService()
     {
-        $this->assertTrue(true);
+        $container = ContainerStub::getContainer();
+        $container->shouldReceive('get')->with(EventDispatcherInterface::class)->andReturnUsing(function () {
+            $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+            $dispatcher->shouldReceive('dispatch')->withAnyArgs()->once()->andReturnUsing(function ($object) {
+                $this->assertInstanceOf(AfterPathRegister::class, $object);
+                $this->assertSame('/id_generator_stub/generate', $object->path);
+                return $object;
+            });
+            return $dispatcher;
+        });
+        $container->shouldReceive('get')->with(PathGeneratorInterface::class)->andReturn(new PathGenerator());
+        $factory = new DispatcherFactory(
+            $container->get(EventDispatcherInterface::class),
+            $container->get(PathGeneratorInterface::class)
+        );
+        $ref = new \ReflectionClass($factory);
+        $m = $ref->getMethod('handleRpcService');
+        $m->setAccessible(true);
+        $m->invokeArgs($factory, [IdGeneratorStub::class, new RpcService('IdGenerator'), [], []]);
     }
 }

--- a/src/rpc-server/tests/RouterDispatcherFactoryTest.php
+++ b/src/rpc-server/tests/RouterDispatcherFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\RpcServer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class RouterDispatcherFactoryTest extends TestCase
+{
+    public function testHandleRpcService()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/src/rpc-server/tests/Stub/ContainerStub.php
+++ b/src/rpc-server/tests/Stub/ContainerStub.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\RpcServer\Stub;
+
+use Hyperf\Utils\ApplicationContext;
+use Mockery;
+use Psr\Container\ContainerInterface;
+
+class ContainerStub
+{
+    public static function getContainer()
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+
+        return $container;
+    }
+}

--- a/src/rpc-server/tests/Stub/IdGeneratorStub.php
+++ b/src/rpc-server/tests/Stub/IdGeneratorStub.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\RpcServer\Stub;
+
+class IdGeneratorStub
+{
+    /**
+     * @var string
+     */
+    public $prefix;
+
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    public function generate(): string
+    {
+        return uniqid();
+    }
+}


### PR DESCRIPTION
rpc register method filter __construct