### PR TITLE
rpc server filter __constructor method

### DIFF
--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -116,6 +116,9 @@ class DispatcherFactory
 
         foreach ($publicMethods as $reflectionMethod) {
             $methodName = $reflectionMethod->getName();
+            if (strtolower($methodName) == '__construct') {
+                continue;
+            }
             $path = $this->pathGenerator->generate($prefix, $methodName);
             $router->addRoute($path, [
                 $className,


### PR DESCRIPTION
注册rpc服务接口时，过滤掉服务类的构造方法