### PR TITLE
修复gen:model传多层路径时报错的bug

### DIFF
--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -171,6 +171,7 @@ class ModelCommand extends Command
 
         $project = new Project();
         $class = $option->getTableMapping()[$table] ?? Str::studly(Str::singular($table));
+        $class = str_replace('/','\\',$class);
         $class = $project->namespace($option->getPath()) . $class;
         $path = BASE_PATH . '/' . $project->path($class);
 


### PR DESCRIPTION
此前命令行执行`php bin/hyperf.php gen:model Test/Test/TestModel`命令时，生成的代码如下：  
```php
<?php

declare(strict_types=1);

namespace App\Model;

use Hyperf\DbConnection\Model\Model;

class Test/Test/TestModel extends Model
{
    /**
     * The table associated with the model.
     *
     * @var string
     */
    protected $table = 'Test/Test/TestModel';

    /**
     * The connection name for the model.
     *
     * @var string
     */
    protected $connection = 'default';

    /**
     * The attributes that are mass assignable.
     *
     * @var array
     */
    protected $fillable = [];

    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [];
}
```  

现在生成代码如下：   
```php
<?php

declare (strict_types=1);
namespace App\Model\Test\Test;

use Hyperf\DbConnection\Model\Model;
/**
 */
class TestModel extends Model
{
    /**
     * The table associated with the model.
     *
     * @var string
     */
    protected $table = 'Test/Test/TestModel';
    /**
     * The attributes that are mass assignable.
     *
     * @var array
     */
    protected $fillable = [];
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [];
}
```