### PR TITLE
[Feature] support middleware arguments

### DIFF
--- a/src/devtool/src/Generator/stubs/middleware.stub
+++ b/src/devtool/src/Generator/stubs/middleware.stub
@@ -6,11 +6,10 @@ namespace %NAMESPACE%;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class %CLASS% implements MiddlewareInterface
+class %CLASS%
 {
     /**
      * @var ContainerInterface

--- a/src/dispatcher/src/AbstractRequestHandler.php
+++ b/src/dispatcher/src/AbstractRequestHandler.php
@@ -62,14 +62,12 @@ abstract class AbstractRequestHandler
         } else {
             /** @var Middleware $middleware */
             $middleware = $this->middlewares[$this->offset];
-//            $handler = $this->container->make($middleware->middleware,$middleware->arguments);
             $handler = $this->container->get($middleware->middleware);
         }
         if (! method_exists($handler, 'process')) {
             throw new InvalidArgumentException(sprintf('Invalid middleware, it has to provide a process() method.'));
         }
-//        return $handler->process($request,$this->next(),...$middleware->arguments ?? []);
-        return $handler->process($request, $this->next());
+        return call_user_func([$handler,'process'],$request,$this->next(),...$middleware->arguments ?? []);
     }
 
     /**

--- a/src/dispatcher/src/AbstractRequestHandler.php
+++ b/src/dispatcher/src/AbstractRequestHandler.php
@@ -12,12 +12,16 @@ declare(strict_types=1);
 namespace Hyperf\Dispatcher;
 
 use Hyperf\Dispatcher\Exceptions\InvalidArgumentException;
+use Hyperf\HttpServer\Annotation\Middleware;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use function array_unique;
-use function is_string;
-use function sprintf;
+use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Class AbstractRequestHandler
+ * @package Hyperf\Dispatcher
+ * @mixin RequestHandlerInterface
+ */
 abstract class AbstractRequestHandler
 {
     /**
@@ -46,7 +50,7 @@ abstract class AbstractRequestHandler
      */
     public function __construct(array $middlewares, $coreHandler, ContainerInterface $container)
     {
-        $this->middlewares = array_unique($middlewares);
+        $this->middlewares = $middlewares;
         $this->coreHandler = $coreHandler;
         $this->container = $container;
     }
@@ -56,16 +60,22 @@ abstract class AbstractRequestHandler
         if (! isset($this->middlewares[$this->offset]) && ! empty($this->coreHandler)) {
             $handler = $this->coreHandler;
         } else {
-            $handler = $this->middlewares[$this->offset];
-            is_string($handler) && $handler = $this->container->get($handler);
+            /** @var Middleware $middleware */
+            $middleware = $this->middlewares[$this->offset];
+//            $handler = $this->container->make($middleware->middleware,$middleware->arguments);
+            $handler = $this->container->get($middleware->middleware);
         }
         if (! method_exists($handler, 'process')) {
             throw new InvalidArgumentException(sprintf('Invalid middleware, it has to provide a process() method.'));
         }
+//        return $handler->process($request,$this->next(),...$middleware->arguments ?? []);
         return $handler->process($request, $this->next());
     }
 
-    protected function next(): self
+    /**
+     * @return static | RequestHandlerInterface
+     */
+    protected function next() :self
     {
         ++$this->offset;
         return $this;

--- a/src/http-server/src/Annotation/Middleware.php
+++ b/src/http-server/src/Annotation/Middleware.php
@@ -55,7 +55,7 @@ class Middleware extends AbstractAnnotation
             if (is_string($middleware) && class_exists($middleware)) {
                 $middlewares[] = new static(compact('middleware'));
             } else if (is_array($middleware) && array_values($middleware) === $middleware) {
-                $middlewares[] = new static(['middleware' => array_shift($middleware),'argument' => $middleware]);
+                $middlewares[] = new static(['middleware' => array_shift($middleware),'arguments' => $middleware]);
             } else {
                 throw new RuntimeException('Invalid Middleware Configuration');
             }

--- a/src/http-server/src/Annotation/Middleware.php
+++ b/src/http-server/src/Annotation/Middleware.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\HttpServer\Annotation;
 
 use Hyperf\Di\Annotation\AbstractAnnotation;
+use RuntimeException;
 
 /**
  * @Annotation
@@ -19,14 +20,38 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
  */
 class Middleware extends AbstractAnnotation
 {
-    /**
-     * @var string
-     */
-    public $middleware = '';
+    public $middleware;
 
-    public function __construct($value = null)
+    /**
+     * @var array
+     */
+    public $arguments = [];
+
+    public function __construct($middleware = null,array $arguments = [])
     {
-        parent::__construct($value);
-        $this->bindMainProperty('middleware', $value);
+        parent::__construct();
+        $this->bindMainProperty('middleware', ['value' => $middleware]);
+        $this->bindMainProperty('arguments', ['value' => $arguments]);
     }
+
+    /**
+     * @param array $config
+     * @return static[]
+     */
+    public static function parseConfig(array $config) :array
+    {
+        $middlewares = [];
+        foreach ($config as $middleware) {
+            if (is_string($middleware) && class_exists($middleware)) {
+                $middlewares[] = new static($middleware);
+            } else if (is_array($middleware) && array_values($middleware) === $middleware) {
+                $middlewares[] = new static(array_shift($middleware),$middleware);
+            } else {
+                throw new RuntimeException('Invalid Middleware Configuration');
+            }
+
+        }
+        return $middlewares;
+    }
+
 }

--- a/src/http-server/src/Annotation/Middleware.php
+++ b/src/http-server/src/Annotation/Middleware.php
@@ -20,6 +20,9 @@ use RuntimeException;
  */
 class Middleware extends AbstractAnnotation
 {
+    /**
+     * @var string
+     */
     public $middleware;
 
     /**
@@ -27,11 +30,18 @@ class Middleware extends AbstractAnnotation
      */
     public $arguments = [];
 
-    public function __construct($middleware = null,array $arguments = [])
+    public function __construct($value = null)
     {
-        parent::__construct();
-        $this->bindMainProperty('middleware', ['value' => $middleware]);
-        $this->bindMainProperty('arguments', ['value' => $arguments]);
+        parent::__construct($value);
+        $this->bindMainProperty('middleware',$value);
+        if(is_array($value)) {
+            if (isset($value['middleware'])) {
+                $this->middleware = $value['middleware'];
+            }
+            if (isset($value['arguments'])) {
+                $this->arguments = $value['arguments'];
+            }
+        }
     }
 
     /**
@@ -43,9 +53,9 @@ class Middleware extends AbstractAnnotation
         $middlewares = [];
         foreach ($config as $middleware) {
             if (is_string($middleware) && class_exists($middleware)) {
-                $middlewares[] = new static($middleware);
+                $middlewares[] = new static(compact('middleware'));
             } else if (is_array($middleware) && array_values($middleware) === $middleware) {
-                $middlewares[] = new static(array_shift($middleware),$middleware);
+                $middlewares[] = new static(['middleware' => array_shift($middleware),'argument' => $middleware]);
             } else {
                 throw new RuntimeException('Invalid Middleware Configuration');
             }
@@ -53,5 +63,4 @@ class Middleware extends AbstractAnnotation
         }
         return $middlewares;
     }
-
 }

--- a/src/http-server/src/Router/DispatcherFactory.php
+++ b/src/http-server/src/Router/DispatcherFactory.php
@@ -165,7 +165,6 @@ class DispatcherFactory
             // Handle method level middlewares.
             if (isset($values)) {
                 $methodMiddlewares = array_merge($methodMiddlewares, $this->handleMiddleware($values));
-                $methodMiddlewares = array_unique($methodMiddlewares);
             }
 
             foreach ($mappingAnnotations as $mappingAnnotation) {
@@ -229,13 +228,13 @@ class DispatcherFactory
             $middlewares = $metadata[Middlewares::class];
             $result = [];
             foreach ($middlewares->middlewares as $middleware) {
-                $result[] = $middleware->middleware;
+                $result[] = $middleware;
             }
             return $result;
         }
         // @Middleware
         /** @var Middleware $middleware */
         $middleware = $metadata[Middleware::class];
-        return [$middleware->middleware];
+        return [$middleware];
     }
 }

--- a/src/http-server/src/Server.php
+++ b/src/http-server/src/Server.php
@@ -19,6 +19,7 @@ use Hyperf\Dispatcher\HttpDispatcher;
 use Hyperf\ExceptionHandler\ExceptionHandlerDispatcher;
 use Hyperf\HttpMessage\Server\Request as Psr7Request;
 use Hyperf\HttpMessage\Server\Response as Psr7Response;
+use Hyperf\HttpServer\Annotation\Middleware;
 use Hyperf\HttpServer\Contract\CoreMiddlewareInterface;
 use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 use Hyperf\HttpServer\Router\Dispatched;
@@ -95,7 +96,7 @@ class Server implements OnRequestInterface, MiddlewareInitializerInterface
         $this->routerDispatcher = $this->createDispatcher($serverName);
 
         $config = $this->container->get(ConfigInterface::class);
-        $this->middlewares = $config->get('middlewares.' . $serverName, []);
+        $this->middlewares = Middleware::parseConfig((array) $config->get('middlewares.' . $serverName, []));
         $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, $this->getDefaultExceptionHandler());
     }
 


### PR DESCRIPTION
对中间件做传参的支持,
改动了中间件合并的方式，**删除了对中间件的唯一性过滤**


##中间件
```php
namespace App\Middleware;

use Psr\Container\ContainerInterface;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Server\MiddlewareInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Http\Server\RequestHandlerInterface;

class TestMiddleware implements MiddlewareInterface
{
    /**
     * @var ContainerInterface
     */
    protected $container;

    public function __construct(ContainerInterface $container)
    {
        $this->container = $container;
    }

    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler,?string $class = null,bool $verified = false): ResponseInterface
    {
        return $handler->handle($request);
    }
}
```

### 配置文件
```php
use App\Middleware\TestMiddleware;
use App\Middleware\TestMiddleware;
use App\Auth\UserAuth;

return [
    'http' => [
        TestMiddleware::class, //无参数
        [TestMiddleware::class], //无参数
        [TestMiddleware::class,UserAuth::class,true], //有参数
    ],
];
```
###  注解

```php
use App\Auth\UserAuth;
use App\Constants\Status;
use App\Middleware\AuthMiddleware;
use App\Middleware\TestMiddleware;
use Hyperf\Utils\Arr;

/**
 * Class IndexController
 * @package App\Controller
 * @Controller(prefix="/index")
 * @Middleware(middleware=TestMiddleware::class,arguments={UserAuth::Class,true})
 */
class IndexController extends AbstractController
{
}
```
