### PR TITLE
fix call Non-static method statically 

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#2783](https://github.com/hyperf/hyperf/pull/2783) Fixed nsq consumer does not works in coroutine style server.
+- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method statically.
 
 # v2.0.18 - 2020-11-09
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#2783](https://github.com/hyperf/hyperf/pull/2783) Fixed nsq consumer does not works in coroutine style server.
-- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method statically.
+- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method statically for class proxy.
 
 # v2.0.18 - 2020-11-09
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#2783](https://github.com/hyperf/hyperf/pull/2783) Fixed nsq consumer does not works in coroutine style server.
-- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method statically for class proxy.
+- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method `__handlePropertyHandler()` statically for class proxy.
 
 # v2.0.18 - 2020-11-09
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#2783](https://github.com/hyperf/hyperf/pull/2783) Fixed nsq consumer does not works in coroutine style server.
-- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method `__handlePropertyHandler()` statically for class proxy.
+- [#2788](https://github.com/hyperf/hyperf/pull/2788) Fixed call non-static method `__handlePropertyHandler()` statically in class proxy.
 
 # v2.0.18 - 2020-11-09
 

--- a/src/di/src/Aop/PropertyHandlerVisitor.php
+++ b/src/di/src/Aop/PropertyHandlerVisitor.php
@@ -65,12 +65,12 @@ class PropertyHandlerVisitor extends NodeVisitorAbstract
             if ($this->visitorMetadata->hasExtends) {
                 $constructor->stmts[] = $this->buildCallParentConstructorStatement();
             }
-            $constructor->stmts[] = $this->buildStaticCallStatement();
+            $constructor->stmts[] = $this->buildMethodCallStatement();
             $node->stmts = array_merge([$this->buildProxyTraitUseStatement()], [$constructor], $node->stmts);
             $this->visitorMetadata->hasConstructor = true;
         } else {
             if ($node instanceof Node\Stmt\ClassMethod && $node->name->toString() === '__construct') {
-                $node->stmts = array_merge([$this->buildStaticCallStatement()], $node->stmts);
+                $node->stmts = array_merge([$this->buildMethodCallStatement()], $node->stmts);
             }
             if ($node instanceof Node\Stmt\Class_ && ! $node->isAnonymous()) {
                 $node->stmts = array_merge([$this->buildProxyTraitUseStatement()], $node->stmts);
@@ -115,9 +115,9 @@ class PropertyHandlerVisitor extends NodeVisitorAbstract
         ]);
     }
 
-    protected function buildStaticCallStatement(): Node\Stmt\Expression
+    protected function buildMethodCallStatement(): Node\Stmt\Expression
     {
-        return new Node\Stmt\Expression(new Node\Expr\StaticCall(new Name('self'), '__handlePropertyHandler', [
+        return new Node\Stmt\Expression(new Node\Expr\MethodCall(new Node\Expr\Variable('this'), '__handlePropertyHandler', [
             new Node\Arg(new Node\Scalar\MagicConst\Class_()),
         ]));
     }

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -63,7 +63,7 @@ class Foo
     use \Hyperf\Di\Aop\PropertyHandlerTrait;
     function __construct()
     {
-        self::__handlePropertyHandler(__CLASS__);
+        $this->__handlePropertyHandler(__CLASS__);
     }
 }', $code);
     }
@@ -83,7 +83,7 @@ class Bar2 extends Bar
     use \Hyperf\Di\Aop\PropertyHandlerTrait;
     public function __construct(int $id)
     {
-        self::__handlePropertyHandler(__CLASS__);
+        $this->__handlePropertyHandler(__CLASS__);
         parent::__construct($id);
     }
     public static function build()
@@ -112,7 +112,7 @@ class Bar5
         {
             public function __construct()
             {
-                self::__handlePropertyHandler(__CLASS__);
+                $this->__handlePropertyHandler(__CLASS__);
                 $this->id = 9501;
             }
         };
@@ -141,7 +141,7 @@ class Bar4
     use \Hyperf\Di\Aop\PropertyHandlerTrait;
     function __construct()
     {
-        self::__handlePropertyHandler(__CLASS__);
+        $this->__handlePropertyHandler(__CLASS__);
     }
     public function toMethodString() : string
     {
@@ -185,7 +185,7 @@ class Bar3 extends Bar
         if (method_exists(parent::class, \'__construct\')) {
             parent::__construct(...func_get_args());
         }
-        self::__handlePropertyHandler(__CLASS__);
+        $this->__handlePropertyHandler(__CLASS__);
     }
     public function getId() : int
     {


### PR DESCRIPTION
In Hyperf\Di\Aop\PropertyHandlerVisitor method leaveNode  modify **__construct** method,  

outout code in runtime/container/proxy/*.proxy.php  like below:
```
use \Hyperf\Di\Aop\PropertyHandlerTrait;
function __construct()
    {
        self::__handlePropertyHandler(__CLASS__);
    }
```
but in **\Hyperf\Di\Aop\PropertyHandlerTrait**, __handlePropertyHandler is **NON-STATIC** method
```
trait PropertyHandlerTrait
{
    protected function __handlePropertyHandler(string $className)
    {
       ...
```

Non-static method self::__handlePropertyHandler should not be called statically