### PR TITLE
服务注册支持 Consul ACL token

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # v2.0.21 - TBD
 
+## Added
+
+- [#2857](https://github.com/hyperf/hyperf/pull/2857) Support Consul ACL Token for Service Governance.
+
 ## Changed
 
 - [#2851](https://github.com/hyperf/hyperf/pull/2851) Changed default engine of view config.

--- a/src/consul/publish/consul.php
+++ b/src/consul/publish/consul.php
@@ -11,5 +11,5 @@ declare(strict_types=1);
  */
 return [
     'uri' => 'http://127.0.0.1:8500',
-    'token' => ''
+    'token' => '',
 ];

--- a/src/consul/publish/consul.php
+++ b/src/consul/publish/consul.php
@@ -11,4 +11,5 @@ declare(strict_types=1);
  */
 return [
     'uri' => 'http://127.0.0.1:8500',
+    'token' => ''
 ];

--- a/src/service-governance/src/Register/ConsulAgentFactory.php
+++ b/src/service-governance/src/Register/ConsulAgentFactory.php
@@ -22,10 +22,19 @@ class ConsulAgentFactory
     {
         return new Agent(function () use ($container) {
             $config = $container->get(ConfigInterface::class);
-            return $container->get(ClientFactory::class)->create([
+            $token = $config->get('consul.token', '');
+            $options = [
                 'timeout' => 2,
                 'base_uri' => $config->get('consul.uri', Agent::DEFAULT_URI),
-            ]);
+            ];
+
+            if (!empty($token)) {
+                $options['headers'] = [
+                    'X-Consul-Token' => $token
+                ];
+            }
+
+            return $container->get(ClientFactory::class)->create($options);
         });
     }
 }

--- a/src/service-governance/src/Register/ConsulAgentFactory.php
+++ b/src/service-governance/src/Register/ConsulAgentFactory.php
@@ -28,9 +28,9 @@ class ConsulAgentFactory
                 'base_uri' => $config->get('consul.uri', Agent::DEFAULT_URI),
             ];
 
-            if (!empty($token)) {
+            if (! empty($token)) {
                 $options['headers'] = [
-                    'X-Consul-Token' => $token
+                    'X-Consul-Token' => $token,
                 ];
             }
 


### PR DESCRIPTION
Consul 的配置文件中增加了 token 选项，不需要就留空