### PR TITLE
Fixed bug that worker will be stoped when `onMessage` or `onClose` failed in websocket server.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: PHPUnit for Hyperf
 on: [push, pull_request]
 
 env:
-  SW_VERSION: '4.5.6'
+  SW_VERSION: '4.5.9'
 
 jobs:
   ci:

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 ## Fixed
 
 - [#2913](https://github.com/hyperf/hyperf/pull/2913) Fixed memory leak when using `with()` for ORM.
+- [#2915](https://github.com/hyperf/hyperf/pull/2915) Fixed bug that worker will be stoped when `onMessage` or `onClose` failed in websocket server.
 
 # v2.0.21 - 2020-11-30
 

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -231,7 +231,11 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
             return;
         }
 
-        $instance->onMessage($server, $frame);
+        try {
+            $instance->onMessage($server, $frame);
+        } catch (\Throwable $exception) {
+            $this->logger->error((string) $exception);
+        }
     }
 
     public function onClose($server, int $fd, int $reactorId): void
@@ -252,7 +256,11 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
 
         $instance = $this->container->get($fdObj->class);
         if ($instance instanceof OnCloseInterface) {
-            $instance->onClose($server, $fd, $reactorId);
+            try {
+                $instance->onClose($server, $fd, $reactorId);
+            } catch (\Throwable $exception) {
+                $this->logger->error((string) $exception);
+            }
         }
     }
 


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/2912