### PR TITLE
revert: flysystem v2.0 support

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.2 - TBD
 
+## Changed
+
+- [#3077](https://github.com/hyperf/hyperf/pull/3077) Reduced `league/flysystem` to `^1.0`.
+
 # v2.1.1 - 2021-01-04
 
 ## Fixed

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "jean85/pretty-package-versions": "^1.2",
         "jonahgeorge/jaeger-client-php": "^0.6.0",
         "laminas/laminas-mime": "^2.7",
-        "league/flysystem": "^1.0|^2.0",
+        "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0|^2.0",
         "league/flysystem-memory": "^1.0|^2.0",
         "league/plates": "^3.3",

--- a/src/filesystem/composer.json
+++ b/src/filesystem/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2",
         "hyperf/di": "~2.1.0",
-        "league/flysystem": "^1.0|^2.0"
+        "league/flysystem": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",


### PR DESCRIPTION
v2.0 is incompatible with almost all adapters available.