### PR TITLE
Fixed unexpected behavior for `ElasticsearchEngine::getTotalCount()` in `hyperf/scout`.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -5,6 +5,7 @@
 - [#3050](https://github.com/hyperf/hyperf/pull/3050) Fixed extra data saved twice when use `save()` after `increment()` with `extra`.
 - [#3082](https://github.com/hyperf/hyperf/pull/3082) Fixed connection has already been bound to another coroutine when used in defer for `hyperf/db`.
 - [#3087](https://github.com/hyperf/hyperf/pull/3087) Fixed memory leak when using pipeline sometimes.
+- [#3095](https://github.com/hyperf/hyperf/pull/3095) Fixed unexpected behavior for `ElasticsearchEngine::getTotalCount()` in `hyperf/scout`.
 
 ## Added
 

--- a/src/scout/src/Engine/ElasticsearchEngine.php
+++ b/src/scout/src/Engine/ElasticsearchEngine.php
@@ -177,7 +177,12 @@ class ElasticsearchEngine extends Engine
      */
     public function getTotalCount($results): int
     {
-        return $results['hits']['total'];
+        $total = $results['hits']['total'];
+        if (is_array($total)) {
+            return $results['hits']['total']['value'];
+        }
+
+        return $total;
     }
 
     /**

--- a/src/scout/src/Engine/ElasticsearchEngine.php
+++ b/src/scout/src/Engine/ElasticsearchEngine.php
@@ -158,7 +158,7 @@ class ElasticsearchEngine extends Engine
      */
     public function map(Builder $builder, $results, $model): Collection
     {
-        if ($results['hits']['total'] === 0) {
+        if ($this->getTotalCount($results) === 0) {
             return $model->newCollection();
         }
         $keys = collect($results['hits']['hits'])->pluck('_id')->values()->all();

--- a/src/scout/src/Engine/ElasticsearchEngine.php
+++ b/src/scout/src/Engine/ElasticsearchEngine.php
@@ -136,7 +136,7 @@ class ElasticsearchEngine extends Engine
             'from' => (($page * $perPage) - $perPage),
             'size' => $perPage,
         ]);
-        $result['nbPages'] = $result['hits']['total'] / $perPage;
+        $result['nbPages'] = $this->getTotalCount($result) / $perPage;
         return $result;
     }
 

--- a/src/scout/tests/Cases/ElasticsearchEngineTest.php
+++ b/src/scout/tests/Cases/ElasticsearchEngineTest.php
@@ -130,7 +130,7 @@ class ElasticsearchEngineTest extends TestCase
         $model->shouldReceive('newCollection')->andReturn($models);
         $results = $engine->map($builder, [
             'hits' => [
-                'total' => '1',
+                'total' => 1,
                 'hits' => [
                     [
                         '_id' => '1',

--- a/src/scout/tests/Cases/ElasticsearchEngineTest.php
+++ b/src/scout/tests/Cases/ElasticsearchEngineTest.php
@@ -140,4 +140,23 @@ class ElasticsearchEngineTest extends TestCase
         ], $model);
         $this->assertEquals(1, count($results));
     }
+
+    public function testGetTotalCount()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $engine = new ElasticsearchEngine($client, 'scout');
+        $this->assertSame(1, $engine->getTotalCount([
+            'hits' => [
+                'total' => 1,
+            ],
+        ]));
+        $this->assertSame(2, $engine->getTotalCount([
+            'hits' => [
+                'total' => [
+                    'value' => 2,
+                    'relation' => 'eq',
+                ],
+            ],
+        ]));
+    }
 }


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/3071