### PR TITLE
Fixed bug that call to a member function getArrayCopy() on null when the parent coroutine context destroyed.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.3 - TBD
 
+## Fixed
+
+- [#3106](https://github.com/hyperf/hyperf/pull/3106) Fixed bug that call to a member function getArrayCopy() on null when the parent coroutine context destroyed.
+
 # v2.1.2 - 2021-01-11
 
 ## Fixed

--- a/src/utils/src/Context.php
+++ b/src/utils/src/Context.php
@@ -58,9 +58,11 @@ class Context
      */
     public static function copy(int $fromCoroutineId, array $keys = []): void
     {
-        /** @var \ArrayObject $from */
         $from = Co::getContextFor($fromCoroutineId);
-        /** @var \ArrayObject $current */
+        if ($from === null) {
+            return;
+        }
+
         $current = Co::getContextFor();
         $current->exchangeArray($keys ? Arr::only($from->getArrayCopy(), $keys) : $from->getArrayCopy());
     }

--- a/src/utils/tests/ContextTest.php
+++ b/src/utils/tests/ContextTest.php
@@ -87,4 +87,23 @@ class ContextTest extends TestCase
 
         $this->assertSame($tid, Context::get('test.store.id')->id);
     }
+
+    public function testContextFromNull()
+    {
+        $res = Context::get('id', $default = 'Hello World!', -1);
+        $this->assertSame($default, $res);
+
+        $res = Context::get('id', null, -1);
+        $this->assertSame(null, $res);
+
+        $this->assertFalse(Context::has('id', -1));
+
+        Context::copy(-1);
+
+        parallel([function () {
+            Context::set('id', $id = uniqid());
+            Context::copy(-1, ['id']);
+            $this->assertSame($id, Context::get('id'));
+        }]);
+    }
 }


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/3104