### PR TITLE
Added `FindNewerDriver` which is friendly with mac, linux and docker for watcher.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -6,6 +6,10 @@
 - [#3174](https://github.com/hyperf/hyperf/pull/3174) Fixed bug that the where bindings will be replaced by not rigorous code.
 - [#3179](https://github.com/hyperf/hyperf/pull/3179) Fixed json-rpc client failed to receive data when the target server restart.
 
+## Added
+
+- [#3170](https://github.com/hyperf/hyperf/pull/3170) Added `FindNewerDriver` which is friendly with mac, linux and docker for watcher.
+
 ## Optimized
 
 - [#3169](https://github.com/hyperf/hyperf/pull/3169) Optimized code for `set_error_handler` of `ErrorExceptionHandler`, which expects `callable(int, string, string, int, array): bool`.

--- a/docs/zh-cn/watcher.md
+++ b/docs/zh-cn/watcher.md
@@ -32,11 +32,12 @@ php bin/hyperf.php vendor:publish hyperf/watcher
 
 ## 支持驱动
 
-|                 驱动                 |                备注                 |
-| :----------------------------------: | :---------------------------------: |
-| Hyperf\Watcher\Driver\ScanFileDriver |              无需扩展               |
-| Hyperf\Watcher\Driver\FswatchDriver  |          需要安装 fswatch           |
-|   Hyperf\Watcher\Driver\FindDriver   | 需要安装 find，MAC 下需要安装 gfind |
+|                 驱动                  |                备注                 |
+| :-----------------------------------: | :---------------------------------: |
+| Hyperf\Watcher\Driver\ScanFileDriver  |              无需扩展               |
+|  Hyperf\Watcher\Driver\FswatchDriver  |          需要安装 fswatch           |
+|   Hyperf\Watcher\Driver\FindDriver    | 需要安装 find，MAC 下需要安装 gfind |
+| Hyperf\Watcher\Driver\FindNewerDriver |            需要安装 find            |
 
 ### `fswatch` 安装
 

--- a/src/watcher/src/Driver/FindNewerDriver.php
+++ b/src/watcher/src/Driver/FindNewerDriver.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\Watcher\Driver;
 
 use Hyperf\Utils\Str;
@@ -18,7 +17,7 @@ use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\System;
 use Swoole\Timer;
 
-class NewerFileDriver implements DriverInterface
+class FindNewerDriver implements DriverInterface
 {
     /**
      * @var Option
@@ -64,7 +63,7 @@ class NewerFileDriver implements DriverInterface
                 $changedFiles = $this->scan();
 
                 $this->scaning = false;
-                $this->count++;
+                ++$this->count;
                 foreach ($changedFiles as $file) {
                     $channel->push($file);
                     return;
@@ -77,10 +76,10 @@ class NewerFileDriver implements DriverInterface
     {
         $changedFiles = [];
 
-        $shell = "";
+        $shell = '';
         $len = count($targets);
         // merge find command
-        for ($i = 0; $i < $len; $i++) {
+        for ($i = 0; $i < $len; ++$i) {
             $dest = $targets[$i];
             $symbol = ($i == $len - 1) ? '' : '&';
             $file = $this->getToScanFile();
@@ -96,7 +95,7 @@ class NewerFileDriver implements DriverInterface
                     continue;
                 }
 
-                if (!empty($ext) && !Str::endsWith($pathName, $ext)) {
+                if (! empty($ext) && ! Str::endsWith($pathName, $ext)) {
                     continue;
                 }
                 $changedFiles[] = $pathName;
@@ -122,9 +121,7 @@ class NewerFileDriver implements DriverInterface
             $dirs[] = implode(' ', $files);
         }
 
-        $changedFiles = $this->find($dirs, $ext);
-
-        return $changedFiles;
+        return $this->find($dirs, $ext);
     }
 
     protected function getToModifyFile()

--- a/src/watcher/src/Driver/NewerFileDriver.php
+++ b/src/watcher/src/Driver/NewerFileDriver.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Watcher\Driver;
+
+use Hyperf\Utils\Str;
+use Hyperf\Watcher\Option;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\System;
+use Swoole\Timer;
+
+class NewerFileDriver implements DriverInterface
+{
+    /**
+     * @var Option
+     */
+    protected $option;
+
+    /**
+     * @var string
+     */
+    protected $tmpFile = '/tmp/hyperf_find.php';
+
+    /**
+     * @var bool
+     */
+    protected $scaning = false;
+
+    /**
+     * @var int
+     */
+    protected $count = 0;
+
+    public function __construct(Option $option)
+    {
+        $this->option = $option;
+
+        $ret = System::exec('which find');
+        if (empty($ret['output'])) {
+            throw new \InvalidArgumentException('find not exists.');
+        }
+        // create two files
+        System::exec('echo 1 > ' . $this->getToModifyFile());
+        System::exec('echo 1 > ' . $this->getToScanFile());
+    }
+
+    public function watch(Channel $channel): void
+    {
+        $ms = $this->option->getScanInterval();
+        Timer::tick($ms, function () use ($channel) {
+            if ($this->scaning == false) {
+                $this->scaning = true;
+
+                System::exec('echo 1 > ' . $this->getToModifyFile());
+                $changedFiles = $this->scan();
+
+                $this->scaning = false;
+                $this->count++;
+                foreach ($changedFiles as $file) {
+                    $channel->push($file);
+                    return;
+                }
+            }
+        });
+    }
+
+    protected function find(array $targets, array $ext = []): array
+    {
+        $changedFiles = [];
+
+        $shell = "";
+        $len = count($targets);
+        // merge find command
+        for ($i = 0; $i < $len; $i++) {
+            $dest = $targets[$i];
+            $symbol = ($i == $len - 1) ? '' : '&';
+            $file = $this->getToScanFile();
+            $shell = $shell . sprintf('find %s -newer %s -type f', $dest, $file) . $symbol;
+        }
+
+        $ret = System::exec($shell);
+        if ($ret['code'] === 0 && strlen($ret['output'])) {
+            $stdout = $ret['output'];
+            $lineArr = explode(PHP_EOL, $stdout);
+            foreach ($lineArr as $pathName) {
+                if (empty($pathName)) {
+                    continue;
+                }
+
+                if (!empty($ext) && !Str::endsWith($pathName, $ext)) {
+                    continue;
+                }
+                $changedFiles[] = $pathName;
+            }
+        }
+
+        return $changedFiles;
+    }
+
+    protected function scan(): array
+    {
+        $ext = $this->option->getExt();
+
+        $dirs = array_map(function ($dir) {
+            return BASE_PATH . '/' . $dir;
+        }, $this->option->getWatchDir());
+
+        $files = array_map(function ($file) {
+            return BASE_PATH . '/' . $file;
+        }, $this->option->getWatchFile());
+
+        if ($files) {
+            $dirs[] = implode(' ', $files);
+        }
+
+        $changedFiles = $this->find($dirs, $ext);
+
+        return $changedFiles;
+    }
+
+    protected function getToModifyFile()
+    {
+        return $this->tmpFile . strval($this->count % 2);
+    }
+
+    protected function getToScanFile()
+    {
+        return $this->tmpFile . strval(($this->count + 1) % 2);
+    }
+}


### PR DESCRIPTION
做了三方面的升级
1. 使用`find %s -newer %s -type f`的语法，支持docker，linux和mac等系统。
2. 通过&符号拼接find的命令行提高find的执行效率。
3. 在`/tmp`创建两个文件，切换更改和扫描的步骤，使查找的文件更加准确，同时删除`$fileModifyTimes`全局变量，降低内存消耗。