### PR TITLE
fix: coroutine leak

### DIFF
--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -81,6 +81,7 @@ class Producer
                 $ack->close();
             } catch (\Throwable $e) {
                 $ack->push($e);
+                throw $e;
             }
         });
         if ($e = $ack->pop()) {
@@ -104,6 +105,7 @@ class Producer
                 $ack->close();
             } catch (\Throwable $e) {
                 $ack->push($e);
+                throw $e;
             }
         });
         if ($e = $ack->pop()) {
@@ -145,7 +147,7 @@ class Producer
                     }
                     try {
                         $closure->call($this);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $this->producer->close();
                         break;
                     }

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -153,6 +153,7 @@ class Producer
                     }
                 }
             }
+            /* @phpstan-ignore-next-line */
             $this->chan = null;
         });
     }


### PR DESCRIPTION
发现过去的写法会导致异常+并发时的协程泄露，即异常前push，但还没来的及pop的协程永久挂起。