### PR TITLE
Update DispatcherFactory.php

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.5 - TBD
 
+## Fixed
+
+- [#3204](https://github.com/hyperf/hyperf/pull/3204) Fixed unexpected behavior for `middlewares` when using `rpc-server`.
+
 # v2.1.4 - 2021-01-25
 
 ## Fixed

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -126,18 +126,17 @@ class DispatcherFactory
                 $methodName,
             ]);
 
+            $methodMiddlewares = $middlewares;
             // Handle method level middlewares.
             if (isset($methodMetadata[$methodName])) {
-                $methodMiddlewares = $this->handleMiddleware($methodMetadata[$methodName]);
-                $middlewares = array_merge($methodMiddlewares, $middlewares);
+                $methodMiddlewares = array_merge($this->handleMiddleware($methodMetadata[$methodName]), $middlewares);
             }
-            $middlewares = array_unique($middlewares);
+            // TODO: Remove array_unique from v3.0.
+            $methodMiddlewares = array_unique($methodMiddlewares);
 
             // Register middlewares.
-            MiddlewareManager::addMiddlewares($annotation->server, $path, 'POST', $middlewares);
-    
-            $middlewares = [];
-            
+            MiddlewareManager::addMiddlewares($annotation->server, $path, 'POST', $methodMiddlewares);
+
             // Trigger the AfterPathRegister event.
             $this->eventDispatcher->dispatch(new AfterPathRegister($path, $className, $methodName, $annotation));
         }

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -135,7 +135,9 @@ class DispatcherFactory
 
             // Register middlewares.
             MiddlewareManager::addMiddlewares($annotation->server, $path, 'POST', $middlewares);
-
+    
+            $middlewares = [];
+            
             // Trigger the AfterPathRegister event.
             $this->eventDispatcher->dispatch(new AfterPathRegister($path, $className, $methodName, $annotation));
         }

--- a/src/rpc-server/tests/Stub/MiddlewareStub.php
+++ b/src/rpc-server/tests/Stub/MiddlewareStub.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\RpcServer\Stub;
+
+class MiddlewareStub
+{
+    public function generate(): string
+    {
+        return uniqid();
+    }
+
+    public function foo(): string
+    {
+        return 'foo';
+    }
+}


### PR DESCRIPTION
rpc-server组件下的DispatcherFactory的handleRpcService方法中的$middlewares变量设置有bug，在rpc service中如果通过注解给一个方法添加中间件后，其后面的方法不管是否使用注解，都会连带使用上面方法设置的中间件，目前我们项目的解决办法是在该DispatcherFactory的139行添加 $middlewares = []; ，即每次循环都会清空上个方法的注解