### PR TITLE
Fixed bug that the value of ttl will be converted to 0 when you don't set it.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.8 - TBD
 
+## Fixed 
+
+- [#3301](https://github.com/hyperf/hyperf/pull/3301) Fixed bug that the value of ttl will be converted to 0 when you don't set it for `hyperf/cache`.
+
 # v2.1.7 - 2021-02-22
 
 ## Fixed

--- a/src/cache/src/Annotation/CachePut.php
+++ b/src/cache/src/Annotation/CachePut.php
@@ -30,7 +30,7 @@ class CachePut extends AbstractAnnotation
     public $value;
 
     /**
-     * @var int|null
+     * @var null|int
      */
     public $ttl;
 

--- a/src/cache/src/Annotation/CachePut.php
+++ b/src/cache/src/Annotation/CachePut.php
@@ -30,7 +30,7 @@ class CachePut extends AbstractAnnotation
     public $value;
 
     /**
-     * @var int
+     * @var int|null
      */
     public $ttl;
 
@@ -48,7 +48,9 @@ class CachePut extends AbstractAnnotation
     public function __construct($value = null)
     {
         parent::__construct($value);
-        $this->ttl = (int) $this->ttl;
+        if ($this->ttl !== null) {
+            $this->ttl = (int) $this->ttl;
+        }
         $this->offset = (int) $this->offset;
     }
 }

--- a/src/cache/src/Annotation/Cacheable.php
+++ b/src/cache/src/Annotation/Cacheable.php
@@ -32,7 +32,7 @@ class Cacheable extends AbstractAnnotation
     public $value;
 
     /**
-     * @var int
+     * @var null|int
      */
     public $ttl;
 
@@ -60,7 +60,9 @@ class Cacheable extends AbstractAnnotation
     public function __construct($value = null)
     {
         parent::__construct($value);
-        $this->ttl = (int) $this->ttl;
+        if ($this->ttl !== null) {
+            $this->ttl = (int) $this->ttl;
+        }
         $this->offset = (int) $this->offset;
     }
 

--- a/src/cache/src/AnnotationManager.php
+++ b/src/cache/src/AnnotationManager.php
@@ -47,7 +47,7 @@ class AnnotationManager
 
         $key = $this->getFormatedKey($annotation->prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl + $this->getRandomOffset($annotation->offset), $group, $annotation];
     }
@@ -76,7 +76,7 @@ class AnnotationManager
 
         $key = $this->getFormatedKey($annotation->prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl + $this->getRandomOffset($annotation->offset), $group, $annotation];
     }
@@ -86,10 +86,10 @@ class AnnotationManager
         /** @var FailCache $annotation */
         $annotation = $this->getAnnotation(FailCache::class, $className, $method);
 
-        $prefix = $annotation->prefix ?? ($className . '::' . $method);
+        $prefix = $annotation->prefix ?: ($className . '::' . $method);
         $key = $this->getFormatedKey($prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl, $group, $annotation];
     }

--- a/src/cache/src/AnnotationManager.php
+++ b/src/cache/src/AnnotationManager.php
@@ -86,7 +86,7 @@ class AnnotationManager
         /** @var FailCache $annotation */
         $annotation = $this->getAnnotation(FailCache::class, $className, $method);
 
-        $prefix = $annotation->prefix ?: ($className . '::' . $method);
+        $prefix = $annotation->prefix ?? ($className . '::' . $method);
         $key = $this->getFormatedKey($prefix, $arguments, $annotation->value);
         $group = $annotation->group;
         $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);

--- a/src/cache/src/AnnotationManager.php
+++ b/src/cache/src/AnnotationManager.php
@@ -47,7 +47,7 @@ class AnnotationManager
 
         $key = $this->getFormatedKey($annotation->prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl + $this->getRandomOffset($annotation->offset), $group, $annotation];
     }
@@ -76,7 +76,7 @@ class AnnotationManager
 
         $key = $this->getFormatedKey($annotation->prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl + $this->getRandomOffset($annotation->offset), $group, $annotation];
     }
@@ -89,7 +89,7 @@ class AnnotationManager
         $prefix = $annotation->prefix ?: ($className . '::' . $method);
         $key = $this->getFormatedKey($prefix, $arguments, $annotation->value);
         $group = $annotation->group;
-        $ttl = $annotation->ttl ?: $this->config->get("cache.{$group}.ttl", 3600);
+        $ttl = $annotation->ttl ?? $this->config->get("cache.{$group}.ttl", 3600);
 
         return [$key, $ttl, $group, $annotation];
     }

--- a/src/cache/tests/Cases/AnnotationTest.php
+++ b/src/cache/tests/Cases/AnnotationTest.php
@@ -52,6 +52,22 @@ class AnnotationTest extends TestCase
         $this->assertSame('test', $annotation->prefix);
         $this->assertSame(3600, $annotation->ttl);
         $this->assertSame(100, $annotation->offset);
+
+        $annotation = new Cacheable([
+            'prefix' => 'test',
+            'ttl' => null,
+        ]);
+
+        $this->assertSame('test', $annotation->prefix);
+        $this->assertSame(null, $annotation->ttl);
+
+        $annotation = new CachePut([
+            'prefix' => 'test',
+            'ttl' => null,
+        ]);
+
+        $this->assertSame('test', $annotation->prefix);
+        $this->assertSame(null, $annotation->ttl);
     }
 
     public function testAnnotationManager()


### PR DESCRIPTION
当缓存注解没有设置 ttl 时，使用 ?? 会读取注解默认的 ttl 值为0，然后导致缓存不会过期