### PR TITLE
Support `#{this.key}` which you can used to get cache key from original object for `Cacheable`, `CachePut` and so on.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -8,6 +8,11 @@
 ## Added
 
 - [#3325](https://github.com/hyperf/hyperf/pull/3325) Added `enable` to control the crontab task which to register or not.
+- [#3331](https://github.com/hyperf/hyperf/pull/3331) Support `#{this.key}` which you can used to get cache key from original object for `Cacheable`, `CachePut` and so on.
+
+## Changed
+
+- [#3331](https://github.com/hyperf/hyperf/pull/3331) Changed input arguments for `Hyperf\Cache\AnnotationManager::get*Value`.
 
 # v2.1.8 - 2021-03-01
 

--- a/src/cache/src/Aspect/CacheEvictAspect.php
+++ b/src/cache/src/Aspect/CacheEvictAspect.php
@@ -49,6 +49,10 @@ class CacheEvictAspect extends AbstractAspect
         $className = $proceedingJoinPoint->className;
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
+        $instance = $proceedingJoinPoint->getInstance();
+        if (!is_null($instance)){
+            $arguments['_this'] = $instance;
+        }
 
         [$key, $all, $group, $annotation] = $this->annotationManager->getCacheEvictValue($className, $method, $arguments);
 

--- a/src/cache/src/Aspect/CacheEvictAspect.php
+++ b/src/cache/src/Aspect/CacheEvictAspect.php
@@ -50,8 +50,8 @@ class CacheEvictAspect extends AbstractAspect
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
         $instance = $proceedingJoinPoint->getInstance();
-        if (!is_null($instance)){
-            $arguments['_this'] = $instance;
+        if (! is_null($instance)) {
+            $arguments['this'] = $instance;
         }
 
         [$key, $all, $group, $annotation] = $this->annotationManager->getCacheEvictValue($className, $method, $arguments);

--- a/src/cache/src/Aspect/CacheEvictAspect.php
+++ b/src/cache/src/Aspect/CacheEvictAspect.php
@@ -46,15 +46,7 @@ class CacheEvictAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $className = $proceedingJoinPoint->className;
-        $method = $proceedingJoinPoint->methodName;
-        $arguments = $proceedingJoinPoint->arguments['keys'];
-        $instance = $proceedingJoinPoint->getInstance();
-        if (! is_null($instance)) {
-            $arguments['this'] = $instance;
-        }
-
-        [$key, $all, $group, $annotation] = $this->annotationManager->getCacheEvictValue($className, $method, $arguments);
+        [$key, $all, $group, $annotation] = $this->annotationManager->getCacheEvictValue($proceedingJoinPoint);
 
         $driver = $this->manager->getDriver($group);
 

--- a/src/cache/src/Aspect/CachePutAspect.php
+++ b/src/cache/src/Aspect/CachePutAspect.php
@@ -48,6 +48,10 @@ class CachePutAspect extends AbstractAspect
         $className = $proceedingJoinPoint->className;
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
+        $instance = $proceedingJoinPoint->getInstance();
+        if (!is_null($instance)){
+            $arguments['_this'] = $instance;
+        }
 
         [$key, $ttl, $group] = $this->annotationManager->getCachePutValue($className, $method, $arguments);
 

--- a/src/cache/src/Aspect/CachePutAspect.php
+++ b/src/cache/src/Aspect/CachePutAspect.php
@@ -49,8 +49,8 @@ class CachePutAspect extends AbstractAspect
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
         $instance = $proceedingJoinPoint->getInstance();
-        if (!is_null($instance)){
-            $arguments['_this'] = $instance;
+        if (! is_null($instance)) {
+            $arguments['this'] = $instance;
         }
 
         [$key, $ttl, $group] = $this->annotationManager->getCachePutValue($className, $method, $arguments);

--- a/src/cache/src/Aspect/CachePutAspect.php
+++ b/src/cache/src/Aspect/CachePutAspect.php
@@ -45,15 +45,7 @@ class CachePutAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $className = $proceedingJoinPoint->className;
-        $method = $proceedingJoinPoint->methodName;
-        $arguments = $proceedingJoinPoint->arguments['keys'];
-        $instance = $proceedingJoinPoint->getInstance();
-        if (! is_null($instance)) {
-            $arguments['this'] = $instance;
-        }
-
-        [$key, $ttl, $group] = $this->annotationManager->getCachePutValue($className, $method, $arguments);
+        [$key, $ttl, $group] = $this->annotationManager->getCachePutValue($proceedingJoinPoint);
 
         $driver = $this->manager->getDriver($group);
 

--- a/src/cache/src/Aspect/CacheableAspect.php
+++ b/src/cache/src/Aspect/CacheableAspect.php
@@ -51,6 +51,10 @@ class CacheableAspect extends AbstractAspect
         $className = $proceedingJoinPoint->className;
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
+        $instance = $proceedingJoinPoint->getInstance();
+        if (!is_null($instance)){
+            $arguments['_this'] = $instance;
+        }
 
         [$key, $ttl, $group, $annotation] = $this->annotationManager->getCacheableValue($className, $method, $arguments);
 

--- a/src/cache/src/Aspect/CacheableAspect.php
+++ b/src/cache/src/Aspect/CacheableAspect.php
@@ -48,15 +48,7 @@ class CacheableAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $className = $proceedingJoinPoint->className;
-        $method = $proceedingJoinPoint->methodName;
-        $arguments = $proceedingJoinPoint->arguments['keys'];
-        $instance = $proceedingJoinPoint->getInstance();
-        if (! is_null($instance)) {
-            $arguments['this'] = $instance;
-        }
-
-        [$key, $ttl, $group, $annotation] = $this->annotationManager->getCacheableValue($className, $method, $arguments);
+        [$key, $ttl, $group, $annotation] = $this->annotationManager->getCacheableValue($proceedingJoinPoint);
 
         $driver = $this->manager->getDriver($group);
 

--- a/src/cache/src/Aspect/CacheableAspect.php
+++ b/src/cache/src/Aspect/CacheableAspect.php
@@ -52,8 +52,8 @@ class CacheableAspect extends AbstractAspect
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
         $instance = $proceedingJoinPoint->getInstance();
-        if (!is_null($instance)){
-            $arguments['_this'] = $instance;
+        if (! is_null($instance)) {
+            $arguments['this'] = $instance;
         }
 
         [$key, $ttl, $group, $annotation] = $this->annotationManager->getCacheableValue($className, $method, $arguments);

--- a/src/cache/src/Aspect/FailCacheAspect.php
+++ b/src/cache/src/Aspect/FailCacheAspect.php
@@ -54,15 +54,7 @@ class FailCacheAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $className = $proceedingJoinPoint->className;
-        $method = $proceedingJoinPoint->methodName;
-        $arguments = $proceedingJoinPoint->arguments['keys'];
-        $instance = $proceedingJoinPoint->getInstance();
-        if (! is_null($instance)) {
-            $arguments['this'] = $instance;
-        }
-
-        [$key, $ttl, $group] = $this->annotationManager->getFailCacheValue($className, $method, $arguments);
+        [$key, $ttl, $group] = $this->annotationManager->getFailCacheValue($proceedingJoinPoint);
 
         $driver = $this->manager->getDriver($group);
 

--- a/src/cache/src/Aspect/FailCacheAspect.php
+++ b/src/cache/src/Aspect/FailCacheAspect.php
@@ -57,6 +57,10 @@ class FailCacheAspect extends AbstractAspect
         $className = $proceedingJoinPoint->className;
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
+        $instance = $proceedingJoinPoint->getInstance();
+        if (!is_null($instance)){
+            $arguments['_this'] = $instance;
+        }
 
         [$key, $ttl, $group] = $this->annotationManager->getFailCacheValue($className, $method, $arguments);
 

--- a/src/cache/src/Aspect/FailCacheAspect.php
+++ b/src/cache/src/Aspect/FailCacheAspect.php
@@ -58,8 +58,8 @@ class FailCacheAspect extends AbstractAspect
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
         $instance = $proceedingJoinPoint->getInstance();
-        if (!is_null($instance)){
-            $arguments['_this'] = $instance;
+        if (! is_null($instance)) {
+            $arguments['this'] = $instance;
         }
 
         [$key, $ttl, $group] = $this->annotationManager->getFailCacheValue($className, $method, $arguments);

--- a/src/cache/src/Helper/StringHelper.php
+++ b/src/cache/src/Helper/StringHelper.php
@@ -25,7 +25,7 @@ class StringHelper
             if ($matches = StringHelper::parse($value)) {
                 foreach ($matches as $search) {
                     $k = str_replace(['#{', '}'], '', $search);
-                    if (strpos($k, 'this.') === 0 && ! array_key_exists('this', $arguments)) {
+                    if (strpos($k, 'this') === 0 && ! array_key_exists('this', $arguments)) {
                         $arguments['this'] = $proceedingJoinPoint->getInstance();
                     }
 

--- a/src/cache/src/Helper/StringHelper.php
+++ b/src/cache/src/Helper/StringHelper.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Cache\Helper;
 
+use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Utils\Str;
 
 class StringHelper
@@ -18,12 +19,15 @@ class StringHelper
     /**
      * Format cache key with prefix and arguments.
      */
-    public static function format(string $prefix, array $arguments, ?string $value = null): string
+    public static function format(string $prefix, array $arguments, ?string $value = null, ?ProceedingJoinPoint $proceedingJoinPoint = null): string
     {
         if ($value !== null) {
             if ($matches = StringHelper::parse($value)) {
                 foreach ($matches as $search) {
                     $k = str_replace(['#{', '}'], '', $search);
+                    if (strpos($k, 'this.') === 0 && ! array_key_exists('this', $arguments)) {
+                        $arguments['this'] = $proceedingJoinPoint->getInstance();
+                    }
 
                     $value = Str::replaceFirst($search, (string) data_get($arguments, $k), $value);
                 }

--- a/src/cache/tests/Cases/AnnotationTest.php
+++ b/src/cache/tests/Cases/AnnotationTest.php
@@ -16,6 +16,7 @@ use Hyperf\Cache\Annotation\CachePut;
 use Hyperf\Cache\AnnotationManager;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -84,17 +85,23 @@ class AnnotationTest extends TestCase
         $manager->shouldReceive('getAnnotation')->with(Cacheable::class, Mockery::any(), Mockery::any())->once()->andReturn($cacheable2);
         $manager->shouldReceive('getAnnotation')->with(CachePut::class, Mockery::any(), Mockery::any())->once()->andReturn($cacheput);
 
-        [$key, $ttl] = $manager->getCacheableValue('Foo', 'test', ['id' => $id = uniqid()]);
+        $closure = static function () {
+        };
+
+        $point = new ProceedingJoinPoint($closure, 'Foo', 'test', ['keys' => ['id' => $id = uniqid()]]);
+        [$key, $ttl] = $manager->getCacheableValue($point);
         $this->assertSame('test:' . $id, $key);
         $this->assertGreaterThanOrEqual(3600, $ttl);
         $this->assertLessThanOrEqual(3700, $ttl);
 
-        [$key, $ttl] = $manager->getCachePutValue('Foo', 'test', ['id' => $id = uniqid()]);
+        $point = new ProceedingJoinPoint($closure, 'Foo', 'test', ['keys' => ['id' => $id = uniqid()]]);
+        [$key, $ttl] = $manager->getCachePutValue($point);
         $this->assertSame('test:' . $id, $key);
         $this->assertGreaterThanOrEqual(3600, $ttl);
         $this->assertLessThanOrEqual(3700, $ttl);
 
-        [$key, $ttl] = $manager->getCacheableValue('Foo', 'test', ['id' => $id = uniqid()]);
+        $point = new ProceedingJoinPoint($closure, 'Foo', 'test', ['keys' => ['id' => $id = uniqid()]]);
+        [$key, $ttl] = $manager->getCacheableValue($point);
         $this->assertSame('test:' . $id, $key);
         $this->assertSame(3600, $ttl);
     }

--- a/src/cache/tests/Cases/StringHelperTest.php
+++ b/src/cache/tests/Cases/StringHelperTest.php
@@ -30,5 +30,10 @@ class StringHelperTest extends TestCase
 
         $string = StringHelper::format('test', ['id' => 1, 'name' => 'Hyperf']);
         $this->assertSame('test:1:Hyperf', $string);
+
+        $string = StringHelper::format('test', ['_this' => new class extends \stdClass {
+            public $id = 1;
+        }], '#{_this.id}');
+        $this->assertSame('test:1', $string);
     }
 }

--- a/src/cache/tests/Cases/StringHelperTest.php
+++ b/src/cache/tests/Cases/StringHelperTest.php
@@ -31,9 +31,12 @@ class StringHelperTest extends TestCase
         $string = StringHelper::format('test', ['id' => 1, 'name' => 'Hyperf']);
         $this->assertSame('test:1:Hyperf', $string);
 
-        $string = StringHelper::format('test', ['_this' => new class extends \stdClass {
+        $string = StringHelper::format('test', ['id' => 1, 'name' => 'Hyperf'], 'Hyperf:#{name}');
+        $this->assertSame('test:Hyperf:Hyperf', $string);
+
+        $string = StringHelper::format('test', ['this' => new class() extends \stdClass {
             public $id = 1;
-        }], '#{_this.id}');
+        }], '#{this.id}');
         $this->assertSame('test:1', $string);
     }
 }


### PR DESCRIPTION
非静态调用可以结合调用者对象中的值来自定义缓存；比如，下面自定义缓存key中使用的 #{_this.id} 来获取当前对象中的主键；不过这个值不能获取到protect和private的值，取决于函数data_get()，所以后面可以完善。
```
class User extends Model
{
    protected $primaryKey = 'id';
    protected $table = 'user';
    /**
     * @Cacheable(group="cache", prefix="userGetRoles", value="#{_this.id}")
     * @return array[]
     */
    public function getRoles(){
        //模拟通过用户id获取roles
        return [
            [
                'id' => 1,
                'name' => '管理员',
                'pivot' => [
                    'role_id' => 1,
                    'user_id' => $this->getKey()
                ]
            ],
            [
                'id' => 2,
                'name' => '默认角色',
                'pivot' => [
                    'role_id' => 2,
                    'user_id' => $this->getKey()
                ]
            ]
        ];

    }
```