### PR TITLE
Fixed bug that Arr::forget failed when the integer key does not exists.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.10 - TBD
 
+## Fixed
+
+- [#3348](https://github.com/hyperf/hyperf/pull/3348) Fixed bug that `Arr::forget` failed when the integer key does not exists.
+
 # v2.1.9 - 2021-03-08
 
 ## Fixed

--- a/src/utils/src/Arr.php
+++ b/src/utils/src/Arr.php
@@ -205,7 +205,7 @@ class Arr
                 unset($array[$key]);
                 continue;
             }
-            $parts = explode('.', $key);
+            $parts = explode('.', (string) $key);
             // clean up before each pass
             $array = &$original;
             while (count($parts) > 1) {

--- a/src/utils/tests/ArrTest.php
+++ b/src/utils/tests/ArrTest.php
@@ -141,4 +141,29 @@ class ArrTest extends TestCase
         $result = Arr::merge($result, $array2);
         $this->assertSame($array1, $result);
     }
+
+    public function testArrorForget()
+    {
+        $data = [1, 2];
+        Arr::forget($data, [1]);
+        $this->assertSame([1], $data);
+
+        $data = ['id' => 1, 'name' => 'Hyperf'];
+        Arr::forget($data, ['gender']);
+        $this->assertSame(['id' => 1, 'name' => 'Hyperf'], $data);
+        Arr::forget($data, ['id']);
+        $this->assertSame(['name' => 'Hyperf'], $data);
+
+        $data = ['id' => 1, 'name' => 'Hyperf', 'data' => ['id' => 2], 'data.name' => 'Swoole'];
+        Arr::forget($data, ['data.gender']);
+        $this->assertSame(['id' => 1, 'name' => 'Hyperf', 'data' => ['id' => 2], 'data.name' => 'Swoole'], $data);
+        Arr::forget($data, ['data.name']);
+        $this->assertSame(['id' => 1, 'name' => 'Hyperf', 'data' => ['id' => 2]], $data);
+        Arr::forget($data, ['data.id']);
+        $this->assertSame(['id' => 1, 'name' => 'Hyperf', 'data' => []], $data);
+
+        $data = [1, 2];
+        Arr::forget($data, [2]);
+        $this->assertSame([1, 2], $data);
+    }
 }

--- a/src/utils/tests/ArrTest.php
+++ b/src/utils/tests/ArrTest.php
@@ -162,6 +162,10 @@ class ArrTest extends TestCase
         Arr::forget($data, ['data.id']);
         $this->assertSame(['id' => 1, 'name' => 'Hyperf', 'data' => []], $data);
 
+        $data = ['data' => ['data' => ['id' => 1, 'name' => 'Hyperf']]];
+        Arr::forget($data, ['data.data.id']);
+        $this->assertSame(['data' => ['data' => ['name' => 'Hyperf']]], $data);
+
         $data = [1, 2];
         Arr::forget($data, [2]);
         $this->assertSame([1, 2], $data);


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/3347