### PR TITLE
optimize cache key when complex arguments

### DIFF
--- a/src/cache/src/Helper/StringHelper.php
+++ b/src/cache/src/Helper/StringHelper.php
@@ -29,7 +29,7 @@ class StringHelper
                 }
             }
         } else {
-            $value = implode(':', $arguments);
+            $value = sha1(serialize($arguments));
         }
 
         return $prefix . ':' . $value;


### PR DESCRIPTION
Example:

```php
/**
 * @Cacheable('cache_prefix', ttl=600)
 */
public function get(array $option = [])
{
    //...
}
```