### PR TITLE
Optimized `phar:build` that you can run phar without `php`.

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -40,4 +40,6 @@ jobs:
           php bin/hyperf.php phar:build --name link_env.phar -M .env.link:.env
           echo APP_NAME=helloworld > .env.link
           php link_env.phar show:name -N helloworld
+          sudo chmod u+x link_env.phar
+          ./link_env.phar show:name -N helloworld
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -7,6 +7,10 @@
 - [#3356](https://github.com/hyperf/hyperf/pull/3356) Fixed bug that could't get the valid `uri` when using `Hyperf\Testing\Client`.
 - [#3363](https://github.com/hyperf/hyperf/pull/3363) Fixed `constants` which defined in `bin/hyperf.php` does not works.
 
+## Optimized
+
+- [#3364](https://github.com/hyperf/hyperf/pull/3364) Optimized `phar:build` that you can run phar without `php`, such as `./composer.phar` instead of `php composer.phar`.
+
 # v2.1.9 - 2021-03-08
 
 ## Fixed

--- a/src/phar/src/TargetPhar.php
+++ b/src/phar/src/TargetPhar.php
@@ -85,10 +85,12 @@ class TargetPhar
      */
     public function createDefaultStub(string $indexFile, string $webIndexFile = null): string
     {
+        $params = [$indexFile];
         if ($webIndexFile != null) {
-            return $this->phar->createDefaultStub($indexFile, $webIndexFile);
+            $params[] = $webIndexFile;
         }
-        return $this->phar->createDefaultStub($indexFile);
+
+        return '#!/usr/bin/env php' . PHP_EOL . $this->phar->createDefaultStub(...$params);
     }
 
     /**


### PR DESCRIPTION
Such as `./composer.phar` instead of `php composer.phar` 