### PR TITLE
Translate docs/en/router.md to english

### DIFF
--- a/docs/en/router.md
+++ b/docs/en/router.md
@@ -1,52 +1,52 @@
-# 路由
+# Routing
 
-默认情况下路由由 [nikic/fast-route](https://github.com/nikic/FastRoute) 提供支持，并由 [hyperf/http-server](https://github.com/hyperf-cloud/http-server) 组件负责接入到 `Hyperf` 中，`RPC` 路由由对应的 [hyperf/rpc-server](https://github.com/hyperf-cloud/rpc-server) 组件负责。
+By default, routing uses the [nikic/fast-route](https://github.com/nikic/FastRoute) package. The [hyperf/http-server](https://github.com/hyperf/http-server) component is responsible for connecting to the `Hyperf` server while `RPC` routing is implemented by [hyperf/rpc-server](https://github.com/hyperf/rpc-server) component.
 
-## HTTP 路由
+## HTTP routing
 
-### 通过配置文件定义路由
+### Define routing via configuration file
 
-在 [hyperf-skeleton](https://github.com/hyperf-cloud/hyperf-skeleton) 骨架下，默认在 `config/routes.php` 文件内完成所有的路由定义，当然如果您路由众多，您也可以对该文件进行扩展，以适应您的需求，但 `Hyperf` 还支持 `注解路由`，我们更推荐使用 `注解路由`，特别是在路由众多的情况下。   
+Under the [hyperf-skeleton](https://github.com/hyperf/hyperf-skeleton) skeleton, all routing definitions are defined in the `config/routes.php` file by default. `Hyperf` also supports `annotation routing`, which is the recommended method, especially when there are a lot of routes.
 
-#### 通过闭包定义路由
+#### Defining routes using closures
 
-构建一个最基本的路由只需一个 URI 和一个 `闭包(Closure)`，我们直接通过代码来演示一下：
+Only a URI and a closure (Closure) are needed to construct a basic route:
 
 ```php
 <?php
 use Hyperf\HttpServer\Router\Router;
 
 Router::get('/hello-hyperf', function () {
-    return 'Hello Hyperf.';
+    return'Hello Hyperf.';
 });
 ```
 
-您可以通过 浏览器 或  `cURL` 命令行来请求 `http://host:port/hello-hyperf` 来访问该路由。
+You can now request `http://host:port/hello-hyperf` through a browser or the `cURL` command line to access the route.
 
-#### 定义标准路由
+#### Define standard routing
 
-所谓标准路由指的是由 `控制器(Controller)` 和 `操作(Action)` 来处理的路由，如果您使用 `请求处理器(Request Handler)` 模式也是类似的，我们通过代码来演示一下：
+The so-called standard routing refers to the routing handled by the `controllers` and `actions`. This method is quite similar to the closure definition with the obvious difference that business logic can be delegated to respective controller classes:
 
 ```php
 <?php
 use Hyperf\HttpServer\Router\Router;
 
-// 下面三种方式的任意一种都可以达到同样的效果
-Router::get('/hello-hyperf', 'App\Controller\IndexController::hello');
-Router::get('/hello-hyperf', 'App\Controller\IndexController@hello');
-Router::get('/hello-hyperf', [App\Controller\IndexController::class, 'hello']);
+// Any of the following three definitions can achieve the same effect
+Router::get('/hello-hyperf','App\Controller\IndexController::hello');
+Router::get('/hello-hyperf','App\Controller\IndexController@hello');
+Router::get('/hello-hyperf', [App\Controller\IndexController::class,'hello']);
 ```
 
-该路由定义为将 `/hello-hyperf` 路径绑定到 `App\Controller\IndexController` 下的 `hello` 方法。
+The route is defined as binding the `/hello-hyperf` path to the `hello` method under `App\Controller\IndexController`.
 
-#### 可用的路由方法
+#### Available routing methods
 
-路由器提供了多种方法帮助您注册任何的 HTTP 请求的路由：
+The router provides multiple methods to help you register any HTTP request routing:
 
 ```php
 use Hyperf\HttpServer\Router\Router;
 
-// 注册与方法名一致的 HTTP METHOD 的路由
+// Register the route of the HTTP METHOD consistent with the method name
 Router::get($uri, $callback);
 Router::post($uri, $callback);
 Router::put($uri, $callback);
@@ -54,21 +54,21 @@ Router::patch($uri, $callback);
 Router::delete($uri, $callback);
 Router::head($uri, $callback);
 
-// 注册任意 HTTP METHOD 的路由
+// Register the route of any HTTP METHOD
 Router::addRoute($httpMethod, $uri, $callback);
 ```
 
-有时候您可能需要注册一个可以同时响应多种 HTTP METHOD 请求的路由，可以通过 `addRoute` 方法实现定义：
+Sometimes you may need to register a route that can correspond to multiple different HTTP methods at the same time. This can be achieved by using the `addRoute` method:
 
 ```php
 use Hyperf\HttpServer\Router\Router;
 
-Router::addRoute(['GET', 'POST','PUT','DELETE'], $uri, $callback);
+Router::addRoute(['GET','POST','PUT','DELETE'], $uri, $callback);
 ```
 
-#### 路由组的定义方式
+#### How to define route groups
 
-实际路由为 `gourp/route`, 即 `/user/index`, `/user/store`, `/user/update`, `/user/delete` 
+The route group adds the group prefix to each URI. The actual route is `group/route`, namely `/user/index`, `/user/store`, `/user/update`, `/user/delete`
 
 ```php
 Router::addGroup('/user/',function (){
@@ -77,18 +77,25 @@ Router::addGroup('/user/',function (){
     Router::get('update','App\Controller\UserController@update');
     Router::post('delete','App\Controller\UserController@delete');
 });
-
 ```
 
-### 通过注解定义路由
+### Define routing via annotations
 
-`Hyperf` 提供了非常便利的 [注解](en/annotation.md) 路由功能，您可以直接在任意类上通过定义 `@Controller` 或 `@AutoController` 注解来完成一个路由的定义。
+`Hyperf` provides a very convenient [annotation](en/annotation.md) routing function. You can directly define a route by defining `@Controller` or `@AutoController` annotations on any class.
 
-#### `@AutoController` 注解
+#### AutoController annotation
 
-`@AutoController` 为绝大多数简单的访问场景提供路由绑定支持，使用 `@AutoController` 时则 `Hyperf` 会自动解析所在类的所有 `public` 方法并提供 `GET` 和 `POST` 两种请求方式。
+`@AutoController` provides routing binding support for most simple access scenarios. When using `@AutoController`, `Hyperf` will automatically parse all the `public` methods of the class it is in and provide both `GET` and `POST` Request method.
 
-> 使用 `@AutoController` 注解时需 `use Hyperf\HttpServer\Annotation\AutoController;` 命名空间；
+> When using `@AutoController` annotation, `use Hyperf\HttpServer\Annotation\AutoController;` namespace is required.
+
+Pascal case controller names will be converted to snake_case automatically. The following is an example of the correspondence between the controller, annotation and the resulting route:
+
+|    Controller    |            Annotation           |    Route URI   |
+|:----------------:|:-------------------------------:|:--------------:|
+| MyDataController |        @AutoController()        | /my_data/index |
+| MydataController |        @AutoController()        | /mydata/index  |
+| MyDataController | @AutoController(prefix="/data") | /data/index    |
 
 ```php
 <?php
@@ -104,28 +111,29 @@ use Hyperf\HttpServer\Annotation\AutoController;
  */
 class UserController
 {
-    // Hyperf 会自动为此方法生成一个 /user/index 的路由，允许通过 GET 或 POST 方式请求
+    // Hyperf will automatically generate a /user/index route for this method, allowing requests via GET or POST
     public function index(RequestInterface $request)
     {
-        // 从请求中获得 id 参数
+        // Obtain the id parameter from the request
         $id = $request->input('id', 1);
         return (string)$id;
     }
 }
 ```
 
-#### `@Controller` 注解
+#### Controller annotation
 
-`@Controller` 为满足更细致的路由定义需求而存在，使用 `@Controller` 注解用于表名当前类为一个 `Controller` 类，同时需配合 `@RequestMapping` 注解来对请求方法和请求路径进行更详细的定义。   
-我们也提供了多种快速便捷的 `Mapping` 注解，如 `@GetMapping`、`@PostMapping`、`@PutMapping`、`@PatchMapping`、`@DeleteMapping` 5种便捷的注解用于表明允许不同的请求方法。
+`@Controller` exists to meet more detailed routing definition requirements. The use of the `@Controller` annotation is used to indicate that the current class is a `controller` class, and the `@RequestMapping` annotation is required to update the detailed definition of request method and URI.
 
-> 使用 `@Controller` 注解时需 `use Hyperf\HttpServer\Annotation\Controller;` 命名空间；   
-> 使用 `@RequestMapping` 注解时需 `use Hyperf\HttpServer\Annotation\RequestMapping;` 命名空间；   
-> 使用 `@GetMapping` 注解时需 `use Hyperf\HttpServer\Annotation\GetMapping;` 命名空间；   
-> 使用 `@PostMapping` 注解时需 `use Hyperf\HttpServer\Annotation\PostMapping;` 命名空间；   
-> 使用 `@PutMapping` 注解时需 `use Hyperf\HttpServer\Annotation\PutMapping;` 命名空间；   
-> 使用 `@PatchMapping` 注解时需 `use Hyperf\HttpServer\Annotation\PatchMapping;` 命名空间；   
-> 使用 `@DeleteMapping` 注解时需 `use Hyperf\HttpServer\Annotation\DeleteMapping;` 命名空间；  
+We also provide a variety of quick and convenient `mapping` annotations, such as `@GetMapping`, `@PostMapping`, `@PutMapping`, `@PatchMapping` and `@DeleteMapping`, each corresponding with a matching request method.
+
+- When using `@Controller` annotation, `use Hyperf\HttpServer\Annotation\Controller` namespace is required.
+- When using `@RequestMapping` annotation, `use Hyperf\HttpServer\Annotation\RequestMapping` namespace is required.
+- When using `@GetMapping` annotation, `use Hyperf\HttpServer\Annotation\GetMapping` namespace is required.
+- When using `@PostMapping` annotation, `use Hyperf\HttpServer\Annotation\PostMapping` namespace is required.
+- When using `@PutMapping` annotation, `use Hyperf\HttpServer\Annotation\PutMapping` namespace is required.
+- When using `@PatchMapping` annotation, `use Hyperf\HttpServer\Annotation\PatchMapping` namespace is required.
+- When using `@DeleteMapping` annotation, `use Hyperf\HttpServer\Annotation\DeleteMapping` namespace is required.
 
 ```php
 <?php
@@ -142,53 +150,70 @@ use Hyperf\HttpServer\Annotation\RequestMapping;
  */
 class UserController
 {
-    // Hyperf 会自动为此方法生成一个 /user/index 的路由，允许通过 GET 或 POST 方式请求
+    // Hyperf will automatically generate a /user/index route for this method, allowing requests via GET or POST
     /**
      * @RequestMapping(path="index", methods="get,post")
      */
     public function index(RequestInterface $request)
     {
-        // 从请求中获得 id 参数
+        // Obtain the id parameter from the request
         $id = $request->input('id', 1);
         return (string)$id;
     }
 }
 ```
 
-#### 注解参数
+#### Annotation parameters
 
-`@Controller` 和 `@AutoController` 都提供了 `prefix` 和 `server` 两个参数。   
+Both `@Controller` and `@AutoController` provide two parameters, `prefix` and `server`.
 
-`prefix` 表示该 `Controller` 下的所有方法路由的前缀，默认为类名的小写，如 `UserController` 则 `prefix` 默认为 `user`，如类内某一方法的 `path` 为 `index`，则最终路由为 `/user/index`。   
-需要注意的是 `prefix` 并非一直有效，当类内的方法的 `path` 以 `/` 开头时，则表明路径从 `URI` 头部开始定义，也就意味着会忽略 `prefix` 的值。
+`prefix` represents the URI prefix for all methods under the controller, the default is the lowercase of the class name. For example, in the case of `UserController`, the `prefix` defaults to `user`, so if the controller method is `index`, then the final route is `/user/index`.
+It should be noted that the `prefix` is not always used: when the `path` of a method in a class starts with `/`, it means that the path is defined as an absolute `URI` and the value of `prefix` will be ignored .
 
-`server` 表示该路由是定义在哪个 `Server` 之上的，由于 `Hyperf` 支持同时启动多个 `Server`，也就意味着有可能会同时存在多个 `HTTP Server`，则在定义路由是可以通过 `server` 参数来进行区分这个路由是为了哪个 `Server` 定义的，默认为 `http`。
+`server` indicates which server the route is defined for. Since `Hyperf` supports starting multiple servers at the same time, there may be multiple HTTP servers running at the same time. Therefore defining the `server` parameter can be used to distinguish which server the route is defined for. The default is `http`.
 
-### 路由参数
+### Route parameters
 
-> 本框架定义的路由参数必须和控制器参数键名、类型保持一致，否则控制器无法接受到相关参数
+> Given route parameters must be consistent with the controller parameter key name and type, otherwise the controller cannot accept the relevant parameters
 
 ```php
-Router::get('/user/{id}', 'App\Controller\UserController::info')
+Router::get('/user/{id}','App\Controller\UserController::info');
 ```
+Access route parameter via controller method injection.
 
 ```php
-public function index(int $id)
+public function info(int $id)
 {
     $user = User::find($id);
     return $user->toArray();
 }
 ```
 
-#### 必填参数
+Access route parameter via request object.
 
-我们可以对 `$uri` 进行一些参数定义，通过 `{}` 来声明参数，如 `/user/{id}` 则声明了 `id` 值为一个必填参数。
+```php
+public function index(RequestInterface $request)
+{
+        // If it exists, it will return, if it does not exist, it will return the default value null
+        $id = $request->route('id');
+        // If it exists, it returns, if it doesn't exist, it returns the default value 0
+        $id = $request->route('id', 0);
+}
+```
 
-#### 可选参数
+#### Required parameters
 
-有时候您可能会希望这个参数是可选的，您可以通过 `[]` 来声明中括号内的参数为一个可选参数，如 `/user/[{id}]`。
+We can define required route parameters using `{}`. For example, `/user/{id}` declares that `id` is a required parameter.
 
-#### 获取路由信息
+#### Optional parameters
 
-如果安装了 devtool 组件，可使用 `php bin/hyperf.php describe:routes` 命令获取路由列表信息，
-并且提供path可选项，方便获取单个路由信息，对应的命令 `php bin/hyperf.php describe:routes --path=/foo/bar`。
+Sometimes you may want a route parameter to be optional. In this case, you can use `[]` to declare the parameter inside the brackets as an optional parameter, such as `/user/[{id}]`.
+
+#### Get routing information
+
+If the devtool component is installed, you can use the `php bin/hyperf.php describe:routes` command to get the routing list information.  You can also provide the path option, which is convenient for obtaining the information of a single route, for example: `php bin/hyperf.php describe:routes --path=/foo/bar`.
+
+## HTTP exceptions
+
+When the route fails to match the route, such as `route not found (404)`, `request method not allowed (405)` and other HTTP exceptions, Hyperf will uniformly throw an exception that inherits the `Hyperf\HttpMessage\Exception\HttpException` class. You need to manage these exceptions through the `ExceptionHandler` mechanism and do the corresponding response processing. By default, you can directly use the `Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler` provided by the component for exception capture and processing. Not that you need to configure this exception handler in the `config/autoload/exceptions.php` configuration file and ensure that the sequence link between multiple exception handlers is correct.
+When you need to customize the response to HTTP exceptions such as `route not found (404)` and `request method not allowed (405)`, you can directly implement your own exception handling based on the code of `HttpExceptionHandler` And configure your own exception handler. For the logic and usage instructions of the exception handler, please refer to [Exception Handling](zh-cn/exception-handler.md).

--- a/docs/en/router.md
+++ b/docs/en/router.md
@@ -17,7 +17,7 @@ Only a URI and a closure (Closure) are needed to construct a basic route:
 use Hyperf\HttpServer\Router\Router;
 
 Router::get('/hello-hyperf', function () {
-    return'Hello Hyperf.';
+    return 'Hello Hyperf.';
 });
 ```
 
@@ -32,9 +32,9 @@ The so-called standard routing refers to the routing handled by the `controllers
 use Hyperf\HttpServer\Router\Router;
 
 // Any of the following three definitions can achieve the same effect
-Router::get('/hello-hyperf','App\Controller\IndexController::hello');
-Router::get('/hello-hyperf','App\Controller\IndexController@hello');
-Router::get('/hello-hyperf', [App\Controller\IndexController::class,'hello']);
+Router::get('/hello-hyperf', 'App\Controller\IndexController::hello');
+Router::get('/hello-hyperf', 'App\Controller\IndexController@hello');
+Router::get('/hello-hyperf', [App\Controller\IndexController::class, 'hello']);
 ```
 
 The route is defined as binding the `/hello-hyperf` path to the `hello` method under `App\Controller\IndexController`.
@@ -71,11 +71,11 @@ Router::addRoute(['GET','POST','PUT','DELETE'], $uri, $callback);
 The route group adds the group prefix to each URI. The actual route is `group/route`, namely `/user/index`, `/user/store`, `/user/update`, `/user/delete`
 
 ```php
-Router::addGroup('/user/',function (){
-    Router::get('index','App\Controller\UserController@index');
-    Router::post('store','App\Controller\UserController@store');
-    Router::get('update','App\Controller\UserController@update');
-    Router::post('delete','App\Controller\UserController@delete');
+Router::addGroup('/user/', function (){
+    Router::get('index', 'App\Controller\UserController@index');
+    Router::post('store', 'App\Controller\UserController@store');
+    Router::get('update', 'App\Controller\UserController@update');
+    Router::post('delete', 'App\Controller\UserController@delete');
 });
 ```
 
@@ -177,7 +177,7 @@ It should be noted that the `prefix` is not always used: when the `path` of a me
 > Given route parameters must be consistent with the controller parameter key name and type, otherwise the controller cannot accept the relevant parameters
 
 ```php
-Router::get('/user/{id}','App\Controller\UserController::info');
+Router::get('/user/{id}', 'App\Controller\UserController::info');
 ```
 Access route parameter via controller method injection.
 
@@ -194,10 +194,10 @@ Access route parameter via request object.
 ```php
 public function index(RequestInterface $request)
 {
-        // If it exists, it will return, if it does not exist, it will return the default value null
-        $id = $request->route('id');
-        // If it exists, it returns, if it doesn't exist, it returns the default value 0
-        $id = $request->route('id', 0);
+    // If it exists, it will return, if it does not exist, it will return the default value null
+    $id = $request->route('id');
+    // If it exists, it returns, if it doesn't exist, it returns the default value 0
+    $id = $request->route('id', 0);
 }
 ```
 


### PR DESCRIPTION
Translated the contents of docs/en/router.md from chinese to english. Also added the new content from the latest chinese doc version.

Are the standardized guidelines for which words should be surrounded by `the backtick notation`? Working through multiple pages of documentation, it seems rather arbitrary as sometimes words like `Hyperf` are in backtick notation while other times it's lacking the notation and is simply written as Hyperf. 