### PR TITLE
Fixed bug that consult couldn't force a node into the left state.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.16 - TBD
 
+## Fixed
+
+- [#3510](https://github.com/hyperf/hyperf/pull/3510) Fixed bug that consult couldn't force a node into the left state.
+
 # v2.1.15 - 2021-04-19
 
 ## Added

--- a/src/consul/src/Agent.php
+++ b/src/consul/src/Agent.php
@@ -48,7 +48,7 @@ class Agent extends Client implements AgentInterface
 
     public function forceLeave($node): ConsulResponse
     {
-        return $this->request('GET', '/v1/agent/force-leave/' . $node);
+        return $this->request('PUT', '/v1/agent/force-leave/' . $node);
     }
 
     public function registerCheck($check): ConsulResponse


### PR DESCRIPTION
[reference](https://www.consul.io/api-docs/agent)