### PR TITLE
fixed NacosConfig.php

### DIFF
--- a/src/nacos/src/Api/NacosConfig.php
+++ b/src/nacos/src/Api/NacosConfig.php
@@ -17,7 +17,7 @@ use Hyperf\Utils\Codec\Json;
 
 class NacosConfig extends AbstractNacos
 {
-    public function get(ConfigModel $configModel): array
+    public function get(ConfigModel $configModel)
     {
         $response = $this->request('GET', '/nacos/v1/cs/configs', [
             RequestOptions::QUERY => $configModel->toArray(),


### PR DESCRIPTION
修复 nacos 配置中心，将配置设置为 html 或者是 text 时获取相关配置报错的问题（ #3530 ）