### PR TITLE
Fixed bug that `fromSub()` and `joinSub()` don't work with table prefix.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -4,6 +4,7 @@
 
 - [#3598](https://github.com/hyperf/hyperf/pull/3598) Fixed bug that `increment/decrement` does not works as expect when used in transaction for model-cache.
 - [#3607](https://github.com/hyperf/hyperf/pull/3607) Fixed bug that coroutine won't destruct when using `onOpen` in coroutine style websocket server.
+- [#3610](https://github.com/hyperf/hyperf/pull/3610) Fixed bug that `fromSub()` and `joinSub()` don't work with table prefix.
 
 # v2.1.17 - 2021-05-17
 

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -324,7 +324,7 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        return $this->fromRaw('(' . $query . ') as ' . $this->grammar->wrap($as), $bindings);
+        return $this->fromRaw('(' . $query . ') as ' . $this->grammar->wrapTable($as), $bindings);
     }
 
     /**
@@ -455,7 +455,7 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '(' . $query . ') as ' . $this->grammar->wrap($as);
+        $expression = '(' . $query . ') as ' . $this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 


### PR DESCRIPTION
修复 子查询表别名前缀错误

fix https://github.com/hyperf/hyperf/issues/3602