### PR TITLE
Add Rpc dot path generator

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -5,6 +5,10 @@
 - [#3618](https://github.com/hyperf/hyperf/pull/3618) Fixed routes with same path but different methods will be merged when using `describe:routes`.
 - [#3625](https://github.com/hyperf/hyperf/pull/3625) Fixed bug that `class_map` does not works in `Hyperf\Di\Annotation\Scanner`.
 
+## Added
+
+- [#3626](https://github.com/hyperf/hyperf/pull/3626) Added `Hyperf\Rpc\PathGenerator\DotPathGenerator`.
+
 # v2.1.18 - 2021-05-24
 
 ## Fixed

--- a/src/json-rpc/src/ConfigProvider.php
+++ b/src/json-rpc/src/ConfigProvider.php
@@ -24,13 +24,13 @@ class ConfigProvider
                 DataFormatter::class => DataFormatterFactory::class,
             ],
             'listeners' => [
-                RegisterProtocolListener::class => intval(2147483647 / 2),
+                RegisterProtocolListener::class,
                 value(function () {
                     if (class_exists(ServiceManager::class)) {
                         return RegisterServiceListener::class;
                     }
                     return null;
-                }) => intval(2147483647 / 2),
+                }),
             ],
             'annotations' => [
                 'scan' => [

--- a/src/json-rpc/src/ConfigProvider.php
+++ b/src/json-rpc/src/ConfigProvider.php
@@ -24,13 +24,13 @@ class ConfigProvider
                 DataFormatter::class => DataFormatterFactory::class,
             ],
             'listeners' => [
-                RegisterProtocolListener::class,
+                RegisterProtocolListener::class => intval(2147483647 / 2),
                 value(function () {
                     if (class_exists(ServiceManager::class)) {
                         return RegisterServiceListener::class;
                     }
                     return null;
-                }),
+                }) => intval(2147483647 / 2),
             ],
             'annotations' => [
                 'scan' => [

--- a/src/rpc/src/PathGenerator/DotPathGenerator.php
+++ b/src/rpc/src/PathGenerator/DotPathGenerator.php
@@ -22,6 +22,6 @@ class DotPathGenerator implements PathGeneratorInterface
         $handledNamespace = Str::replaceArray('\\', ['/'], end($handledNamespace));
         $path = Str::studly($handledNamespace);
 
-        $result = $path . '.' . Str::studly($method);
+        return $path . '.' . Str::studly($method);
     }
 }

--- a/src/rpc/src/PathGenerator/DotPathGenerator.php
+++ b/src/rpc/src/PathGenerator/DotPathGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Rpc\PathGenerator;
+
+use Hyperf\Rpc\Contract\PathGeneratorInterface;
+use Hyperf\Utils\Str;
+
+class DotPathGenerator implements PathGeneratorInterface
+{
+    public function generate(string $service, string $method): string
+    {
+        $handledNamespace = explode('\\', $service);
+        $handledNamespace = Str::replaceArray('\\', ['/'], end($handledNamespace));
+        $path = Str::studly($handledNamespace);
+
+        $result = $path . '.' . Str::studly($method);
+    }
+}


### PR DESCRIPTION
- Add 「dot」 style path generator for RPC, allow the method of rpc service using `FooSerivce.Bar` style to instead of URL Style `/foo/bar`
- The default priority of listeners is 1, so user could create an new listener to replace the data of protocol manager

How to use: 
Create an Listener like below
```php
<?php

namespace App\Listener;


use Hyperf\Di\Annotation\Inject;
use Hyperf\Event\Annotation\Listener;
use Hyperf\Event\Contract\ListenerInterface;
use Hyperf\Framework\Event\BootApplication;
use Hyperf\Rpc\PathGenerator\DotPathGenerator;

/**
 * @Listener(priority=0)
 */
class RpcProtocolRegister implements ListenerInterface
{

    /**
     * @Inject()
     * @var \Hyperf\Rpc\ProtocolManager
     */
    protected $protocolManager;

    public function listen(): array
    {
        return [
            BootApplication::class,
        ];
    }

    public function process(object $event)
    {
        $this->protocolManager->registerOrAppend('jsonrpc-http', [
            'path-generator' => DotPathGenerator::class,
        ]);
    }
}
```