### PR TITLE
fixed type conversion priority

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.20 - TBD
 
+## Fixed
+
+- [#3663](https://github.com/hyperf/hyperf/pull/3663) Fixed undefined index: Port for `AbstractServiceClient::getNodesFromConsul()`.
+
 # v2.1.19 - 2021-05-31
 
 ## Fixed

--- a/src/rpc-client/src/AbstractServiceClient.php
+++ b/src/rpc-client/src/AbstractServiceClient.php
@@ -247,7 +247,7 @@ abstract class AbstractServiceClient
 
             if ($passing) {
                 $address = $service['Address'] ?? '';
-                $port = (int) $service['Port'] ?? 0;
+                $port = (int) ($service['Port'] ?? 0);
                 // @TODO Get and set the weight property.
                 $address && $port && $nodes[] = new Node($address, $port);
             }


### PR DESCRIPTION
因为 (int) 优先级比 ?? 高，那 ?? 后面的值将无法得到执行，如果 ?? 后面为默认端口（例如9501），那默认端口将得不到执行，结果永远为0（虽然目前的结果都是 0，但防范于未然）