### PR TITLE
Fixed the wrong judgment of `counter` or `duration` for circuit breaker.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#3684](https://github.com/hyperf/hyperf/pull/3684) Fixed the wrong judgment of `fail counter` or `duration` for circuit breaker.
+- [#3684](https://github.com/hyperf/hyperf/pull/3684) Fixed the wrong judgment of `counter` or `duration` for circuit breaker.
 
 # v2.1.20 - 2021-06-07
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.21 - TBD
 
+## Fixed
+
+- [#3684](https://github.com/hyperf/hyperf/pull/3684) Fixed the wrong judgment of fail counter for circuit breaker.
+
 # v2.1.20 - 2021-06-07
 
 ## Fixed

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#3684](https://github.com/hyperf/hyperf/pull/3684) Fixed the wrong judgment of fail counter for circuit breaker.
+- [#3684](https://github.com/hyperf/hyperf/pull/3684) Fixed the wrong judgment of `fail counter` or `duration` for circuit breaker.
 
 # v2.1.20 - 2021-06-07
 

--- a/src/circuit-breaker/src/Handler/AbstractHandler.php
+++ b/src/circuit-breaker/src/Handler/AbstractHandler.php
@@ -77,7 +77,7 @@ abstract class AbstractHandler implements HandlerInterface
         $state = $breaker->state();
         if ($state->isClose()) {
             $this->logger->debug('The current state is closed.');
-            if ($breaker->getDuration() > $annotation->duration) {
+            if ($breaker->getDuration() >= $annotation->duration) {
                 $info = sprintf(
                     'The duration=%ss of closed state longer than the annotation duration=%ss and is reset to the closed state.',
                     $breaker->getDuration(),
@@ -87,7 +87,7 @@ abstract class AbstractHandler implements HandlerInterface
                 return $breaker->close();
             }
 
-            if (! $status && $breaker->getFailCounter() > $annotation->failCounter) {
+            if (! $status && $breaker->getFailCounter() >= $annotation->failCounter) {
                 $info = sprintf(
                     'The failCounter=%s more than the annotation failCounter=%s and is reset to the open state.',
                     $breaker->getFailCounter(),
@@ -102,7 +102,7 @@ abstract class AbstractHandler implements HandlerInterface
 
         if ($state->isHalfOpen()) {
             $this->logger->debug('The current state is half opened.');
-            if (! $status && $breaker->getFailCounter() > $annotation->failCounter) {
+            if (! $status && $breaker->getFailCounter() >= $annotation->failCounter) {
                 $info = sprintf(
                     'The failCounter=%s more than the annotation failCounter=%s and is reset to the open state.',
                     $breaker->getFailCounter(),
@@ -112,7 +112,7 @@ abstract class AbstractHandler implements HandlerInterface
                 return $breaker->open();
             }
 
-            if ($status && $breaker->getSuccessCounter() > $annotation->successCounter) {
+            if ($status && $breaker->getSuccessCounter() >= $annotation->successCounter) {
                 $info = sprintf(
                     'The successCounter=%s more than the annotation successCounter=%s and is reset to the closed state.',
                     $breaker->getSuccessCounter(),
@@ -127,7 +127,7 @@ abstract class AbstractHandler implements HandlerInterface
 
         if ($state->isOpen()) {
             $this->logger->debug('The current state is opened.');
-            if ($breaker->getDuration() > $annotation->duration) {
+            if ($breaker->getDuration() >= $annotation->duration) {
                 $info = sprintf(
                     'The duration=%ss of opened state longer than the annotation duration=%ss and is reset to the half opened state.',
                     $breaker->getDuration(),


### PR DESCRIPTION
关于熔断器，假如 failCounter = 1
第 1 次正常执行
第 2 次调用时应当熔断，执行 fallback，但实际上第 3 次才会进行熔断

因为 switch 是在执行完「业务方法」之后，也就是为下一次熔断机制作准备，
所以 switch 一些判断规则不能用 > ，而是 >=