### PR TITLE
update socketio event annotation collector, make event useable in trait methods

### DIFF
--- a/src/socketio-server/src/Collector/EventAnnotationCollector.php
+++ b/src/socketio-server/src/Collector/EventAnnotationCollector.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\SocketIOServer\Collector;
 
 use Hyperf\Di\MetadataCollector;
+use Hyperf\Di\ReflectionManager;
 use Hyperf\SocketIOServer\Annotation\Event;
 
 class EventAnnotationCollector extends MetadataCollector
@@ -21,12 +22,66 @@ class EventAnnotationCollector extends MetadataCollector
      */
     protected static $container = [];
 
+    /**
+     * @var array
+     */
+    protected static $traits = [];
+
+    /**
+     * @var array
+     */
+    protected static $classes = [];
+
     public static function collectEvent(string $class, string $method, Event $value): void
+    {
+        $reflectedClass = ReflectionManager::reflectClass($class);
+        if ($reflectedClass->isTrait()) {
+            if (array_key_exists($class, static::$traits) ?: fn() => static::$traits[$class] = [] or
+                ! array_key_exists($value->event, static::$traits[$class])) {
+                static::$traits[$class][$value->event] = [[$method,$value, false]];
+            }
+
+            foreach (static::$classes as $targetClass => $traits) {
+                if (in_array($reflectedClass->name, $traits)) {
+                    static::recordEvent($targetClass, $method, $value);
+                }
+            }
+        } else {
+            $traits = $reflectedClass->getTraits();
+            if (! empty($traits)) {
+                foreach ($traits as $trait => $reflectedTrait) {
+                    if (array_key_exists($class, static::$classes) ?: fn() => static::$classes[$class] = [] or
+                        ! array_key_exists($trait, static::$classes[$class])) {
+                        static::$classes[$class][] = $trait;
+                    }
+
+                    if (array_key_exists($trait, static::$traits)) {
+                        foreach (static::$traits[$trait] as &$methodCollection) {
+                            if (empty($methodCollection)) {
+                                continue;
+                            }
+                            foreach ($methodCollection as [$traitMethod, $event, &$recorded]) {
+                                if (! $recorded) {
+                                    static::recordEvent($class, $traitMethod, $event);
+                                    $recorded = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // register self
+            static::recordEvent($class, $method, $value);
+        }
+    }
+
+    protected static function recordEvent(string $class, string $method, Event $value)
     {
         if (static::has($class . '.' . $value->event)) {
             static::$container[$class][$value->event][] = [$class, $method];
         } else {
             static::$container[$class][$value->event] = [[$class, $method]];
         }
+
     }
 }


### PR DESCRIPTION
[issue3529](https://github.com/hyperf/hyperf/issues/3529)
我提供的一种思路是允许注册```event```注解在```trait method```当中， 但是传递进原```collectEvent```的第一个参数class却是trait的命名空间 而不是使用了该trait的类的命名空间。

所以我的思路是使用两个数组做一下缓存，当trait优先被扫描，使用他的类没有被扫描时，把trait的命名空间和```collectEvent```的参数先缓存到```static::$traits```中，等到有使用的了该trait的类被扫描时，检查static::$traits数组，并且将对应的函数注册到container中。

如果使用了```trait```的```class```类先被扫描，那么注册```class  ->  [traitA, traitB ...]```的关系到```static::$classes```数组，
等到被使用的trait被扫描时，检查该数组，并且将```collectEvent```中的第一个class参数替换成使用该trait的类的命名空间。如果class没有使用trait，那么就正常注册。

简单实现了一下，应该还有优化的空间，当然还有一种办法应该是修改```socketIORouter```，使用```backward```而不是```forward```进行路由。

另外我不是很清楚```MetadataCollector::clear()```函数的用法，因为```static::classes```和```static::$traits``` 在扫描结束后是可以释放掉的，我的想法是增加一个监听器，但是不知道有没有更好的办法。

@Reasno 

