### PR TITLE
Fixed wrong parameter definition of TimeoutException::__construct

### DIFF
--- a/src/circuit-breaker/src/Exception/TimeoutException.php
+++ b/src/circuit-breaker/src/Exception/TimeoutException.php
@@ -13,9 +13,9 @@ namespace Hyperf\CircuitBreaker\Exception;
 
 class TimeoutException extends CircuitBreakerException
 {
-    public function __construct(string $message = '', $result)
+    public function __construct(string $message = '', $result = null)
     {
         parent::__construct($message);
-        $this->result = $result;
+        $this->setResult($result);
     }
 }


### PR DESCRIPTION
Fixed `PHP Deprecated:  Required parameter $result follows optional parameter $message`