### PR TITLE
处理验证器内置规则in与not_in验证"0"与"00"结果错误的问题

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.22 - TBD
 
+## Fixed
+
+- [#3721](https://github.com/hyperf/hyperf/pull/3721) Fixed the `in` and `not in` rule for validation in input fails to correctly check `in:00` rule when passing `0`.
+
 # v2.1.21 - 2021-06-21
 
 ## Fixed

--- a/src/validation/src/Concerns/FormatsMessages.php
+++ b/src/validation/src/Concerns/FormatsMessages.php
@@ -291,7 +291,7 @@ trait FormatsMessages
         $actualValue = $this->getValue($attribute);
 
         if (is_scalar($actualValue) || is_null($actualValue)) {
-            $message = str_replace(':input', $actualValue, $message);
+            $message = str_replace(':input', (string) $actualValue, $message);
         }
 
         return $message;

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -630,7 +630,7 @@ trait ValidatesAttributes
             return count(array_diff($value, $parameters)) === 0;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters,true);
+        return ! is_array($value) && in_array((string) $value, $parameters, true);
     }
 
     /**

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -630,7 +630,7 @@ trait ValidatesAttributes
             return count(array_diff($value, $parameters)) === 0;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array((string) $value, $parameters,true);
     }
 
     /**

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -1823,6 +1823,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 0], ['name' => 'In:bar,baz']);
         $this->assertFalse($v->passes());
 
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 0], ['name' => 'In:00,000']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'In:foo,baz']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
例子：
```
        $data = [
             'foo' => '0'
        ];
        $validator = $this->validationFactory->make(
            $data,
            [
                'foo' => [
                    'in:000',
                ],
            ],
            [
                'foo.in' => 'foo must in 000',
            ]
        );
        return $validator->errors()->first();
        // 返回的结果应该为验证不通过,结果返回了验证通过
````