### PR TITLE
Fixed the active_url rule for validation in input fails to correctly check dns record with dns_get_record resulting in bypassing the validation.

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,5 +1,9 @@
 # v2.1.22 - TBD
 
+## Security
+
+- [#3723](https://github.com/hyperf/hyperf/pull/3723) Fixed the active_url rule for validation in input fails to correctly check dns record with dns_get_record resulting in bypassing the validation.
+
 # v2.1.21 - 2021-06-21
 
 ## Fixed

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -58,7 +58,7 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+                return count(dns_get_record($url . '.', DNS_A | DNS_AAAA)) > 0;
             } catch (Exception $e) {
                 return false;
             }


### PR DESCRIPTION
Ref: https://huntr.dev/bounties/2-laravel/framework/