### PR TITLE
Fixed bug that `config-center` conflicts with `metrics`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -78,3 +78,4 @@
 
 - [#3650](https://github.com/hyperf/hyperf/pull/3650) Fixed bug that `ReflectionParameter::getClass()` will be deprecated in php8.
 - [#3692](https://github.com/hyperf/hyperf/pull/3692) Fixed bug that class proxies couldn't be included when building phar.
+- [#3769](https://github.com/hyperf/hyperf/pull/3769) Fixed bug that `config-center` conflicts with `metrics`.

--- a/src/config-center/src/Listener/OnPipeMessageListener.php
+++ b/src/config-center/src/Listener/OnPipeMessageListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\ConfigCenter\Listener;
 
 use Hyperf\ConfigCenter\Contract\DriverInterface;
+use Hyperf\ConfigCenter\Contract\PipeMessageInterface;
 use Hyperf\ConfigCenter\DriverFactory;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
@@ -62,7 +63,7 @@ class OnPipeMessageListener implements ListenerInterface
     {
         if ($instance = $this->createDriverInstance()) {
             if ($event instanceof OnPipeMessage || $event instanceof UserProcessPipeMessage) {
-                $instance->onPipeMessage($event->data);
+                $event->data instanceof PipeMessageInterface && $instance->onPipeMessage($event->data);
             }
         }
     }

--- a/src/config-center/tests/Listener/OnPipeMessageListenerTest.php
+++ b/src/config-center/tests/Listener/OnPipeMessageListenerTest.php
@@ -84,5 +84,22 @@ class OnPipeMessageListenerTest extends TestCase
 
     public function testOnPipeMessageWithoutPipeMessageInterface()
     {
+        $config = new Config([
+            'config_center' => [
+                'enable' => true,
+                'driver' => 'etcd',
+                'drivers' => [
+                    'etcd' => [
+                        'driver' => EtcdDriver::class,
+                    ],
+                ],
+            ],
+        ]);
+        ContainerStub::mockContainer($config);
+        $factory = new DriverFactory($config);
+        $logger = Mockery::mock(StdoutLoggerInterface::class);
+        $listener = new OnPipeMessageListener($factory, $config, $logger);
+        $listener->process(new UserProcessPipeMessage(null));
+        $this->assertTrue(true);
     }
 }

--- a/src/config-center/tests/Listener/OnPipeMessageListenerTest.php
+++ b/src/config-center/tests/Listener/OnPipeMessageListenerTest.php
@@ -81,4 +81,8 @@ class OnPipeMessageListenerTest extends TestCase
         $listener->process(new UserProcessPipeMessage($pipeMessage));
         $this->assertTrue(true);
     }
+
+    public function testOnPipeMessageWithoutPipeMessageInterface()
+    {
+    }
 }


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/3767

```
TypeError: Hyperf\ConfigCenter\AbstractDriver::onPipeMessage(): Argument #1 ($pipeMessage) must be of type Hyperf\ConfigCenter\Contract\PipeMessageInterface, Hyperf\Metric\Adapter\RemoteProxy\Histogram given
```