### PR TITLE
Fixed type error when using `BladeCompiler::getRawPlaceholder()`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -82,3 +82,4 @@
 - [#3692](https://github.com/hyperf/hyperf/pull/3692) Fixed bug that class proxies couldn't be included when building phar.
 - [#3769](https://github.com/hyperf/hyperf/pull/3769) Fixed bug that `config-center` conflicts with `metrics`.
 - [#3770](https://github.com/hyperf/hyperf/pull/3770) Fixed type error when using `Str::slug()`.
+- [#3788](https://github.com/hyperf/hyperf/pull/3788) Fixed type error when using `BladeCompiler::getRawPlaceholder()`.

--- a/src/rpc-server/src/Server.php
+++ b/src/rpc-server/src/Server.php
@@ -109,8 +109,8 @@ abstract class Server implements OnReceiveInterface, MiddlewareInitializerInterf
             CoordinatorManager::until(Constants::WORKER_START)->yield();
 
             // Initialize PSR-7 Request and Response objects.
-            Context::set(ResponseInterface::class, $this->buildResponse($fd, $server));
             Context::set(ServerRequestInterface::class, $request = $this->buildRequest($fd, $reactorId, $data));
+            Context::set(ResponseInterface::class, $this->buildResponse($fd, $server));
 
             // $middlewares = array_merge($this->middlewares, MiddlewareManager::get());
             $middlewares = $this->middlewares;

--- a/src/rpc-server/src/Server.php
+++ b/src/rpc-server/src/Server.php
@@ -109,8 +109,8 @@ abstract class Server implements OnReceiveInterface, MiddlewareInitializerInterf
             CoordinatorManager::until(Constants::WORKER_START)->yield();
 
             // Initialize PSR-7 Request and Response objects.
-            Context::set(ServerRequestInterface::class, $request = $this->buildRequest($fd, $reactorId, $data));
             Context::set(ResponseInterface::class, $this->buildResponse($fd, $server));
+            Context::set(ServerRequestInterface::class, $request = $this->buildRequest($fd, $reactorId, $data));
 
             // $middlewares = array_merge($this->middlewares, MiddlewareManager::get());
             $middlewares = $this->middlewares;

--- a/src/view-engine/src/Compiler/BladeCompiler.php
+++ b/src/view-engine/src/Compiler/BladeCompiler.php
@@ -591,7 +591,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function getRawPlaceholder($replace): string
     {
-        return str_replace('#', (string)$replace, '@__raw_block_#__@');
+        return str_replace('#', (string) $replace, '@__raw_block_#__@');
     }
 
     /**

--- a/src/view-engine/src/Compiler/BladeCompiler.php
+++ b/src/view-engine/src/Compiler/BladeCompiler.php
@@ -591,7 +591,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function getRawPlaceholder($replace): string
     {
-        return str_replace('#', $replace, '@__raw_block_#__@');
+        return str_replace('#', (string)$replace, '@__raw_block_#__@');
     }
 
     /**


### PR DESCRIPTION
fixed:  throw "str_replace(): Argument #2 ($replace) must be of type array|string, int given" exception on PHP8