### PR TITLE
Fixed bug that amqp consumer couldn't restart when rabbitmq stopped.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -85,3 +85,4 @@
 - [#3770](https://github.com/hyperf/hyperf/pull/3770) Fixed type error when using `Str::slug()`.
 - [#3788](https://github.com/hyperf/hyperf/pull/3788) Fixed type error when using `BladeCompiler::getRawPlaceholder()`.
 - [#3794](https://github.com/hyperf/hyperf/pull/3794) Fixed bug that `retry_interval` does not work for `rpc-multiplex`.
+- [#3798](https://github.com/hyperf/hyperf/pull/3798) Fixed bug that amqp consumer couldn't restart when rabbitmq server stopped.

--- a/src/amqp/tests/Stub/AMQPConnectionStub.php
+++ b/src/amqp/tests/Stub/AMQPConnectionStub.php
@@ -12,11 +12,14 @@ declare(strict_types=1);
 namespace HyperfTest\Amqp\Stub;
 
 use Hyperf\Amqp\AMQPConnection;
+use Hyperf\Utils\Channel\ChannelManager;
 
 class AMQPConnectionStub extends AMQPConnection
 {
     public function __construct()
     {
+        $this->channelManager = new ChannelManager(16);
+        $this->channelManager->get(0, true);
     }
 
     public function setLastChannelId(int $id)


### PR DESCRIPTION
close https://github.com/hyperf/hyperf/issues/3795