### PR TITLE
add an extra field in LoadBalancer/Node

### DIFF
--- a/src/consul/publish/consul.php
+++ b/src/consul/publish/consul.php
@@ -12,4 +12,5 @@ declare(strict_types=1);
 return [
     'uri' => 'http://127.0.0.1:8500',
     'token' => '',
+    'node_filter' => '',
 ];

--- a/src/load-balancer/src/Node.php
+++ b/src/load-balancer/src/Node.php
@@ -28,10 +28,16 @@ class Node
      */
     public $port;
 
-    public function __construct(string $host, int $port, int $weight = 0)
+    /**
+     * @var array
+     */
+    public $extra;
+
+    public function __construct(string $host, int $port, array $extra = [], int $weight = 0)
     {
         $this->host = $host;
         $this->port = $port;
+        $this->extra = $extra;
         $this->weight = $weight;
     }
 }

--- a/src/rpc-client/src/AbstractServiceClient.php
+++ b/src/rpc-client/src/AbstractServiceClient.php
@@ -229,7 +229,7 @@ abstract class AbstractServiceClient
         $nodes = [];
         foreach ($nodeArray as $node) {
             // @TODO Get and set the weight property.
-            $nodes[] = new Node($node['host'], $node['port']);
+            $nodes[] = new Node($node['host'], $node['port'], $node['extra'] ?? []);
         }
 
         return $nodes;


### PR DESCRIPTION
为LoaderBalancer/Node添加了一个默认为空的extra属性
原因是希望使用consul注册rpc服务时 写一个自定义的负载均衡算法, 但是原Node类中只有host和port以及weight这三个属性 我可能会需要其他属性比如Service Id或者Service Name等, 所以在consul的配置文件中添加了一个node_filter选项, 对应一个callback function, 参数为DrvierInterface中getNodes方法的每一个元素, 返回值作为extra属性的值