### PR TITLE
Fixed bug that `libxml_disable_entity_loader()` has been deprecated as of PHP 8.0.0.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -87,4 +87,4 @@
 - [#3788](https://github.com/hyperf/hyperf/pull/3788) Fixed type error when using `BladeCompiler::getRawPlaceholder()`.
 - [#3794](https://github.com/hyperf/hyperf/pull/3794) Fixed bug that `retry_interval` does not work for `rpc-multiplex`.
 - [#3798](https://github.com/hyperf/hyperf/pull/3798) Fixed bug that amqp consumer couldn't restart when rabbitmq server stopped.
-- [#3814](https://github.com/hyperf/hyperf/pull/3814) Fixed libxml_disable_entity_loader function is deprecated as of PHP 8.0.0.
+- [#3814](https://github.com/hyperf/hyperf/pull/3814) Fixed bug that `libxml_disable_entity_loader()` has been deprecated as of PHP 8.0.0.

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -87,3 +87,4 @@
 - [#3788](https://github.com/hyperf/hyperf/pull/3788) Fixed type error when using `BladeCompiler::getRawPlaceholder()`.
 - [#3794](https://github.com/hyperf/hyperf/pull/3794) Fixed bug that `retry_interval` does not work for `rpc-multiplex`.
 - [#3798](https://github.com/hyperf/hyperf/pull/3798) Fixed bug that amqp consumer couldn't restart when rabbitmq server stopped.
+- [#3814](https://github.com/hyperf/hyperf/pull/3814) Fixed libxml_disable_entity_loader function is deprecated as of PHP 8.0.0.

--- a/src/utils/src/Codec/Xml.php
+++ b/src/utils/src/Codec/Xml.php
@@ -49,9 +49,14 @@ class Xml
 
     public static function toArray($xml)
     {
-        $disableLibxmlEntityLoader = libxml_disable_entity_loader(true);
-        $respObject = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NOERROR);
-        libxml_disable_entity_loader($disableLibxmlEntityLoader);
+        if (\PHP_VERSION_ID < 80000) {
+            $disableLibxmlEntityLoader = libxml_disable_entity_loader(true);
+            $respObject = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NOERROR);
+            libxml_disable_entity_loader($disableLibxmlEntityLoader);
+        } else {
+            $respObject = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NOERROR);
+        }
+
         if ($respObject === false) {
             throw new InvalidArgumentException('Syntax error.');
         }

--- a/src/utils/src/Codec/Xml.php
+++ b/src/utils/src/Codec/Xml.php
@@ -49,6 +49,10 @@ class Xml
 
     public static function toArray($xml)
     {
+        // For PHP 8.0, libxml_disable_entity_loader() has been deprecated.
+        // As libxml 2.9.0 is now required, external entity loading is guaranteed to be disabled by default.
+        // And this function is no longer needed to protect against XXE attacks, unless the (still vulnerable). LIBXML_NOENT is used.
+        // In that case, it is recommended to refactor the code using libxml_set_external_entity_loader() to suppress loading of external entities.
         if (\PHP_VERSION_ID < 80000) {
             $disableLibxmlEntityLoader = libxml_disable_entity_loader(true);
             $respObject = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NOERROR);


### PR DESCRIPTION
In PHP 8.0 and later, PHP uses libxml versions from 2.9.0, libxml_disable_entity_loader is deprecated.

close https://github.com/hyperf/hyperf/issues/3813

