### PR TITLE
Support RFC 5987 for `download()` which allows utf-8 encoding, percentage encoded (url-encoded).

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -10,6 +10,7 @@
 ## Optimized
 
 - [#3843](https://github.com/hyperf/hyperf/pull/3843) Check the status code and body of the response to ensure whether the instance already be registered.
+- [#3854](https://github.com/hyperf/hyperf/pull/3854) Support RFC 5987 for `Hyperf\HttpServer\Contract\ResponseInterface::download()` which allows utf-8 encoding, percentage encoded (url-encoded).
 
 # v2.2.0 - 2021-07-19
 

--- a/src/http-server/src/Response.php
+++ b/src/http-server/src/Response.php
@@ -166,7 +166,7 @@ class Response implements PsrResponseInterface, ResponseInterface
 
         return $this->withHeader('content-description', 'File Transfer')
             ->withHeader('content-type', $contentType)
-            ->withHeader('content-disposition', "attachment; filename={$filename}")
+            ->withHeader('content-disposition', "attachment; filename*=UTF-8''" . rawurlencode($filename))
             ->withHeader('content-transfer-encoding', 'binary')
             ->withHeader('pragma', 'public')
             ->withHeader('etag', $etag)

--- a/src/http-server/src/Response.php
+++ b/src/http-server/src/Response.php
@@ -166,7 +166,7 @@ class Response implements PsrResponseInterface, ResponseInterface
 
         return $this->withHeader('content-description', 'File Transfer')
             ->withHeader('content-type', $contentType)
-            ->withHeader('content-disposition', "attachment; filename*=UTF-8''" . rawurlencode($filename))
+            ->withHeader('content-disposition', "attachment; filename={$filename}; filename*=UTF-8''" . rawurlencode($filename))
             ->withHeader('content-transfer-encoding', 'binary')
             ->withHeader('pragma', 'public')
             ->withHeader('etag', $etag)


### PR DESCRIPTION
文件下载rfc规范以及多浏览器兼容
https://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http