### PR TITLE
Fixed bug that heartbeat failed when using nacos without default group.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.2 - TBD
 
+## Fixed
+
+- [#3872](https://github.com/hyperf/hyperf/pull/3872) Fixed bug that heartbeat failed when using nacos without default group.
+
 # v2.2.1 - 2021-07-27
 
 ## Fixed

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -192,15 +192,15 @@ class NacosDriver implements DriverInterface
                     if (CoordinatorManager::until(Constants::WORKER_EXIT)->yield($heartbeat)) {
                         break;
                     }
-
+                    $groupName = $this->config->get('services.drivers.nacos.group_name');
                     $response = $this->client->instance->beat(
                         $name,
                         [
                             'ip' => $host,
                             'port' => $port,
-                            'serviceName' => $name,
+                            'serviceName' => $groupName . "@@" . $name,
                         ],
-                        $this->config->get('services.drivers.nacos.group_name'),
+                        $groupName,
                         $this->config->get('services.drivers.nacos.namespace_id'),
                     );
 

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -198,7 +198,7 @@ class NacosDriver implements DriverInterface
                         [
                             'ip' => $host,
                             'port' => $port,
-                            'serviceName' => $groupName . "@@" . $name,
+                            'serviceName' => $groupName . '@@' . $name,
                         ],
                         $groupName,
                         $this->config->get('services.drivers.nacos.namespace_id'),


### PR DESCRIPTION
修复nacos 2.0.2在使用非 default_group 时会出现周期性服务不健康的问题
心跳数据中需要对服务传入分组信息才能正确识别心跳数据