### PR TITLE
Support PHP8.0 transaction repeat annotation

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,7 @@
 
 - [#3872](https://github.com/hyperf/hyperf/pull/3872) Fixed bug that heartbeat failed when using nacos without default group.
 - [#3879](https://github.com/hyperf/hyperf/pull/3879) Fixed bug that `watcher` does not work caused by proxies replaced.
+- [#3887](https://github.com/hyperf/hyperf/pull/3887) Support PHP 8.0 transaction repeat annotation
 
 # v2.2.1 - 2021-07-27
 

--- a/src/db-connection/src/Annotation/Transactional.php
+++ b/src/db-connection/src/Annotation/Transactional.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace Hyperf\DbConnection\Annotation;
 
 use Attribute;
-use Hyperf\Di\Annotation\AbstractAnnotation;
+use Hyperf\Di\Annotation\AbstractMultipleAnnotation;
 
 /**
  * @Annotation
  * @Target({"METHOD"})
  */
-#[Attribute(Attribute::TARGET_METHOD)]
-class Transactional extends AbstractAnnotation
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Transactional extends AbstractMultipleAnnotation
 {
     /**
      * @var string

--- a/src/db-connection/src/Aspect/TransactionAspect.php
+++ b/src/db-connection/src/Aspect/TransactionAspect.php
@@ -15,6 +15,7 @@ use Hyperf\DbConnection\Annotation\Transactional;
 use Hyperf\DbConnection\Db;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Di\Annotation\Aspect;
+use Hyperf\Di\Annotation\MultipleAnnotation;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Di\Exception\AnnotationException;
@@ -30,23 +31,31 @@ class TransactionAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $transactional = $this->getTransactionalAnnotation($proceedingJoinPoint->className, $proceedingJoinPoint->methodName);
+        $annotations = $this->getTransactionalAnnotations($proceedingJoinPoint->className, $proceedingJoinPoint->methodName);
 
-        return Db::connection($transactional->connection)->transaction(
-            static function () use ($proceedingJoinPoint) {
-                return $proceedingJoinPoint->process();
-            },
-            $transactional->attempts
-        );
+        $func = static function () use ($proceedingJoinPoint) {
+            return $proceedingJoinPoint->process();
+        };
+        $annotations = array_reverse($annotations->toAnnotations());
+        foreach ($annotations as $transactional) {
+            $func = static function () use ($transactional, $func) {
+                return Db::connection($transactional->connection)->transaction(
+                    $func,
+                    $transactional->attempts
+                );
+            };
+        }
+        return $func();
     }
 
-    protected function getTransactionalAnnotation(string $className, string $method): Transactional
+    protected function getTransactionalAnnotations(string $className, string $method): MultipleAnnotation
     {
-        $annotation = AnnotationCollector::getClassMethodAnnotation($className, $method)[Transactional::class] ?? null;
-        if (! $annotation instanceof Transactional) {
-            throw new AnnotationException("Annotation Transactional couldn't be collected successfully.");
+        $annotations = AnnotationCollector::getClassMethodAnnotation($className, $method)[Transactional::class] ?? null;
+        foreach ($annotations as $annotation) {
+            if (! $annotation instanceof Transactional) {
+                throw new AnnotationException("Annotation Transactional couldn't be collected successfully.");
+            }
         }
-
-        return $annotation;
+        return $annotations;
     }
 }


### PR DESCRIPTION
Support 
```php
    #[Transactional]
    #[Transactional(connection: 'main')]
    public function create(array $data)
    {
    }
```
执行流程
default  "beganTransaction"

main connection "beganTransaction"

main connection "committed"

default conection "committed"
