### PR TITLE
消费者如果返回uacked，开发人员可以自行指定是否需要重新入队。

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -8,6 +8,7 @@
 ## Added
 
 - [#3924](https://github.com/hyperf/hyperf/pull/3924) Added health check parameters for consul service register.
+- [#3932](https://github.com/hyperf/hyperf/pull/3932) Support requeue the message when return `NACK` for `AMQP` consumer.
 
 # v2.2.3 - 2021-08-09
 

--- a/src/amqp/src/Consumer.php
+++ b/src/amqp/src/Consumer.php
@@ -204,7 +204,7 @@ class Consumer extends Builder
             }
             if ($result === Result::NACK) {
                 $this->logger->debug($deliveryTag . ' uacked.');
-                return $channel->basic_nack($deliveryTag);
+                return $channel->basic_nack($deliveryTag, false, $consumerMessage->isRequeue());
             }
             if ($consumerMessage->isRequeue() && $result === Result::REQUEUE) {
                 $this->logger->debug($deliveryTag . ' requeued.');


### PR DESCRIPTION
 原因：rabbitmq的ack机制下，可以在rabbitmq控制台中监控到unack数量，可以给开发人员提供预警信息，而直接requeue会是一条新的消息。另外 消费者消费过程中如果服务挂了，消费中的信息一样是unack状态。
PhpAmqpLib封装方法public function basic_nack($delivery_tag, $multiple = false, $requeue = false)第三个参数就是为了让开发人员自行决定是否要重新入队。现在hyperf的方法是直接丢弃掉。
