### PR TITLE
Support service register for `rpc-multiplex`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -9,6 +9,7 @@
 
 - [#3924](https://github.com/hyperf/hyperf/pull/3924) Added health check parameters for consul service register.
 - [#3932](https://github.com/hyperf/hyperf/pull/3932) Support requeue the message when return `NACK` for `AMQP` consumer.
+- [#3941](https://github.com/hyperf/hyperf/pull/3941) Support service register for `rpc-multiplex`.
 
 # v2.2.3 - 2021-08-09
 

--- a/docs/zh-cn/rpc-multiplex.md
+++ b/docs/zh-cn/rpc-multiplex.md
@@ -85,6 +85,11 @@ return [
             'id' => App\JsonRpc\CalculatorServiceInterface::class,
             'protocol' => Hyperf\RpcMultiplex\Constant::PROTOCOL_DEFAULT,
             'load_balancer' => 'random',
+            // 这个消费者要从哪个服务中心获取节点信息，如不配置则不会从服务中心获取节点信息
+            'registry' => [
+                'protocol' => 'consul',
+                'address' => 'http://127.0.0.1:8500',
+            ],
             'nodes' => [
                 ['host' => '127.0.0.1', 'port' => 9502],
             ],

--- a/docs/zh-cn/rpc-multiplex.md
+++ b/docs/zh-cn/rpc-multiplex.md
@@ -2,8 +2,6 @@
 
 本组件基于 `TCP` 协议，多路复用的设计借鉴于 `AMQP` 组件。
 
-> 暂不支持注册中心
-
 ## 安装
 
 ```
@@ -115,5 +113,15 @@ return [
 
 ```
 
+### 注册中心
+
+如果需要使用注册中心，则需要手动添加以下监听器
+
+```php
+<?php
+return [
+    Hyperf\RpcMultiplex\Listener\RegisterServiceListener::class,
+];
+```
 
 

--- a/docs/zh-hk/rpc-multiplex.md
+++ b/docs/zh-hk/rpc-multiplex.md
@@ -85,6 +85,11 @@ return [
             'id' => App\JsonRpc\CalculatorServiceInterface::class,
             'protocol' => Hyperf\RpcMultiplex\Constant::PROTOCOL_DEFAULT,
             'load_balancer' => 'random',
+            // 這個消費者要從哪個服務中心獲取節點信息，如不配置則不會從服務中心獲取節點信息
+            'registry' => [
+                'protocol' => 'consul',
+                'address' => 'http://127.0.0.1:8500',
+            ],
             'nodes' => [
                 ['host' => '127.0.0.1', 'port' => 9502],
             ],

--- a/docs/zh-tw/rpc-multiplex.md
+++ b/docs/zh-tw/rpc-multiplex.md
@@ -85,6 +85,11 @@ return [
             'id' => App\JsonRpc\CalculatorServiceInterface::class,
             'protocol' => Hyperf\RpcMultiplex\Constant::PROTOCOL_DEFAULT,
             'load_balancer' => 'random',
+            // 這個消費者要從哪個服務中心獲取節點資訊，如不配置則不會從服務中心獲取節點資訊
+            'registry' => [
+                'protocol' => 'consul',
+                'address' => 'http://127.0.0.1:8500',
+            ],
             'nodes' => [
                 ['host' => '127.0.0.1', 'port' => 9502],
             ],

--- a/src/json-rpc/src/Listener/RegisterServiceListener.php
+++ b/src/json-rpc/src/Listener/RegisterServiceListener.php
@@ -43,7 +43,7 @@ class RegisterServiceListener implements ListenerInterface
     public function process(object $event)
     {
         $annotation = $event->annotation;
-        if (! in_array($annotation->protocol, ['jsonrpc', 'jsonrpc-http', 'jsonrpc-tcp-length-check'])) {
+        if (! in_array($annotation->protocol, ['jsonrpc', 'jsonrpc-http', 'jsonrpc-tcp-length-check', 'multiplex.default'])) {
             return;
         }
         $metadata = $event->toArray();

--- a/src/rpc-multiplex/src/Listener/RegisterServiceListener.php
+++ b/src/rpc-multiplex/src/Listener/RegisterServiceListener.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-namespace Hyperf\JsonRpc\Listener;
+namespace Hyperf\RpcMultiplex\Listener;
 
 use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\RpcMultiplex\Constant;
 use Hyperf\RpcServer\Event\AfterPathRegister;
 use Hyperf\ServiceGovernance\ServiceManager;
 
@@ -43,12 +44,19 @@ class RegisterServiceListener implements ListenerInterface
     public function process(object $event)
     {
         $annotation = $event->annotation;
-        if (! in_array($annotation->protocol, ['jsonrpc', 'jsonrpc-http', 'jsonrpc-tcp-length-check'])) {
+        if (! in_array($annotation->protocol, $this->getProtocols(), true)) {
             return;
         }
         $metadata = $event->toArray();
         $annotationArray = $metadata['annotation'];
         unset($metadata['path'], $metadata['annotation'], $annotationArray['name']);
         $this->serviceManager->register($annotation->name, $event->path, array_merge($metadata, $annotationArray));
+    }
+
+    protected function getProtocols(): array
+    {
+        return [
+            Constant::PROTOCOL_DEFAULT,
+        ];
     }
 }

--- a/src/service-governance-consul/src/ConsulDriver.php
+++ b/src/service-governance-consul/src/ConsulDriver.php
@@ -107,7 +107,7 @@ class ConsulDriver implements DriverInterface
                 'Interval' => $interval,
             ];
         }
-        if (in_array($protocol, ['jsonrpc', 'jsonrpc-tcp-length-check'], true)) {
+        if (in_array($protocol, ['jsonrpc', 'jsonrpc-tcp-length-check', 'multiplex.default'], true)) {
             $requestBody['Check'] = [
                 'DeregisterCriticalServiceAfter' => $deregisterCriticalServiceAfter,
                 'TCP' => "{$host}:{$port}",


### PR DESCRIPTION
考虑到 `hyperf/rpc-multiplex` 是可选安装，没有使用 `Hyperf\RpcMultiplex\Constant::PROTOCOL_DEFAULT`