### PR TITLE
feat(str): mask function

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -10,6 +10,7 @@
 - [#3924](https://github.com/hyperf/hyperf/pull/3924) Added health check parameters for consul service register.
 - [#3932](https://github.com/hyperf/hyperf/pull/3932) Support requeue the message when return `NACK` for `AMQP` consumer.
 - [#3941](https://github.com/hyperf/hyperf/pull/3941) Support service register for `rpc-multiplex`.
+- [#3947](https://github.com/hyperf/hyperf/pull/3947) Added method `Str::mask` which used to replace chars from a string by a given char.
 
 ## Optimized
 

--- a/src/utils/src/Str.php
+++ b/src/utils/src/Str.php
@@ -484,6 +484,23 @@ class Str
     }
 
     /**
+     * Replaces the first or the last ones chars from a string by a given char.
+     *
+     * @param string $string
+     * @param int $offset If is negative it starts from the end.
+     * @param string $replacement Default is *.
+     * @return string
+     */
+    public static function mask(string $string, int $offset = 0, string $replacement = '*'): string
+    {
+        $hidden_length = strlen($string) - abs($offset);
+
+        $hidden = str_repeat($replacement, $hidden_length);
+
+        return substr_replace($string, $hidden, max(0, $offset), $hidden_length);
+    }
+
+    /**
      * Returns the replacements for the ascii method.
      * Note: Adapted from Stringy\Stringy.
      *

--- a/src/utils/src/Str.php
+++ b/src/utils/src/Str.php
@@ -490,44 +490,25 @@ class Str
      * @param int $offset if is negative it starts from the end
      * @param string $replacement default is *
      */
-    public static function mask(string $string, int $offset = 0, int $length = 0, string $replacement = '*'): string
+    public static function mask(string $string, int $offset = 0, int $length = 0, string $replacement = '*')
     {
-        if ($offset < 0 || $length < 0) {
-            throw new InvalidArgumentException('The offset and length must equal or greater than zero.');
-        }
-
-        $stringLength = strlen($string);
-        if ($offset >= $stringLength) {
-            return $string;
-        }
-
-        $hiddenLength = $length ?: $stringLength - $offset;
-
-        $hidden = str_repeat($replacement, $hiddenLength);
-
-        return substr_replace($string, $hidden, $offset, $hiddenLength);
-    }
-
-    /**
-     * Replaces the first or the last ones chars from a string by a given char.
-     *
-     * @param int $offset if is negative it starts from the end
-     * @param string $replacement default is *
-     */
-    public static function mbMask(string $string, int $offset = 0, int $length = 0, string $replacement = '*')
-    {
-        if ($offset < 0 || $length < 0) {
-            throw new InvalidArgumentException('The offset and length must equal or greater than zero.');
+        if ($length < 0) {
+            throw new InvalidArgumentException('The length must equal or greater than zero.');
         }
 
         $stringLength = mb_strlen($string);
-        if ($offset >= $stringLength) {
+        $absOffset = abs($offset);
+        if ($absOffset >= $stringLength) {
             return $string;
         }
 
-        $hiddenLength = $length ?: $stringLength - $offset;
+        $hiddenLength = $length ?: $stringLength - $absOffset;
 
-        return mb_substr($string, 0, $offset) . str_repeat($replacement, $hiddenLength) . mb_substr($string, $offset + $hiddenLength);
+        if ($offset >= 0) {
+            return mb_substr($string, 0, $offset) . str_repeat($replacement, $hiddenLength) . mb_substr($string, $offset + $hiddenLength);
+        }
+
+        return mb_substr($string, 0, max($stringLength - $hiddenLength - $absOffset, 0)) . str_repeat($replacement, $hiddenLength) . mb_substr($string, $offset);
     }
 
     /**

--- a/src/utils/src/Str.php
+++ b/src/utils/src/Str.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Utils;
 
+use Hyperf\Utils\Exception\InvalidArgumentException;
 use Hyperf\Utils\Traits\Macroable;
 
 /**
@@ -486,18 +487,20 @@ class Str
     /**
      * Replaces the first or the last ones chars from a string by a given char.
      *
-     * @param string $string
-     * @param int $offset If is negative it starts from the end.
-     * @param string $replacement Default is *.
-     * @return string
+     * @param int $offset if is negative it starts from the end
+     * @param string $replacement default is *
      */
-    public static function mask(string $string, int $offset = 0, string $replacement = '*'): string
+    public static function mask(string $string, int $offset = 0, int $length = 0, string $replacement = '*'): string
     {
-        $hidden_length = strlen($string) - abs($offset);
+        if ($offset < 0 || $length < 0) {
+            throw new InvalidArgumentException('The offset and length must equal or greater than zero.');
+        }
 
-        $hidden = str_repeat($replacement, $hidden_length);
+        $hiddenLength = $length ?: strlen($string) - $offset;
 
-        return substr_replace($string, $hidden, max(0, $offset), $hidden_length);
+        $hidden = str_repeat($replacement, $hiddenLength);
+
+        return substr_replace($string, $hidden, $offset, $hiddenLength);
     }
 
     /**

--- a/src/utils/src/Str.php
+++ b/src/utils/src/Str.php
@@ -496,11 +496,38 @@ class Str
             throw new InvalidArgumentException('The offset and length must equal or greater than zero.');
         }
 
-        $hiddenLength = $length ?: strlen($string) - $offset;
+        $stringLength = strlen($string);
+        if ($offset >= $stringLength) {
+            return $string;
+        }
+
+        $hiddenLength = $length ?: $stringLength - $offset;
 
         $hidden = str_repeat($replacement, $hiddenLength);
 
         return substr_replace($string, $hidden, $offset, $hiddenLength);
+    }
+
+    /**
+     * Replaces the first or the last ones chars from a string by a given char.
+     *
+     * @param int $offset if is negative it starts from the end
+     * @param string $replacement default is *
+     */
+    public static function mbMask(string $string, int $offset = 0, int $length = 0, string $replacement = '*')
+    {
+        if ($offset < 0 || $length < 0) {
+            throw new InvalidArgumentException('The offset and length must equal or greater than zero.');
+        }
+
+        $stringLength = mb_strlen($string);
+        if ($offset >= $stringLength) {
+            return $string;
+        }
+
+        $hiddenLength = $length ?: $stringLength - $offset;
+
+        return mb_substr($string, 0, $offset) . str_repeat($replacement, $hiddenLength) . mb_substr($string, $offset + $hiddenLength);
     }
 
     /**

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -38,4 +38,24 @@ class StrTest extends TestCase
             break;
         }
     }
+
+    public function testMask()
+    {
+        $res = Str::mask('hyperf');
+
+        $this->assertSame('******', $res);
+
+        $res = Str::mask('hyperf', 3);
+
+        $this->assertSame('hyp***', $res);
+
+        $res = Str::mask('hyperf', -3);
+
+        $this->assertSame('***erf', $res);
+
+        $res = Str::mask('hyperf', 0, '-');
+
+        $this->assertSame('------', $res);
+
+    }
 }

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -80,6 +80,38 @@ class StrTest extends TestCase
 
     public function testMbMask()
     {
+        $res = Str::mbMask('hyperf');
+
+        $this->assertSame('******', $res);
+
+        $res = Str::mbMask('hyperf', 3);
+
+        $this->assertSame('hyp***', $res);
+
+        $res = Str::mbMask('hyperf', 3, 1);
+
+        $this->assertSame('hyp*rf', $res);
+
+        $res = Str::mbMask('hyperf', 0, 3);
+
+        $this->assertSame('***erf', $res);
+
+        $res = Str::mbMask('hyperf', 0, 0, '-');
+
+        $this->assertSame('------', $res);
+
+        $res = Str::mbMask('hyperf', 6, 2);
+
+        $this->assertSame('hyperf', $res);
+
+        $res = Str::mbMask('hyperf', 7);
+
+        $this->assertSame('hyperf', $res);
+
+        $res = Str::mbMask('hyperf', 3, 10);
+
+        $this->assertSame('hyp**********', $res);
+
         $res = Str::mbMask('你好啊');
 
         $this->assertSame('***', $res);

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Utils;
 
+use Hyperf\Utils\Exception\InvalidArgumentException;
 use Hyperf\Utils\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -49,13 +50,23 @@ class StrTest extends TestCase
 
         $this->assertSame('hyp***', $res);
 
-        $res = Str::mask('hyperf', -3);
+        $res = Str::mask('hyperf', 3, 1);
+
+        $this->assertSame('hyp*rf', $res);
+
+        $res = Str::mask('hyperf', 0, 3);
 
         $this->assertSame('***erf', $res);
 
-        $res = Str::mask('hyperf', 0, '-');
+        $res = Str::mask('hyperf', 1, 1);
+
+        $this->assertSame('h*perf', $res);
+
+        $res = Str::mask('hyperf', 0, 0, '-');
 
         $this->assertSame('------', $res);
 
+        $this->expectException(InvalidArgumentException::class);
+        Str::mask('hyperf', -1);
     }
 }

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -58,15 +58,62 @@ class StrTest extends TestCase
 
         $this->assertSame('***erf', $res);
 
-        $res = Str::mask('hyperf', 1, 1);
-
-        $this->assertSame('h*perf', $res);
-
         $res = Str::mask('hyperf', 0, 0, '-');
 
         $this->assertSame('------', $res);
 
+        $res = Str::mask('hyperf', 6, 2);
+
+        $this->assertSame('hyperf', $res);
+
+        $res = Str::mask('hyperf', 7);
+
+        $this->assertSame('hyperf', $res);
+
+        $res = Str::mask('hyperf', 3, 10);
+
+        $this->assertSame('hyp**********', $res);
+
         $this->expectException(InvalidArgumentException::class);
         Str::mask('hyperf', -1);
+    }
+
+    public function testMbMask()
+    {
+        $res = Str::mbMask('你好啊');
+
+        $this->assertSame('***', $res);
+
+        $res = Str::mbMask('你好世界', 3);
+
+        $this->assertSame('你好世*', $res);
+
+        $res = Str::mbMask('你好世界', 2, 1);
+
+        $this->assertSame('你好*界', $res);
+
+        $res = Str::mbMask('你好世界', 0, 3);
+
+        $this->assertSame('***界', $res);
+
+        $res = Str::mbMask('你好世界', 1, 1);
+
+        $this->assertSame('你*世界', $res);
+
+        $res = Str::mbMask('你好世界', 0, 0, '-');
+
+        $this->assertSame('----', $res);
+
+        $res = Str::mbMask('你好世界', 6, 2);
+
+        $this->assertSame('你好世界', $res);
+
+        $res = Str::mbMask('你好世界', 7);
+
+        $this->assertSame('你好世界', $res);
+
+        $res = Str::mbMask('你好世界', 3, 10);
+
+        $this->assertSame('你好世**********', $res);
     }
 }

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -74,78 +74,64 @@ class StrTest extends TestCase
 
         $this->assertSame('hyp**********', $res);
 
-        $this->expectException(InvalidArgumentException::class);
-        Str::mask('hyperf', -1);
-    }
-
-    public function testMbMask()
-    {
-        $res = Str::mbMask('hyperf');
-
-        $this->assertSame('******', $res);
-
-        $res = Str::mbMask('hyperf', 3);
-
-        $this->assertSame('hyp***', $res);
-
-        $res = Str::mbMask('hyperf', 3, 1);
-
-        $this->assertSame('hyp*rf', $res);
-
-        $res = Str::mbMask('hyperf', 0, 3);
-
+        $res = Str::mask('hyperf', -3);
         $this->assertSame('***erf', $res);
 
-        $res = Str::mbMask('hyperf', 0, 0, '-');
+        $res = Str::mask('hyperf', -3, 1);
+        $this->assertSame('hy*erf', $res);
 
-        $this->assertSame('------', $res);
+        $res = Str::mask('hyperf', -3, 3);
+        $this->assertSame('***erf', $res);
 
-        $res = Str::mbMask('hyperf', 6, 2);
+        $res = Str::mask('hyperf', -3, 5);
+        $this->assertSame('*****erf', $res);
 
-        $this->assertSame('hyperf', $res);
-
-        $res = Str::mbMask('hyperf', 7);
-
-        $this->assertSame('hyperf', $res);
-
-        $res = Str::mbMask('hyperf', 3, 10);
-
-        $this->assertSame('hyp**********', $res);
-
-        $res = Str::mbMask('你好啊');
+        $res = Str::mask('你好啊');
 
         $this->assertSame('***', $res);
 
-        $res = Str::mbMask('你好世界', 3);
+        $res = Str::mask('你好世界', 3);
 
         $this->assertSame('你好世*', $res);
 
-        $res = Str::mbMask('你好世界', 2, 1);
+        $res = Str::mask('你好世界', 2, 1);
 
         $this->assertSame('你好*界', $res);
 
-        $res = Str::mbMask('你好世界', 0, 3);
+        $res = Str::mask('你好世界', 0, 3);
 
         $this->assertSame('***界', $res);
 
-        $res = Str::mbMask('你好世界', 1, 1);
+        $res = Str::mask('你好世界', 1, 1);
 
         $this->assertSame('你*世界', $res);
 
-        $res = Str::mbMask('你好世界', 0, 0, '-');
+        $res = Str::mask('你好世界', 0, 0, '-');
 
         $this->assertSame('----', $res);
 
-        $res = Str::mbMask('你好世界', 6, 2);
+        $res = Str::mask('你好世界', 6, 2);
 
         $this->assertSame('你好世界', $res);
 
-        $res = Str::mbMask('你好世界', 7);
+        $res = Str::mask('你好世界', 7);
 
         $this->assertSame('你好世界', $res);
 
-        $res = Str::mbMask('你好世界', 3, 10);
+        $res = Str::mask('你好世界', 3, 10);
 
         $this->assertSame('你好世**********', $res);
+
+        $res = Str::mask('你好世界', -1);
+        $this->assertSame('***界', $res);
+
+        $res = Str::mask('你好世界', -1, 1);
+        $this->assertSame('你好*界', $res);
+
+        $res = Str::mask('你好世界', -3, 3);
+        $this->assertSame('***好世界', $res);
+
+        $this->expectException(InvalidArgumentException::class);
+        Str::mask('hyperf', -1, -1);
     }
 }


### PR DESCRIPTION
Replaces the first or the last ones chars from a string by a given char.
If the `$offset` is negative it starts from the end.

```php
Str::mask('hyperf', -3); // ***erf
```

It is useful to avoid logging sensitive data like credit cards, api keys, personal documents and so on.
```php
$credit_card = Str::mask('372042788648832', -4); // ***********8832
```

Full `string` can be masked using a 0 offset, which is the default.
```php
$fully_hidden = Str::mask('some@email.tld'); // **************
```