### PR TITLE
Fixed validate rule `date` does not work as expected when the value isn't string.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.5 - TBD
 
+## Fixed
+
+- [#3959](https://github.com/hyperf/hyperf/pull/3959) Fixed 
+
 ## Optimized
 
 - [#3957](https://github.com/hyperf/hyperf/pull/3957) Support generate the type of getAttribute with `@return` for command `gen:model`.

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#3959](https://github.com/hyperf/hyperf/pull/3959) Fixed 
+- [#3959](https://github.com/hyperf/hyperf/pull/3959) Fixed validate rule `date` does not work as expected when the value isn't string.
 
 ## Optimized
 

--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -23,7 +23,8 @@
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns (^3.0).",
-        "nikic/php-parser": "Required to use ModelCommand. (^4.0)"
+        "nikic/php-parser": "Required to use ModelCommand. (^4.0)",
+        "php-di/phpdoc-reader": "Required to use ModelCommand. (^2.2)"
     },
     "autoload": {
         "psr-4": {

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -220,7 +220,7 @@ trait ValidatesAttributes
             return true;
         }
 
-        if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+        if ((! is_string($value) && ! is_numeric($value)) || strtotime((string) $value) === false) {
             return false;
         }
 

--- a/src/validation/tests/Cases/ValidateAttributesTest.php
+++ b/src/validation/tests/Cases/ValidateAttributesTest.php
@@ -61,4 +61,11 @@ class ValidateAttributesTest extends TestCase
         $this->assertFalse($validator->validateAlphaNum('', '123_f1'));
         $this->assertFalse($validator->validateAlphaNum('', 'xxx_yy'));
     }
+
+    public function testValidateDate()
+    {
+        $validator = new ValidatesAttributesStub();
+
+        $this->assertFalse($validator->validateDate('', 123));
+    }
 }


### PR DESCRIPTION
解决date日期判断strtotime参数为int时报错的问题
Fix #3951