### PR TITLE
Fixed type error when using `Hyperf\Validation\Rules\Unique::__toString()` in PHP8.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.6 - TBD
 
+## Fixed
+
+- [#3969](https://github.com/hyperf/hyperf/pull/3969) Fixed type error when using `Hyperf\Validation\Rules\Unique::__toString()` in PHP8.
+
 # v2.2.5 - 2021-08-23
 
 ## Fixed

--- a/src/validation/src/Rules/DatabaseRule.php
+++ b/src/validation/src/Rules/DatabaseRule.php
@@ -159,7 +159,7 @@ trait DatabaseRule
     protected function formatWheres(): string
     {
         return collect($this->wheres)->map(function ($where) {
-            return $where['column'] . ',' . '"' . str_replace('"', '""', $where['value']) . '"';
+            return $where['column'] . ',' . '"' . str_replace('"', '""', (string) $where['value']) . '"';
         })->implode(',');
     }
 }

--- a/src/validation/tests/Cases/ValidationUniqueRuleTest.php
+++ b/src/validation/tests/Cases/ValidationUniqueRuleTest.php
@@ -59,6 +59,10 @@ class ValidationUniqueRuleTest extends TestCase
         $rule = new Unique('table');
         $rule->where('foo', '"bar"');
         $this->assertEquals('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
+
+        $rule = new Unique('table');
+        $rule->where('foo', 1);
+        $this->assertEquals('unique:table,NULL,NULL,id,foo,"1"', (string) $rule);
     }
 }
 


### PR DESCRIPTION
```php
<?php
declare(strict_types=1);

str_replace('"', '""', 1)
```

php7.4 正常
php8.0 报错

> Uncaught TypeError: str_replace(): Argument #3 ($subject) must be of type array|string
