### PR TITLE
Support delayed message exchange for AMQP.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -6,6 +6,10 @@
 - [#3979](https://github.com/hyperf/hyperf/pull/3979) Fixed bug that timeout property does not work in circuit breaker.
 - [#3986](https://github.com/hyperf/hyperf/pull/3986) Fixed OSS hook failed when using `SWOOLE_HOOK_NATIVE_CURL`.
 
+## Added
+
+- [#3987](https://github.com/hyperf/hyperf/pull/3987) Support delayed message exchange for AMQP.
+
 # v2.2.5 - 2021-08-23
 
 ## Fixed

--- a/docs/zh-cn/amqp.md
+++ b/docs/zh-cn/amqp.md
@@ -159,15 +159,15 @@ class DemoConsumer extends ConsumerMessage
 
 ## 延时队列
 
-####生产者
-使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例 direct 类型，其他类型如 fanout、topic，改生产者和消费者中的 type 即可。
+### 生产者
+
+使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例 `direct` 类型，其他类型如 `fanout`、`topic`，改生产者和消费者中的 `type` 即可。
 
 ```bash
 php bin/hyperf.php gen:amqp-producer DelayDirectProducer
 ```
 
-在 DelayDirectProducer 文件中，加入`use ProducerDelayedMessageTrait;`。
-示例如下。
+在 DelayDirectProducer 文件中，加入`use ProducerDelayedMessageTrait;`，示例如下：
 
 ```php
 <?php
@@ -198,15 +198,15 @@ class DelayDirectProducer extends ProducerMessage
     }
 }
 ```
-####消费者
+### 消费者
+
 使用 `gen:amqp-consumer` 命令创建一个 `consumer`。
 
 ```bash
 php bin/hyperf.php gen:amqp-consumer DelayDirectConsumer
 ```
 
-在 DelayDirectConsumer 文件中，增加引入`use ProducerDelayedMessageTrait, ConsumerDelayedMessageTrait;`。
-示例如下：
+在 `DelayDirectConsumer` 文件中，增加引入`use ProducerDelayedMessageTrait, ConsumerDelayedMessageTrait;`，示例如下：
 
 ```php
 <?php
@@ -247,7 +247,11 @@ class DelayDirectConsumer extends ConsumerMessage
 }
 
 ```
-####生产延时消息
+
+### 生产延时消息
+
+> 以下是在 Command 中演示如何使用，具体用法请以实际为准
+
 使用 `gen:command DelayCommand` 命令创建一个 `DelayCommand`。如下：
 
 ```php

--- a/docs/zh-cn/amqp.md
+++ b/docs/zh-cn/amqp.md
@@ -159,6 +159,9 @@ class DemoConsumer extends ConsumerMessage
 
 ## 延时队列
 
+AMQP 的延时队列，并不会根据延时时间进行排序，所以，一旦你投递了一个延时 10s 的任务，又往这个队列中投递了一个延时 5s 的任务，那么也一定会在第一个 10s 任务完成后，才会消费第二个 5s 的任务。
+所以，需要根据时间设置不同的队列，如果想要更加灵活的延时队列，可以尝试 异步队列(async-queue) 和 AMQP 配合使用。
+
 ### 生产者
 
 使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例 `direct` 类型，其他类型如 `fanout`、`topic`，改生产者和消费者中的 `type` 即可。

--- a/docs/zh-cn/amqp.md
+++ b/docs/zh-cn/amqp.md
@@ -162,6 +162,14 @@ class DemoConsumer extends ConsumerMessage
 AMQP 的延时队列，并不会根据延时时间进行排序，所以，一旦你投递了一个延时 10s 的任务，又往这个队列中投递了一个延时 5s 的任务，那么也一定会在第一个 10s 任务完成后，才会消费第二个 5s 的任务。
 所以，需要根据时间设置不同的队列，如果想要更加灵活的延时队列，可以尝试 异步队列(async-queue) 和 AMQP 配合使用。
 
+另外，AMQP 需要下载 [延时插件](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases)，并激活才能正常使用
+
+```shell
+wget https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.9.0/rabbitmq_delayed_message_exchange-3.9.0.ez
+cp rabbitmq_delayed_message_exchange-3.9.0.ez /opt/rabbitmq/plugins/
+rabbitmq-plugins enable rabbitmq_delayed_message_exchange
+```
+
 ### 生产者
 
 使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例 `direct` 类型，其他类型如 `fanout`、`topic`，改生产者和消费者中的 `type` 即可。

--- a/docs/zh-cn/amqp.md
+++ b/docs/zh-cn/amqp.md
@@ -160,7 +160,7 @@ class DemoConsumer extends ConsumerMessage
 ## 延时队列
 
 ####生产者
-使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例direct类型，其他类型如fanout、topic，改生产者和消费者中的type即可。
+使用 `gen:amqp-producer` 命令创建一个 `producer`。这里举例 direct 类型，其他类型如 fanout、topic，改生产者和消费者中的 type 即可。
 
 ```bash
 php bin/hyperf.php gen:amqp-producer DelayDirectProducer

--- a/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Amqp\Message;
+
+use Hyperf\Amqp\Builder\QueueBuilder;
+use PhpAmqpLib\Wire\AMQPTable;
+
+/**
+ * @method ConsumerMessage getQueue()
+ */
+trait ConsumerDelayedMessageTrait
+{
+    /**
+     * Overwrite.
+     */
+    public function getQueueBuilder(): QueueBuilder
+    {
+        return (new QueueBuilder())->setQueue((string)$this->getQueue())
+            ->setArguments(new AMQPTable(['x-dead-letter-exchange' => 'delayed']));
+    }
+}

--- a/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\Amqp\Message;
 
 use Hyperf\Amqp\Builder\QueueBuilder;
@@ -25,7 +24,7 @@ trait ConsumerDelayedMessageTrait
      */
     public function getQueueBuilder(): QueueBuilder
     {
-        return (new QueueBuilder())->setQueue((string)$this->getQueue())
+        return (new QueueBuilder())->setQueue((string) $this->getQueue())
             ->setArguments(new AMQPTable(['x-dead-letter-exchange' => 'delayed']));
     }
 }

--- a/src/amqp/src/Message/ProducerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ProducerDelayedMessageTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Amqp\Message;
+
+use Hyperf\Amqp\Builder\ExchangeBuilder;
+use PhpAmqpLib\Wire\AMQPTable;
+
+/**
+ * @method ProducerMessage getExchange()
+ * @method ProducerMessage getType()
+ * @property ProducerMessage $properties
+ */
+trait ProducerDelayedMessageTrait
+{
+    /**
+     * Set the delay time.
+     * @param int $millisecond
+     * @param string $name
+     * @return $this
+     */
+    public function setDelayMs(int $millisecond, string $name = 'x-delay'): self
+    {
+        $this->properties['application_headers'] = new AMQPTable([$name => $millisecond]);
+        return $this;
+    }
+
+    /**
+     * Overwrite.
+     */
+    public function getExchangeBuilder(): ExchangeBuilder
+    {
+        return (new ExchangeBuilder())->setExchange((string)$this->getExchange())
+            ->setType('x-delayed-message')
+            ->setArguments(new AMQPTable(['x-delayed-type' => $this->getType()]));
+    }
+}

--- a/src/amqp/src/Message/ProducerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ProducerDelayedMessageTrait.php
@@ -23,8 +23,6 @@ trait ProducerDelayedMessageTrait
 {
     /**
      * Set the delay time.
-     * @param int $millisecond
-     * @param string $name
      * @return $this
      */
     public function setDelayMs(int $millisecond, string $name = 'x-delay'): self
@@ -38,7 +36,7 @@ trait ProducerDelayedMessageTrait
      */
     public function getExchangeBuilder(): ExchangeBuilder
     {
-        return (new ExchangeBuilder())->setExchange((string)$this->getExchange())
+        return (new ExchangeBuilder())->setExchange((string) $this->getExchange())
             ->setType('x-delayed-message')
             ->setArguments(new AMQPTable(['x-delayed-type' => $this->getType()]));
     }


### PR DESCRIPTION
基于rabbitmq延时插件rabbitmq_delayed_message_exchange实现延时队列。生产者和消费者通过引入trait覆盖父类同名方法支持x-delayed-message