### PR TITLE
hyperf xxljob client

### DIFF
--- a/src/xxljob/.gitattributes
+++ b/src/xxljob/.gitattributes
@@ -1,0 +1,3 @@
+/tests export-ignore
+/.github export-ignore
+.gitignore export-ignore

--- a/src/xxljob/.gitignore
+++ b/src/xxljob/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+composer.lock
+*.cache
+*.log
+.DS_Store
+.idea
+

--- a/src/xxljob/LICENSE
+++ b/src/xxljob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Tang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/xxljob/README.md
+++ b/src/xxljob/README.md
@@ -1,0 +1,90 @@
+## PHP XxlJob Client
+
+基于 [Hyperf](https://github.com/hyperf/hyperf) 框架的 xxlJob PHP 客户端
+
+##### 优点
+
+- 分布式任务调度平台
+- 任务可以随时关闭与开启
+- 日志可通过服务端查看
+
+##### 缺点
+
+- 不能取消正在执行的任务
+
+
+## 安装
+
+```
+composer require hyperf/xxljob
+```
+
+## 使用
+
+#### 发布配置文件
+
+```bash
+php bin/hyperf.php vendor:publish hyperf/xxljob
+```
+##### 配置信息
+> config/autoload/xxl_job.php
+```php
+return [
+    // enable false 将不会启动服务
+    'enable' => true,
+    //服务端地址
+    'admin_address' => 'http://127.0.0.1:8769/xxl-job-admin',
+    //执行器名称
+    'app_name' => 'xxl-job-demo',
+    //客户端请求前缀
+    'prefix_url' => 'php-xxl-job',
+    //access_token
+    'access_token' => null,
+    'log' => [
+        'filename' => BASE_PATH . '/runtime/logs/xxl-job/job.log',
+        //日志最大留存天数 0:不删除
+        'maxDay' => 30,
+    ],
+];
+```
+
+#### BEAN模式(类形式)
+Bean模式任务，支持基于类的开发方式，每个任务对应一个PHP类。
+##### 步骤一：新建目录，开发Job类：
+```php
+class DemoJob extends AbstractJobHandler{}
+```
+##### 步骤二：调度中心，新建调度任务
+```
+1. 编写job类继承AbstractJobHandler
+2. 注解配置：为Job类添加注解 "#[JobHandler('自定义jobhandler名称')]"，注解value值对应的是调度中心新建任务的JobHandler属性的值。
+3. 执行日志：需要通过 "$this->getXxlJobHelper()->log('...')" 打印执行日志;
+```
+对新建的任务进行参数配置，运行模式选中 “BEAN模式”，JobHandler属性填写任务注解“#[JobHandler]”中定义的值
+![hMvJnQ](https://www.xuxueli.com/doc/static/xxl-job/images/img_ZAsz.png)
+
+#### 完整示例
+```php
+namespace App\Job;
+
+use Hyperf\XxlJob\Annotation\JobHandler;
+use Hyperf\XxlJob\Handler\AbstractJobHandler;
+
+#[JobHandler('demoJob')]
+class DemoJob extends AbstractJobHandler
+{
+    
+    public function handle(): void
+    {
+        //获取参数
+        $params = $this->getParams();
+        //处理...
+        for ($i=1;$i<5;$i++) {
+            $this->getXxlJobHelper()->log($i);
+            $this->getXxlJobHelper()->log("demoJob");
+        }
+
+    }
+}
+```
+详细文档 [xxl-job](https://www.xuxueli.com/xxl-job) 

--- a/src/xxljob/composer.json
+++ b/src/xxljob/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "hyperf/xxljob",
+    "description": "php hyperf xxljob",
+    "license": "MIT",
+    "keywords": [
+        "xxljob",
+        "hyperf xxljob",
+        "php xxljob"
+    ],
+    "authors": [
+        {
+            "name": "tw2066",
+            "email": "tw2066@163.com",
+            "homepage": "https://github.com/tw2066",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=7.3",
+        "hyperf/http-server": "^2.2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Hyperf\\XxlJob\\": "src/"
+        }
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "hyperf": {
+            "config": "Hyperf\\XxlJob\\ConfigProvider"
+        },
+        "branch-alias":{
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/src/xxljob/src/Annotation/JobHandler.php
+++ b/src/xxljob/src/Annotation/JobHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Annotation;
+
+use Attribute;
+use Hyperf\Di\Annotation\AbstractAnnotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class JobHandler extends AbstractAnnotation
+{
+    /**
+     * @var string
+     */
+    public $value = '';
+
+    public function __construct(string $value = '')
+    {
+        $this->value = $value;
+    }
+}

--- a/src/xxljob/src/Application.php
+++ b/src/xxljob/src/Application.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob;
+
+use Exception;
+use Hyperf\XxlJob\Provider\ServiceProvider;
+
+/**
+ * @property ServiceProvider $service
+ */
+class Application
+{
+    protected $alias = [
+        'service' => ServiceProvider::class,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $providers = [];
+
+    /**
+     * @var array
+     */
+    protected static $jobHandlers = [];
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param mixed $name
+     * @throws Exception
+     */
+    public function __get($name)
+    {
+        if (! isset($name) || ! isset($this->alias[$name])) {
+            throw new Exception("{$name} is invalid.");
+        }
+
+        if (isset($this->providers[$name])) {
+            return $this->providers[$name];
+        }
+
+        $class = $this->alias[$name];
+        return $this->providers[$name] = new $class($this->config);
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->config;
+    }
+
+    public static function getJobHandlers(string $key): string
+    {
+        return self::$jobHandlers[$key] ?? '';
+    }
+
+    public static function setJobHandlers(string $key, string $value): void
+    {
+        self::$jobHandlers[$key] = $value;
+    }
+}

--- a/src/xxljob/src/ApplicationFactory.php
+++ b/src/xxljob/src/ApplicationFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob;
+
+use Hyperf\Contract\ConfigInterface;
+use Psr\Container\ContainerInterface;
+
+class ApplicationFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $xxlJobConfig = $container->get(ConfigInterface::class)->get('xxl_job', []);
+        $config = new Config();
+        $config->setEnable($xxlJobConfig['enable'] ?? false);
+        $config->setAppName($xxlJobConfig['app_name'] ?? '');
+        $config->setAccessToken($xxlJobConfig['access_token'] ?? '');
+        $adminAddressArr = parse_url($xxlJobConfig['admin_address'] ?? 'http://127.0.0.1:8769/xxl-job-admin');
+        $config->setBaseUri(sprintf('%s://%s:%s', $adminAddressArr['scheme'], $adminAddressArr['host'], $adminAddressArr['port']));
+        $config->setServerUrlPrefix($adminAddressArr['path'] ?? '');
+        $config->setHeartbeat($xxlJobConfig['heartbeat'] ?? 30);
+        if (isset($xxlJobConfig['guzzle']['config']) && ! empty($xxlJobConfig['guzzle']['config'])) {
+            $config->setGuzzleConfig($xxlJobConfig['guzzle']['config']);
+        }
+        return new Application($config);
+    }
+}

--- a/src/xxljob/src/Config.php
+++ b/src/xxljob/src/Config.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob;
+
+class Config
+{
+    /**
+     * @var bool
+     */
+    private $enable = false;
+
+    /**
+     * @var string
+     */
+    private $baseUri = 'http://127.0.0.1:8080';
+
+    /**
+     * @var string
+     */
+    private $accessToken = '';
+
+    /**
+     * @var string
+     */
+    private $serverUrlPrefix = '';
+
+    /**
+     * @var array
+     */
+    private $guzzleConfig = [
+        'headers' => [
+            'charset' => 'UTF-8',
+        ],
+        'timeout' => 10,
+    ];
+
+    /**
+     * @var string
+     */
+    private $appName = '';
+
+    /**
+     * @var string
+     */
+    private $clientUrl = '';
+
+    /**
+     * @var int
+     */
+    private $heartbeat = 30;
+
+    public function isEnable(): bool
+    {
+        return $this->enable;
+    }
+
+    public function setEnable(bool $enable): void
+    {
+        $this->enable = $enable;
+    }
+
+    public function setBaseUri(string $baseUri): void
+    {
+        $this->baseUri = $baseUri;
+    }
+
+    public function setAccessToken(string $accessToken): void
+    {
+        $this->accessToken = $accessToken;
+    }
+
+    public function setServerUrlPrefix(string $serverUrlPrefix): void
+    {
+        $this->serverUrlPrefix = $serverUrlPrefix;
+    }
+
+    public function setGuzzleConfig(array $guzzleConfig): void
+    {
+        $this->guzzleConfig = $guzzleConfig;
+    }
+
+    public function getAppName(): string
+    {
+        return $this->appName;
+    }
+
+    public function setAppName(string $appName): void
+    {
+        $this->appName = $appName;
+    }
+
+    public function getClientUrl(): string
+    {
+        return $this->clientUrl;
+    }
+
+    public function setClientUrl(string $clientUrl): void
+    {
+        $this->clientUrl = $clientUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeartbeat(): int
+    {
+        return $this->heartbeat;
+    }
+
+    public function setHeartbeat(int $heartbeat): void
+    {
+        $this->heartbeat = $heartbeat;
+    }
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function getServerUrlPrefix(): string
+    {
+        return $this->serverUrlPrefix;
+    }
+
+    public function getBaseUri(): string
+    {
+        return $this->baseUri;
+    }
+
+    public function getGuzzleConfig(): array
+    {
+        return $this->guzzleConfig;
+    }
+}

--- a/src/xxljob/src/ConfigProvider.php
+++ b/src/xxljob/src/ConfigProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob;
+
+use Hyperf\XxlJob\Listener\BootAppRouteListener;
+use Hyperf\XxlJob\Listener\MainWorkerStartListener;
+
+class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies' => [
+                Application::class => ApplicationFactory::class,
+            ],
+            'listeners' => [
+                BootAppRouteListener::class,
+                MainWorkerStartListener::class,
+            ],
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                ],
+            ],
+            'publish' => [
+                [
+                    'id' => 'config',
+                    'description' => 'The config for xxl_job.',
+                    'source' => __DIR__ . '/../publish/xxl_job.php',
+                    'destination' => BASE_PATH . '/config/autoload/xxl_job.php',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/xxljob/src/Dispatcher/BaseJobController.php
+++ b/src/xxljob/src/Dispatcher/BaseJobController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Dispatcher;
+
+use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\HttpServer\Contract\ResponseInterface;
+use Hyperf\Server\ServerFactory;
+use Hyperf\Utils\Codec\Json;
+use Hyperf\XxlJob\Application;
+use Hyperf\XxlJob\Logger\XxlJobHelper;
+use Hyperf\XxlJob\Logger\XxlJobLogger;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class BaseJobController
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * @var array
+     */
+    protected $success = [
+        'code' => 200,
+        'msg' => null,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $fail = [
+        'code' => 500,
+        'msg' => null,
+    ];
+
+    private $xxlJobLogger;
+
+    private $xxlJobHelper;
+    /**
+     * @var ServerFactory
+     */
+    protected $serverFactory;
+
+    public function __construct(ContainerInterface $container, XxlJobLogger $xxlJobLogger, XxlJobHelper $xxlJobHelper)
+    {
+        $this->container = $container;
+        $this->xxlJobLogger = $xxlJobLogger;
+        $this->xxlJobHelper = $xxlJobHelper;
+        $this->app = $this->container->get(Application::class);
+        $this->serverFactory = $container->get(ServerFactory::class);
+
+    }
+
+    public function getXxlJobHelper(): XxlJobHelper
+    {
+        return $this->xxlJobHelper;
+    }
+
+    public function getXxlJobLogger(): XxlJobLogger
+    {
+        return $this->xxlJobLogger;
+    }
+
+    /**
+     * @return array
+     */
+    public function input()
+    {
+        return $this->container->get(ServerRequestInterface::class)->getParsedBody();
+    }
+
+    public function resultJson($data): ResponseInterface
+    {
+        $response = $this->container->get(ResponseInterface::class);
+        return $response->withAddedHeader('content-type', 'application/json')->withBody(new SwooleStream(Json::encode($data)));
+    }
+}

--- a/src/xxljob/src/Dispatcher/JobController.php
+++ b/src/xxljob/src/Dispatcher/JobController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Dispatcher;
+
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\ExceptionHandler\Formatter\FormatterInterface;
+use Hyperf\HttpServer\Contract\ResponseInterface;
+use Hyperf\Utils\Context;
+use Hyperf\Utils\Coroutine;
+use Hyperf\XxlJob\Application;
+use Hyperf\XxlJob\Handler\AbstractJobHandler;
+use Hyperf\XxlJob\Logger\XxlJobLogger;
+use Hyperf\XxlJob\Requests\LogRequest;
+use Hyperf\XxlJob\Requests\RunRequest;
+use Throwable;
+
+class JobController extends BaseJobController
+{
+    public function run(): ResponseInterface
+    {
+        $runRequest = RunRequest::create($this->input());
+        if ($runRequest->getGlueType() != 'BEAN') {
+            return $this->resultJson($this->fail['msg'] = 'the client only supports BEAN');
+        }
+        $executorHandler = $runRequest->getExecutorHandler();
+        $className = Application::getJobHandlers($executorHandler);
+
+        if (empty($className)) {
+            return $this->resultJson($this->fail['msg'] = 'executorHandler:' . $executorHandler . ' class not found!');
+        }
+
+        $stdoutLogger = $this->container->get(StdoutLoggerInterface::class);
+        $jobHandlerObj = $this->container->get($className);
+        if (! $jobHandlerObj instanceof AbstractJobHandler) {
+            $message = 'XxlJob:' . $className . ' not instanceof AbstractJobHandler';
+            $stdoutLogger->error($message);
+            return $this->resultJson($this->fail['msg'] = $message);
+        }
+        $jobHandlerObj->setRunRequest($runRequest);
+
+        Coroutine::create(function () use ($jobHandlerObj, $runRequest) {
+            $this->handle($jobHandlerObj, $runRequest);
+        });
+        return $this->resultJson($this->success);
+    }
+
+    public function log(): ResponseInterface
+    {
+        $logRequest = LogRequest::create($this->input());
+
+        $logFile = $this->getXxlJobHelper()->logFile();
+
+        if (! file_exists($logFile)) {
+            $data = [
+                'code' => 200,
+                'msg' => null,
+                'content' => [
+                    'fromLineNum' => $logRequest->getFromLineNum(),
+                    'toLineNum' => 0,
+                    'logContent' => 'readLog fail, logFile not exists',
+                    'isEnd' => true,
+                ],
+            ];
+            return $this->resultJson($data);
+        }
+
+        [$content,$row] = $this->getXxlJobLogger()->getLine($logFile, $logRequest->getFromLineNum());
+        $data = [
+            'code' => 200,
+            'msg' => null,
+            'content' => [
+                'fromLineNum' => $logRequest->getFromLineNum(),
+                'toLineNum' => $row,
+                'logContent' => $content,
+                'isEnd' => false,
+            ],
+        ];
+
+        return $this->resultJson($data);
+    }
+
+    public function beat(): ResponseInterface
+    {
+        return $this->resultJson($this->success);
+    }
+
+    public function idleBeat(): ResponseInterface
+    {
+        return $this->resultJson($this->success);
+    }
+
+    public function kill(): ResponseInterface
+    {
+        return $this->resultJson($this->fail['msg'] = 'not supported !');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function handle(AbstractJobHandler $jobHandlerObj, RunRequest $runRequest)
+    {
+        //set
+        Context::set(XxlJobLogger::MARK_JOB_LOG_ID, $runRequest->getLogId());
+        /*$server = $this->serverFactory->getServer()->getServer();
+        $workerId = $server->getWorkerId();
+        $cid = Coroutine::id();
+        $this->getXxlJobHelper()->log("----------- workId:{$workerId} cid:{$cid} -----------");*/
+        //log
+        $this->getXxlJobHelper()->log('----------- php xxl-job job execute start -----------');
+        $this->getXxlJobHelper()->log('----------- param:' . $runRequest->getExecutorParams());
+
+        try {
+            $jobHandlerObj->handle();
+            $this->getXxlJobHelper()->log('----------- php xxl-job job execute end(finish) -----------');
+        } catch (Throwable $throwable) {
+            $message = $throwable->getMessage();
+            if ($this->container->has(FormatterInterface::class)) {
+                $formatter = $this->container->get(FormatterInterface::class);
+                $message = $formatter->format($throwable);
+                $message = str_replace("\n", '<br>', $message);
+            }
+            $this->getXxlJobHelper()->get()->error($message);
+            $this->app->service->callback($runRequest->getLogId(), $runRequest->getLogDateTime(), 500, $message);
+            throw $throwable;
+        }
+        $this->app->service->callback($runRequest->getLogId(), $runRequest->getLogDateTime());
+    }
+}

--- a/src/xxljob/src/Dispatcher/XxlJobRoute.php
+++ b/src/xxljob/src/Dispatcher/XxlJobRoute.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Dispatcher;
+
+use Hyperf\HttpServer\Router\RouteCollector;
+use Hyperf\XxlJob\Middleware\JobMiddleware;
+
+class XxlJobRoute
+{
+    public function add(RouteCollector $route, $prefixUrl)
+    {
+        /*
+         * 心跳
+         */
+        $route->addRoute(['POST'], '/' . $prefixUrl . '/beat', [JobController::class, 'beat'], ['middleware' => [JobMiddleware::class]]);
+
+        /*
+         * 触发任务执行
+         */
+        $route->addRoute(['POST'], '/' . $prefixUrl . '/run', [JobController::class, 'run'], ['middleware' => [JobMiddleware::class]]);
+
+        /*
+         * 忙碌检测
+         */
+        $route->addRoute(['POST'], '/' . $prefixUrl . '/idleBeat', [JobController::class, 'idleBeat'], ['middleware' => [JobMiddleware::class]]);
+
+        /*
+         * 终止任务
+         */
+        $route->addRoute(['POST'], '/' . $prefixUrl . '/kill', [JobController::class, 'kill'], ['middleware' => [JobMiddleware::class]]);
+
+        /*
+         * 日志
+         */
+        $route->addRoute(['POST'], '/' . $prefixUrl . '/log', [JobController::class, 'log'], ['middleware' => [JobMiddleware::class]]);
+    }
+}

--- a/src/xxljob/src/Handler/AbstractJobHandler.php
+++ b/src/xxljob/src/Handler/AbstractJobHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Handler;
+
+use Hyperf\XxlJob\Logger\XxlJobHelper;
+use Hyperf\XxlJob\Requests\RunRequest;
+
+abstract class AbstractJobHandler implements JobHandlerInterface
+{
+    private $runRequest;
+
+    private $xxlJobHelper;
+
+    public function __construct(XxlJobHelper $xxlJobHelper)
+    {
+        $this->xxlJobHelper = $xxlJobHelper;
+    }
+
+    public function getXxlJobHelper(): XxlJobHelper
+    {
+        return $this->xxlJobHelper;
+    }
+
+    public function getRunRequest(): RunRequest
+    {
+        return $this->runRequest;
+    }
+
+    public function getParams(): string
+    {
+        return $this->runRequest->getExecutorParams();
+    }
+
+    public function setRunRequest(RunRequest $runRequest): void
+    {
+        $this->runRequest = $runRequest;
+    }
+}

--- a/src/xxljob/src/Handler/JobHandlerInterface.php
+++ b/src/xxljob/src/Handler/JobHandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Handler;
+
+interface JobHandlerInterface
+{
+    /**
+     * The logical of process will place in here.
+     */
+    public function handle(): void;
+}

--- a/src/xxljob/src/Listener/BootAppRouteListener.php
+++ b/src/xxljob/src/Listener/BootAppRouteListener.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Listener;
+
+use Exception;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Di\Annotation\AnnotationCollector;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\BootApplication;
+use Hyperf\HttpServer\Router\DispatcherFactory;
+use Hyperf\Server\Server;
+use Hyperf\ServiceGovernance\IPReaderInterface;
+use Hyperf\Utils\ApplicationContext;
+use Hyperf\XxlJob\Annotation\JobHandler;
+use Hyperf\XxlJob\Application;
+use Hyperf\XxlJob\Dispatcher\XxlJobRoute;
+use Psr\Container\ContainerInterface;
+
+class BootAppRouteListener implements ListenerInterface
+{
+
+    /**
+     * @var Application
+     */
+    private $app;
+
+    public function __construct(ContainerInterface $container, Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function listen(): array
+    {
+        return [
+            BootApplication::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        $container = ApplicationContext::getContainer();
+        $logger = $container->get(StdoutLoggerInterface::class);
+        $config = $container->get(ConfigInterface::class);
+        if (! $config->get('xxl_job.enable', false)) {
+            $logger->debug('xxl_job not enable');
+            return;
+        }
+        $prefixUrl = $config->get('xxl_job.prefix_url', 'php-xxl-job');
+        $servers = $config->get('server.servers');
+        $httpServerRouter = null;
+        $serverConfig = null;
+        foreach ($servers as $server) {
+            $router = $container->get(DispatcherFactory::class)->getRouter($server['name']);
+            if (empty($httpServerRouter) && $server['type'] == Server::SERVER_HTTP) {
+                $httpServerRouter = $router;
+                $serverConfig = $server;
+            }
+        }
+        if (empty($httpServerRouter)) {
+            $logger->warning('XxlJob: http Service not started');
+            $this->app->getConfig()->setEnable(false);
+            return;
+        }
+
+        $list = AnnotationCollector::list();
+        $this->initAnnotationRoute($list);
+        $route = new XxlJobRoute();
+        $route->add($httpServerRouter, $prefixUrl);
+
+        $host = $serverConfig['host'];
+        if (in_array($host, ['0.0.0.0', 'localhost'])) {
+            $host = $this->getIp();
+        }
+
+        $xxlJobConfig = $container->get(ConfigInterface::class)->get('xxl_job', []);
+        $url = sprintf('http://%s:%s/%s/', $host, $serverConfig['port'], $xxlJobConfig['prefix_url']);
+        $this->app->getConfig()->setClientUrl($url);
+    }
+
+    private function initAnnotationRoute(array $collector): void
+    {
+        foreach ($collector as $className => $metadata) {
+            if (isset($metadata['_c'][JobHandler::class])) {
+                /** @var JobHandler $jobHandler */
+                $jobHandler = $metadata['_c'][JobHandler::class];
+                Application::setJobHandlers($jobHandler->value, $className);
+            }
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getIp(): string
+    {
+        $ips = swoole_get_local_ip();
+        if (is_array($ips) && ! empty($ips)) {
+            return current($ips);
+        }
+        /** @var mixed|string $ip */
+        $ip = gethostbyname(gethostname());
+        if (is_string($ip)) {
+            return $ip;
+        }
+        throw new Exception('Can not get the internal IP.');
+    }
+}

--- a/src/xxljob/src/Listener/MainWorkerStartListener.php
+++ b/src/xxljob/src/Listener/MainWorkerStartListener.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Listener;
+
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\MainWorkerStart;
+use Hyperf\Server\Event\MainCoroutineServerStart;
+use Hyperf\Utils\Coordinator\Constants;
+use Hyperf\Utils\Coordinator\CoordinatorManager;
+use Hyperf\Utils\Coroutine;
+use Hyperf\XxlJob\Application;
+use Throwable;
+
+class MainWorkerStartListener implements ListenerInterface
+{
+    /**
+     * @var Application
+     */
+    private $app;
+
+    /**
+     * @var StdoutLoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Application $app, StdoutLoggerInterface $logger)
+    {
+        $this->app = $app;
+        $this->logger = $logger;
+    }
+
+    public function listen(): array
+    {
+        return [
+            MainWorkerStart::class,
+            MainCoroutineServerStart::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        $config = $this->app->getConfig();
+        if (! $config->isEnable()) {
+            return;
+        }
+        $this->registerHeartbeat($config->getAppName(), $config->getClientUrl(), $config->getHeartbeat());
+    }
+
+    protected function registerHeartbeat(string $appName, string $url, $heartbeat = 30): void
+    {
+        Coroutine::create(function () use ($appName, $url, $heartbeat) {
+            retry(INF, function () use ($appName, $url, $heartbeat) {
+                while (true) {
+                    if (CoordinatorManager::until(Constants::WORKER_EXIT)->yield($heartbeat)) {
+                        break;
+                    }
+                    try {
+                        $this->app->service->registry($appName, $url);
+                        $this->logger->debug(sprintf('xxlJob registry app name:%s heartbeat successfully', $appName));
+                    } catch (Throwable $throwable) {
+                        $this->logger->error($throwable);
+                        throw $throwable;
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/xxljob/src/Listener/OnShutdownListener.php
+++ b/src/xxljob/src/Listener/OnShutdownListener.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Listener;
+
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\OnShutdown;
+use Hyperf\Server\Event\CoroutineServerStop;
+use Hyperf\XxlJob\Application;
+use Psr\Container\ContainerInterface;
+
+class OnShutdownListener implements ListenerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var StdoutLoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var bool
+     */
+    private $processed = false;
+
+    /**
+     * @var Application
+     */
+    private $app;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->logger = $container->get(StdoutLoggerInterface::class);
+        $this->app = $container->get(Application::class);
+    }
+
+    public function listen(): array
+    {
+        return [
+            OnShutdown::class,
+            CoroutineServerStop::class,
+        ];
+    }
+
+    public function process(object $event)
+    {
+        if ($this->processed) {
+            return;
+        }
+        $this->processed = true;
+
+        $config = $this->app->getConfig();
+        if (! $config->isEnable()) {
+            return;
+        }
+        $response = $this->app->service->registryRemove($config->getAppName(), $config->getClientUrl());
+        if ($response->getStatusCode() === 200) {
+            $this->logger->debug(sprintf('xxlJob app name:%s url:%s remove successfully!', $config->getAppName(), $config->getClientUrl()));
+        } else {
+            $this->logger->error(sprintf('xxlJob app name:%s url:%s remove failed!', $config->getAppName(), $config->getClientUrl()));
+        }
+    }
+}

--- a/src/xxljob/src/Logger/JobFileHandler.php
+++ b/src/xxljob/src/Logger/JobFileHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Logger;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Utils;
+
+class JobFileHandler extends StreamHandler
+{
+    /**
+     * @var int
+     */
+    private $logId;
+
+    /**
+     * @var string
+     */
+    private $filename;
+
+    public function __construct(int $logId, string $filename,$level = Logger::DEBUG, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false)
+    {
+        $this->filename = Utils::canonicalizePath($filename);
+        $this->logId = $logId;
+        parent::__construct($this->getTimedFilename(), $level, $bubble, $filePermission, $useLocking);
+    }
+
+    public function rotate($nextMaxDayTime): void
+    {
+        $logFiles = glob($this->getGlobPattern());
+        if ($logFiles === false) {
+            // failed to glob
+            return;
+        }
+        asort($logFiles, SORT_STRING | SORT_FLAG_CASE | SORT_NATURAL);
+        $i = 0;
+        foreach ($logFiles as $file) {
+            if (is_writable($file)) {
+                $mtime = filemtime($file);
+                if ($mtime < $nextMaxDayTime) {
+                    // suppress errors here as unlink() might fail if two processes
+                    // are cleaning up/rotating at the same time
+                    set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+                        return false;
+                    });
+                    unlink($file);
+                    restore_error_handler();
+                } else {
+                    ++$i;
+                    if ($i > 5) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public function getTimedFilename(): string
+    {
+        $fileInfo = pathinfo($this->filename);
+        $jogId = $this->getLogId() ?: 'job';
+        return $fileInfo['dirname'] . '/' . $jogId . '.log';
+    }
+
+
+    protected function getGlobPattern(): string
+    {
+        $fileInfo = pathinfo($this->filename);
+        return $fileInfo['dirname'] . '/[0-9]*.log';
+    }
+
+    private function getLogId(): ?int
+    {
+        return $this->logId;
+    }
+}

--- a/src/xxljob/src/Logger/XxlJobHelper.php
+++ b/src/xxljob/src/Logger/XxlJobHelper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Logger;
+
+use Hyperf\Utils\Context;
+use Psr\Log\LoggerInterface;
+
+class XxlJobHelper
+{
+    /**
+     * @var XxlJobLogger
+     */
+    private $xxlJobLogger;
+
+    public function __construct(XxlJobLogger $xxlJobLogger)
+    {
+        $this->xxlJobLogger = $xxlJobLogger;
+    }
+
+    public function log($message)
+    {
+        if (empty(Context::get(XxlJobLogger::MARK_JOB_LOG_ID))) {
+            return;
+        }
+        $this->xxlJobLogger->get()->info($message);
+    }
+
+    public function get(): ?LoggerInterface
+    {
+        if (empty(Context::get(XxlJobLogger::MARK_JOB_LOG_ID))) {
+            return null;
+        }
+        return $this->xxlJobLogger->get();
+    }
+
+    public function logFile(): string
+    {
+        return $this->xxlJobLogger->getStream()->getTimedFilename();
+    }
+}

--- a/src/xxljob/src/Logger/XxlJobLogger.php
+++ b/src/xxljob/src/Logger/XxlJobLogger.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Logger;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Utils\Context;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\FirePHPHandler;
+use Monolog\Logger;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use SplFileObject;
+
+class XxlJobLogger
+{
+    public const MARK_JOB_LOG_ID = 'XXL-JOB-CONTEXT-LOG-ID';
+
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var int
+     */
+    private $maxDay;
+
+    /**
+     * @var JobFileHandler
+     */
+    private $stream;
+
+    /**
+     * @var int
+     */
+    private $nextMaxDayTime = 0;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $config = $container->get(ConfigInterface::class);
+        $this->filename = $config->get('xxl_job.log.filename', BASE_PATH . '/runtime/logs/xxl-job/job.log');
+        $this->maxDay = $config->get('xxl_job.log.maxDay', 30);
+    }
+
+    public function getStream(): JobFileHandler
+    {
+        $this->get();
+        return $this->stream;
+    }
+
+    public function get(): LoggerInterface
+    {
+        return Context::override(self::class, function () {
+            $logId = Context::get(XxlJobLogger::MARK_JOB_LOG_ID);
+            return $this->make($logId);
+        });
+    }
+
+    public function getLine($fileName, $start): array
+    {
+        $file = new SplFileObject($fileName, 'r');
+        $file->seek($start - 1);
+        $content = '';
+        while (! $file->eof()) {
+            $current = $file->current();
+            if (empty($current)) {
+                break;
+            }
+            $content .= $current;
+            $file->next();
+        }
+        $row = $file->key();
+        //Closing file object
+        $file = null;
+        return [$content, $row];
+    }
+
+    protected function make($logId): Logger
+    {
+        $log = new Logger('xxl-job-log');
+        $this->stream = new JobFileHandler($logId, $this->filename,Logger::DEBUG);
+        $fire = new FirePHPHandler();
+        $dateFormat = 'Y-m-d H:i:s';
+        $output = "%datetime% [%level_name%]: %message%\n";
+        $formatter = new LineFormatter($output, $dateFormat);
+        $this->stream->setFormatter($formatter);
+        $log->pushHandler($this->stream);
+        $log->pushHandler($fire);
+        $maxDayTime = $this->getMaxDayTime();
+        if($this->maxDay > 0 && $this->nextMaxDayTime != $maxDayTime){
+            $this->stream->rotate($maxDayTime);
+            $this->nextMaxDayTime = $maxDayTime;
+        }
+        return $log;
+    }
+
+    protected function getMaxDayTime(): int
+    {
+        $time = sprintf('-%s days', $this->maxDay);
+        $date = date('Y-m-d 00:00:00', strtotime($time));
+        return strtotime($date);
+    }
+
+}

--- a/src/xxljob/src/Middleware/JobMiddleware.php
+++ b/src/xxljob/src/Middleware/JobMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Middleware;
+
+use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\HttpServer\Contract\ResponseInterface as HttpResponse;
+use Hyperf\Utils\Context;
+use Hyperf\XxlJob\Application;
+use Hyperf\XxlJob\Logger\XxlJobLogger;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class JobMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var Application
+     */
+    private $app;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container, Application $app)
+    {
+        $this->app = $app;
+        $this->container = $container;
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $token = $request->getHeaders()['xxl-job-access-token'][0] ?? '';
+        if ($token != $this->app->getConfig()->getAccessToken()) {
+            $response = $this->container->get(HttpResponse::class);
+            $json = json_encode([
+                'code' => 401,
+                'msg' => 'token fail',
+            ], JSON_UNESCAPED_UNICODE);
+            return $response->withStatus(401)
+                ->withAddedHeader('content-type', 'application/json; charset=utf-8')
+                ->withBody(new SwooleStream($json));
+        }
+        $body = $this->container->get(ServerRequestInterface::class)->getParsedBody();
+
+        Context::set(XxlJobLogger::MARK_JOB_LOG_ID, $body['logId'] ?? null);
+
+        return $handler->handle($request);
+    }
+}

--- a/src/xxljob/src/Provider/AbstractProvider.php
+++ b/src/xxljob/src/Provider/AbstractProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Hyperf\XxlJob\Config;
+
+abstract class AbstractProvider
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    public function request($method, $uri, array $options = [])
+    {
+        $token = $this->config->getAccessToken();
+        $uri = $this->config->getServerUrlPrefix() . $uri;
+        $token && $options[RequestOptions::HEADERS]['XXL-JOB-ACCESS-TOKEN'] = $token;
+        return $this->client()->request($method, $uri, $options);
+    }
+
+    public function client(): Client
+    {
+        $config = array_merge($this->config->getGuzzleConfig(), [
+            'base_uri' => $this->config->getBaseUri(),
+        ]);
+        return new Client($config);
+    }
+}

--- a/src/xxljob/src/Provider/ServiceProvider.php
+++ b/src/xxljob/src/Provider/ServiceProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Provider;
+
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+class ServiceProvider extends AbstractProvider
+{
+    public function registry(string $registryKey, string $registryValue): ResponseInterface
+    {
+        $body = [
+            'registryGroup' => 'EXECUTOR',
+            'registryKey' => $registryKey,
+            'registryValue' => $registryValue,
+        ];
+        return $this->request('POST', '/api/registry', [
+            RequestOptions::JSON => $body,
+        ]);
+    }
+
+    public function registryRemove(string $registryKey, string $registryValue): ResponseInterface
+    {
+        $body = [
+            'registryGroup' => 'EXECUTOR',
+            'registryKey' => $registryKey,
+            'registryValue' => $registryValue,
+        ];
+        return $this->request('POST', '/api/registryRemove', [
+            RequestOptions::JSON => $body,
+        ]);
+    }
+
+    public function callback(int $logId, int $logDateTim, int $handleCode = 200, $handleMsg = null): ResponseInterface
+    {
+        $body = [[
+            'logId' => $logId,
+            'logDateTim' => $logDateTim,
+            'handleCode' => $handleCode,
+            'handleMsg' => $handleMsg,
+        ]];
+        return $this->request('POST', '/api/callback', [
+            RequestOptions::JSON => $body,
+        ]);
+    }
+}

--- a/src/xxljob/src/Requests/BaseRequest.php
+++ b/src/xxljob/src/Requests/BaseRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Requests;
+
+class BaseRequest
+{
+    public static function create(array $data = []): static
+    {
+        $obj = new static();
+        foreach ($data as $k => $v) {
+            if (property_exists($obj, $k)) {
+                $obj->{$k} = $v;
+            }
+        }
+        return $obj;
+    }
+}

--- a/src/xxljob/src/Requests/LogRequest.php
+++ b/src/xxljob/src/Requests/LogRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Requests;
+
+class LogRequest extends BaseRequest
+{
+    protected $logDateTim;
+
+    protected $logId;
+
+    protected $fromLineNum;
+
+    public function getLogDateTim(): int
+    {
+        return $this->logDateTim;
+    }
+
+    public function getLogId(): int
+    {
+        return $this->logId;
+    }
+
+    public function getFromLineNum(): int
+    {
+        return $this->fromLineNum;
+    }
+}

--- a/src/xxljob/src/Requests/RunRequest.php
+++ b/src/xxljob/src/Requests/RunRequest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\XxlJob\Requests;
+
+class RunRequest extends BaseRequest
+{
+    protected $jobId;  // 任务ID
+
+    protected $executorHandler; // 任务标识
+
+    protected $executorParams; // 任务参数
+
+    protected $executorBlockStrategy; // 任务阻塞策略，可选值参考 com.xxl.job.core.enums.ExecutorBlockStrategyEnum
+
+    protected $executorTimeout; // 任务超时时间，单位秒，大于零时生效
+
+    protected $logId; // 本次调度日志ID
+
+    protected $logDateTime; // 本次调度日志时间
+
+    protected $glueType; // 任务模式，可选值参考 com.xxl.job.core.glue.GlueTypeEnum
+
+    protected $glueSource;  // GLUE脚本代码
+
+    protected $glueUpdatetime; // GLUE脚本更新时间，用于判定脚本是否变更以及是否需要刷新
+
+    protected $broadcastIndex; // 分片参数：当前分片
+
+    protected $broadcastTotal; // 分片参数：总分片
+
+    public function getJobId(): int
+    {
+        return $this->jobId;
+    }
+
+    public function getExecutorHandler(): string
+    {
+        return $this->executorHandler;
+    }
+
+    public function getExecutorParams(): string
+    {
+        return $this->executorParams;
+    }
+
+    public function getExecutorBlockStrategy(): string
+    {
+        return $this->executorBlockStrategy;
+    }
+
+    public function getExecutorTimeout(): int
+    {
+        return $this->executorTimeout;
+    }
+
+    public function getLogId(): int
+    {
+        return $this->logId;
+    }
+
+    public function getLogDateTime(): int
+    {
+        return $this->logDateTime;
+    }
+
+    public function getGlueType(): string
+    {
+        return $this->glueType;
+    }
+
+    public function getGlueSource(): string
+    {
+        return $this->glueSource;
+    }
+
+    public function getGlueUpdatetime(): string
+    {
+        return $this->glueUpdatetime;
+    }
+
+    public function getBroadcastIndex(): int
+    {
+        return $this->broadcastIndex;
+    }
+
+    public function getBroadcastTotal(): int
+    {
+        return $this->broadcastTotal;
+    }
+}

--- a/src/xxljob/src/publish/xxl_job.php
+++ b/src/xxljob/src/publish/xxl_job.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // enable false 将不会启动服务
+    'enable' => true,
+    'admin_address' => 'http://127.0.0.1:8769/xxl-job-admin',
+    'app_name' => 'xxl-job-demo',
+    'prefix_url' => 'php-xxl-job',
+    //access_token
+    'access_token' => null,
+    'log' => [
+        'filename' => BASE_PATH . '/runtime/logs/xxl-job/job.log',
+        'maxDay' => 30,
+    ],
+];


### PR DESCRIPTION
## PHP XxlJob Client

基于 [Hyperf](https://github.com/hyperf/hyperf) 框架的 xxlJob PHP 客户端

##### 优点

- 分布式任务调度平台
- 任务可以随时关闭与开启
- 日志可通过服务端查看

##### 缺点

- 不能取消正在执行的任务


## 安装

```
composer require hyperf/xxljob
```

## 使用

#### 发布配置文件

```bash
php bin/hyperf.php vendor:publish hyperf/xxljob
```
##### 配置信息
> config/autoload/xxl_job.php
```php
return [
    // enable false 将不会启动服务
    'enable' => true,
    //服务端地址
    'admin_address' => 'http://127.0.0.1:8769/xxl-job-admin',
    //执行器名称
    'app_name' => 'xxl-job-demo',
    //客户端请求前缀
    'prefix_url' => 'php-xxl-job',
    //access_token
    'access_token' => null,
    'log' => [
        'filename' => BASE_PATH . '/runtime/logs/xxl-job/job.log',
        //日志最大留存天数 0:不删除
        'maxDay' => 30,
    ],
];
```

#### BEAN模式(类形式)
Bean模式任务，支持基于类的开发方式，每个任务对应一个PHP类。
##### 步骤一：新建目录，开发Job类：
```php
class DemoJob extends AbstractJobHandler{}
```
##### 步骤二：调度中心，新建调度任务
```
1. 编写job类继承AbstractJobHandler
2. 注解配置：为Job类添加注解 "#[JobHandler('自定义jobhandler名称')]"，注解value值对应的是调度中心新建任务的JobHandler属性的值。
3. 执行日志：需要通过 "$this->getXxlJobHelper()->log('...')" 打印执行日志;
```
对新建的任务进行参数配置，运行模式选中 “BEAN模式”，JobHandler属性填写任务注解“#[JobHandler]”中定义的值
![hMvJnQ](https://www.xuxueli.com/doc/static/xxl-job/images/img_ZAsz.png)

#### 完整示例
```php
namespace App\Job;

use Hyperf\XxlJob\Annotation\JobHandler;
use Hyperf\XxlJob\Handler\AbstractJobHandler;

#[JobHandler('demoJob')]
class DemoJob extends AbstractJobHandler
{
    
    public function handle(): void
    {
        //获取参数
        $params = $this->getParams();
        //处理...
        for ($i=1;$i<5;$i++) {
            $this->getXxlJobHelper()->log($i);
            $this->getXxlJobHelper()->log("demoJob");
        }

    }
}
```
详细文档 [xxl-job](https://www.xuxueli.com/xxl-job) 
