### PR TITLE
Optimized `ReflectionParameter::getClass()` is deprecated in PHP8.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -5,6 +5,9 @@
 - [#3997](https://github.com/hyperf/hyperf/pull/3997) Fixed unexpected termination of nats consumer after timeout.
 - [#3998](https://github.com/hyperf/hyperf/pull/3998) Fixed bug that `apollo` does not support `https`.
 
+## Optimized
+- Optimized `ReflectionParameter::getClass()` is deprecated in PHP8.
+
 # v2.2.6 - 2021-08-30
 
 ## Fixed

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -6,7 +6,7 @@
 - [#3998](https://github.com/hyperf/hyperf/pull/3998) Fixed bug that `apollo` does not support `https`.
 
 ## Optimized
-- Optimized `ReflectionParameter::getClass()` is deprecated in PHP8.
+- [#4009](https://github.com/hyperf/hyperf/pull/4009) Optimized `ReflectionParameter::getClass()` is deprecated in PHP8.
 
 # v2.2.6 - 2021-08-30
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -6,7 +6,7 @@
 - [#3998](https://github.com/hyperf/hyperf/pull/3998) Fixed bug that `apollo` does not support `https`.
 
 ## Optimized
-- [#4009](https://github.com/hyperf/hyperf/pull/4009) Optimized `ReflectionParameter::getClass()` is deprecated in PHP8.
+- [#4009](https://github.com/hyperf/hyperf/pull/4009) Optimized method `MethodDefinitionCollector::getOrParse()` to avoid deprecated in PHP8.
 
 # v2.2.6 - 2021-08-30
 

--- a/src/di/src/MethodDefinitionCollector.php
+++ b/src/di/src/MethodDefinitionCollector.php
@@ -55,7 +55,7 @@ class MethodDefinitionCollector extends AbstractCallableDefinitionCollector impl
                     $definitions[] = [
                         'type' => 'object',
                         'name' => $parameter->getName(),
-                        'ref' => $parameter->getType()->getName() ?? null,
+                        'ref' => $type ?? null,
                         'allowsNull' => $parameter->allowsNull(),
                     ];
                     break;

--- a/src/di/src/MethodDefinitionCollector.php
+++ b/src/di/src/MethodDefinitionCollector.php
@@ -55,7 +55,7 @@ class MethodDefinitionCollector extends AbstractCallableDefinitionCollector impl
                     $definitions[] = [
                         'type' => 'object',
                         'name' => $parameter->getName(),
-                        'ref' => $parameter->getClass()->getName() ?? null,
+                        'ref' => $parameter->getType()->getName() ?? null,
                         'allowsNull' => $parameter->allowsNull(),
                     ];
                     break;


### PR DESCRIPTION
php8 使用 gRPC 时出现的