### PR TITLE
fix(metrics): success rate calculation

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- [#4028](https://github.com/hyperf/hyperf/pull/4028) Fixed the success rate calculation in grafana dashboard.
 - [#4030](https://github.com/hyperf/hyperf/pull/4030) Fixed bug that async-queue broken caused by uncompress model failed.
 
 ## Added

--- a/src/metric/grafana.json
+++ b/src/metric/grafana.json
@@ -1189,7 +1189,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(rate([[app_name]]_http_requests_count{instance=~\"$instance\",request_status=~\"[1-3]\\\\d{2}\"}[5m]))  by (request_path)/sum(rate([[app_name]]_http_requests_count{instance=~\"$instance\",request_status=~\"[1-3]\\\\d{2}\"}[5m])) by (request_path)",
+          "expr": "sum(rate([[app_name]]_http_requests_count{instance=~\"$instance\",request_status=~\"[1-3]\\\\d{2}\"}[5m]))  by (request_path)/sum(rate([[app_name]]_http_requests_count{instance=~\"$instance\"}[5m])) by (request_path)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
Should be the success requests divided by the total requests, not by the success requests again