### PR TITLE
2.0使用配置中心的时候，会报错:ProcessCollector::isEmpty方法未找到

### DIFF
--- a/src/process/src/ProcessCollector.php
+++ b/src/process/src/ProcessCollector.php
@@ -38,8 +38,7 @@ class ProcessCollector
         }
         return $result;
     }
-    
-    
+   
     public static function isEmpty(): bool
     {
         return static::$processes === [];

--- a/src/process/src/ProcessCollector.php
+++ b/src/process/src/ProcessCollector.php
@@ -38,4 +38,10 @@ class ProcessCollector
         }
         return $result;
     }
+    
+    
+    public static function isEmpty(): bool
+    {
+        return static::$processes === [];
+    }
 }


### PR DESCRIPTION
2.0使用配置中心的时候，会报错:ProcessCollector::isEmpty方法未找到