### PR TITLE
开发者自定义死信队列

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -10,7 +10,7 @@
 - [#4013](https://github.com/hyperf/hyperf/pull/4013) Support `sameSite=None` when return response with cookies.
 - [#4017](https://github.com/hyperf/hyperf/pull/4017) Added `Macroable` into `Hyperf\Utils\Collection`.
 - [#4021](https://github.com/hyperf/hyperf/pull/4021) Added argument `$attempts` into `$callback` when using function `retry()`.
-- [#4040](https://github.com/hyperf/hyperf/pull/4040) Added property `$deadLetterExchange` into `ConsumerDelayedMessageTrait`, you can rewrite it by yourself.
+- [#4040](https://github.com/hyperf/hyperf/pull/4040) Added method `ConsumerDelayedMessageTrait::getDeadLetterExchange()` which used to rewrite `x-dead-letter-exchange` by yourself.
 
 ## Removed
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -10,6 +10,7 @@
 - [#4013](https://github.com/hyperf/hyperf/pull/4013) Support `sameSite=None` when return response with cookies.
 - [#4017](https://github.com/hyperf/hyperf/pull/4017) Added `Macroable` into `Hyperf\Utils\Collection`.
 - [#4021](https://github.com/hyperf/hyperf/pull/4021) Added argument `$attempts` into `$callback` when using function `retry()`.
+- [#4040](https://github.com/hyperf/hyperf/pull/4040) Added property `$deadLetterExchange` into `ConsumerDelayedMessageTrait`, you can rewrite it by yourself.
 
 ## Removed
 

--- a/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
@@ -20,11 +20,16 @@ use PhpAmqpLib\Wire\AMQPTable;
 trait ConsumerDelayedMessageTrait
 {
     /**
+     * @var string x-dead-letter-exchange
+     */
+    protected $deadLetterExchange = 'delayed';
+
+    /**
      * Overwrite.
      */
     public function getQueueBuilder(): QueueBuilder
     {
         return (new QueueBuilder())->setQueue((string) $this->getQueue())
-            ->setArguments(new AMQPTable(['x-dead-letter-exchange' => 'delayed']));
+            ->setArguments(new AMQPTable(['x-dead-letter-exchange' => $this->deadLetterExchange]));
     }
 }

--- a/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
+++ b/src/amqp/src/Message/ConsumerDelayedMessageTrait.php
@@ -20,16 +20,16 @@ use PhpAmqpLib\Wire\AMQPTable;
 trait ConsumerDelayedMessageTrait
 {
     /**
-     * @var string x-dead-letter-exchange
-     */
-    protected $deadLetterExchange = 'delayed';
-
-    /**
      * Overwrite.
      */
     public function getQueueBuilder(): QueueBuilder
     {
         return (new QueueBuilder())->setQueue((string) $this->getQueue())
-            ->setArguments(new AMQPTable(['x-dead-letter-exchange' => $this->deadLetterExchange]));
+            ->setArguments(new AMQPTable(['x-dead-letter-exchange' => $this->getDeadLetterExchange()]));
+    }
+
+    protected function getDeadLetterExchange(): string
+    {
+        return 'delayed';
     }
 }

--- a/src/amqp/tests/ConsumerTest.php
+++ b/src/amqp/tests/ConsumerTest.php
@@ -18,6 +18,8 @@ use Hyperf\Utils\Exception\ChannelClosedException;
 use Hyperf\Utils\Reflection\ClassInvoker;
 use HyperfTest\Amqp\Stub\AMQPConnectionStub;
 use HyperfTest\Amqp\Stub\ContainerStub;
+use HyperfTest\Amqp\Stub\Delay2Consumer;
+use HyperfTest\Amqp\Stub\DelayConsumer;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -55,5 +57,14 @@ class ConsumerTest extends TestCase
         $this->expectException(ChannelClosedException::class);
         $chan->close();
         $invoker->wait_channel(1);
+    }
+
+    public function testRewriteDelayMessage()
+    {
+        $consumer = new DelayConsumer();
+        $this->assertSame('x-delayed', (new ClassInvoker($consumer))->getDeadLetterExchange());
+
+        $consumer = new Delay2Consumer();
+        $this->assertSame('delayed', (new ClassInvoker($consumer))->getDeadLetterExchange());
     }
 }

--- a/src/amqp/tests/Stub/Delay2Consumer.php
+++ b/src/amqp/tests/Stub/Delay2Consumer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Amqp\Stub;
+
+use Hyperf\Amqp\Message\ConsumerDelayedMessageTrait;
+use Hyperf\Amqp\Message\ConsumerMessage;
+
+class Delay2Consumer extends ConsumerMessage
+{
+    use ConsumerDelayedMessageTrait;
+}

--- a/src/amqp/tests/Stub/DelayConsumer.php
+++ b/src/amqp/tests/Stub/DelayConsumer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Amqp\Stub;
+
+use Hyperf\Amqp\Message\ConsumerDelayedMessageTrait;
+use Hyperf\Amqp\Message\ConsumerMessage;
+
+class DelayConsumer extends ConsumerMessage
+{
+    use ConsumerDelayedMessageTrait;
+
+    protected function getDeadLetterExchange(): string
+    {
+        return 'x-delayed';
+    }
+}


### PR DESCRIPTION
开发人员可以自定义延时队列的死信exchange，原因是实际项目中会有多个独立的队列，死信队列最好能跟根据业务区分但，方便开发人员单独处理死信问题；