### PR TITLE
Improve clarity of English language installation documentation

### DIFF
--- a/docs/en/donate.md
+++ b/docs/en/donate.md
@@ -2,7 +2,7 @@
 
 Hyperf is an MIT licensed open source project and completely free to use. However, the amount of effort needed to maintain and develop new features for the project is not sustainable without proper financial backing. You can support Hyperf development via the following methods:
 
-## Sponsored the development of Hyperf
+## Sponsor the development of Hyperf
 
 If you run a business and are using Hyperf in a revenue-generating product, it makes business sense to sponsor Hyperf development: it ensures the project that your product relies on stays healthy and actively maintained. It can also help your exposure in the Hyperf community and makes it easier to attract Hyperf developers.
 If you are an individual user and have enjoyed the productivity of using Hyperf, consider donating as a sign of appreciation - like buying me coffee once in a while :)

--- a/docs/en/quick-start/install.md
+++ b/docs/en/quick-start/install.md
@@ -2,19 +2,19 @@
 
 ## Requirements
 
-Hyperf has some requirements for the system environment, it can only run under Linux and Mac environment, but due to the development of Docker virtualization technology, Docker for Windows can also be used as the running environment under Windows. Generally, in Mac environment, we are more A local environment deployment is recommended, to avoid the problem of slowly I/O  of shared disks, this will causing Hyperf to start up slowly. 
+Hyperf can only run on the Linux and MacOS system environments. However, due to the development of Docker virtualization technology, it is possible to use Windows as the system environment using Docker for Windows. If you use MacOS we recommend a local deployment to avoid the Docker shared disk causing slow startup times for Hyperf.
 
-The various versions of Dockerfile have been prepared for you in the [hyperf/hyperf-docker](https://github.com/hyperf/hyperf-docker) project, or directly based on the already built [hyperf\ Hyperf] (https://hub.docker.com/r/hyperf/hyperf) Image to run.
+Various Dockerfiles have been prepared for in the [hyperf/hyperf-docker](https://github.com/hyperf/hyperf-docker) project, or you can use a prebuilt image based on [hyperf\Hyperf](https://hub.docker.com/r/hyperf/hyperf).
 
-When you don't want to use Docker as the basis for your running environment, you need to make sure that your operating environment meets the following requirements:  
+If you don't use Docker as the basis for your system environment, you need to make sure that your native environment meets the following requirements:
 
  - PHP >= 7.3
- - Swoole PHP extension >= 4.5，and Disabled `Short Name`
+ - Swoole PHP extension >= 4.5，with `swoole.use_shortname` set to `Off` in your `php.ini`
  - OpenSSL PHP extension
  - JSON PHP extension
- - PDO PHP extension （If you need to use MySQL Client）
- - Redis PHP extension （If you need to use Redis Client）
- - Protobuf PHP extension （If you need to use gRPC Server of Client）
+ - PDO PHP extension （If you need to use the MySQL Client）
+ - Redis PHP extension （If you need to use the Redis Client）
+ - Protobuf PHP extension （If you need to use the gRPC Server or Client）
 
 
 ## Install Hyperf
@@ -23,36 +23,46 @@ Hyperf uses [Composer] (https://getcomposer.org) to manage project dependencies.
 
 ### Create project via `Composer`
 
-The project [hyperf/hyperf-skeleton](https://github.com/hyperf/hyperf-skeleton) is a skeleton project that we have prepared for you, with built-in files for common components and related configuration. And it is a Web project foundation that can be quickly used for business development. At the time of installation, you can choose component dependencies according to your own needs.
+The project [hyperf/hyperf-skeleton](https://github.com/hyperf/hyperf-skeleton) is a skeleton project that we have prepared for you, with built-in files for common components and related configuration. It is a foundational web project that can be quickly used to get started with professional Hyperf development. At the time of installation, you can choose component dependencies according to your own needs.
 Execute the following command to create a hyperf-skeleton project at the current location
 
 ```
 composer create-project hyperf/hyperf-skeleton 
 ```
 
-### Develope in Docker
+### Develop in Docker
 
-Assuming your native environment does not meet the Hyperf environment requirements, or maybe you are not so familiar with the environment configuration, you can run and develop the Hyperf project in the following ways:
+If your native environment does not meet the Hyperf system requirements, or if you are unfamiliar with  system configuration, you can run and develop the Hyperf project as follows using Docker.
+
+In the following example the host will be mapped to the local directory `/workspace/skeleton`:
+
+> If the `selinux-enabled` option is enabled when docker starts, access to host resources in the container will be restricted, so you should add the `--privileged -u root` option when starting the container.
 
 ```
-# Download and run hyperf/hyperf image，and bind the directory of project with /tmp/skeleton of Host
-docker run -v /tmp/skeleton:/hyperf-skeleton -p 9501:9501 -it --entrypoint /bin/sh hyperf/hyperf:7.4-alpine-v3.11-swoole
+# Boot the docker image
+docker run --name hyperf \
+-v /workspace/skeleton:/data/project \
+-p 9501:9501 -it \
+--privileged -u root \
+--entrypoint /bin/sh \
+hyperf/hyperf:7.4-alpine-v3.11-swoole
 
 # Install hyperf/hyperf-skeleton project via Composer
+cd /data/project
 composer create-project hyperf/hyperf-skeleton
 
 # Cd to the installed directory
 cd hyperf-skeleton
+
 # Start Hyperf
 php bin/hyperf.php start
 ```
 
-Next, you can see your installed project in `/tmp/skeleton`. Since Hyperf is a persistent CLI framework, when you have modified your code, you should terminate the currently started process instance with `CTRL + C` and re-execute the `php bin/hyperf.php start` startup command to restart your server and reload the code.
+Next, you can see your installed project in `/workspace/skeleton`. Since Hyperf is a persistent CLI framework, when you have modified your code, you should terminate the running process instance with `CTRL + C` and re-execute the `php bin/hyperf.php start` startup command to restart your server and reload the code.
 
 ## Incompatible extensions
 
-Because Hyperf is based on the Swoole coroutine implementation, and the Swoole 4's coroutine functionality is unprecedented in PHP, there is still in-compatibility with many extensions.
-The following extensions (including but not limited to) will cause certain in-compatibility issues:
+Because Hyperf is based on Swoole's unprecedented coroutine functionality many extensions are incompatible, the following (including but not limited to) extensions are currently incompatible:
 
 - xhprof
 - xdebug


### PR DESCRIPTION
I made the English language version of the installation documentation clearer and fixed several issues and typos which had cropped up during the original translation.

I updated the Docker development instructions to match the instructions used in the `zh-cn` version (including the directory being bound to Docker from the host) so that we can easily update the instructions in the future without worrying about having two different version.

I also updated a minor grammatical issue on the donation page.

(_On a side note this is my first foray in to contributing to the Hyperf project as one of your English language users and several of the documentation pages are incorrect or missing in the English language version. I'd very much like to fix that as I rely on these docs heavily so you'll be seeing many more commits from me in the future._)