### PR TITLE
chore(deps): remove zipkin hard-dependency

### DIFF
--- a/docs/en/tracer.md
+++ b/docs/en/tracer.md
@@ -1,7 +1,9 @@
 # Call link tracking
 
 In the microservice architecture, there will be a lot of services by splitting, which means that a business request may go through 3 or 4 services at least, even dozens or more. Under this architecture, it is extremely difficult when we need to debug a certain problem. Then we need a call link tracking system to help us dynamically display the service call link so that we can quickly locate the problem, and also optimize the service based on the link information.
-In `Hyperf`, we provide the [hyperf/tracer](https://github.com/hyperf/tracer) component to track and analyze the call of each cross-network request. Currently, the [Zipkin](https://zipkin.io/) system and the [Jaeger](https://www.jaegertracing.io/) system are docked according to the [OpenTracing](https://opentracing.io) protocol. Users can also customize this by following the OpenTracing protocol.
+In `Hyperf`, we provide the [hyperf/tracer](https://github.com/hyperf/tracer) component to track and analyze the call of each cross-network request.
+Currently, the [Zipkin](https://zipkin.io/) system and the [Jaeger](https://www.jaegertracing.io/) system are docked according to the [OpenTracing](https://opentracing.io) protocol.
+Users can also customize this by following the OpenTracing protocol.
 
 ## Installation
 
@@ -11,11 +13,15 @@ In `Hyperf`, we provide the [hyperf/tracer](https://github.com/hyperf/tracer) co
 composer require hyperf/tracer
 ```
 
-The [hyperf/tracer](https://github.com/hyperf/tracer) component has installed [Zipkin](https://zipkin.io/) related dependencies by default. If you want to use [Jaeger](https://www.jaegertracing.io/), you need to execute the following command to install the corresponding dependencies:
-
-```bash
-composer require jonahgeorge/jaeger-client-php
-```
+The [hyperf/tracer](https://github.com/hyperf/tracer) component depends on peer dependencies:
+- For [Zipkin](https://zipkin.io/), you need to execute the following command to install the corresponding dependencies:
+    ```bash
+    composer require jcchavezs/zipkin-opentracing    
+    ```
+- And if you want to use [Jaeger](https://www.jaegertracing.io/), you need to execute the following command to install the corresponding dependencies:
+    ```bash
+    composer require jonahgeorge/jaeger-client-php
+    ```
 
 ### Add component configuration
 

--- a/docs/zh-cn/tracer.md
+++ b/docs/zh-cn/tracer.md
@@ -11,11 +11,15 @@
 composer require hyperf/tracer
 ```
 
-[hyperf/tracer](https://github.com/hyperf/tracer) 组件默认安装了 [Zipkin](https://zipkin.io/) 相关依赖。如果要使用 [Jaeger](https://www.jaegertracing.io/)，还需要执行下面的命令安装对应的依赖：
-
-```bash
-composer require jonahgeorge/jaeger-client-php
-```
+[hyperf/tracer](https://github.com/hyperf/tracer) 组件依赖于对等依赖：
+- 对于[Zipkin](https://zipkin.io/)，需要执行如下命令安装对应的依赖：
+    ```bash
+    composer require jcchavezs/zipkin-opentracing    
+    ```
+- 而如果要使用[Jaeger](https://www.jaegertracing.io/)，则需要执行如下命令安装对应的依赖:
+    ```bash
+    composer require jonahgeorge/jaeger-client-php
+    ```
 
 ### 增加组件配置
 

--- a/src/tracer/composer.json
+++ b/src/tracer/composer.json
@@ -22,7 +22,6 @@
         "hyperf/di": "~2.2.0",
         "hyperf/guzzle": "~2.2.0",
         "hyperf/utils": "~2.2.0",
-        "jcchavezs/zipkin-opentracing":"^1.0",
         "opentracing/opentracing":"^1.0"
     },
     "suggest": {

--- a/src/tracer/composer.json
+++ b/src/tracer/composer.json
@@ -26,6 +26,7 @@
     },
     "suggest": {
         "hyperf/event": "Required to use DbQueryExecutedListener.",
+        "jcchavezs/zipkin-opentracing": "Required to use zipkin tracing.",
         "jonahgeorge/jaeger-client-php":"Required (^0.6) to use jaeger tracing."
     },
     "autoload": {


### PR DESCRIPTION
It's a proposal to remove the Zipkin hard-dependency because it is currently a PHP 8.x blocker. Even if we could use Jaeger (which supports 8) this dep is hardened with hyperf/tracer.

**对不起普通话不好**