### PR TITLE
Docs now automatically display in the chosen language of the users br…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-php.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify-edit-on-github/index.js"></script>
+  <script src="/plugin/localization.js"></script>
   <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
   <script>
     mermaid.initialize({ startOnLoad: false });
@@ -62,7 +63,8 @@
         '/summary.md': './zh-cn/summary.md'
       },
       plugins: [
-        EditOnGithubPlugin.create('https://github.com/hyperf/hyperf/blob/master/docs/')
+        EditOnGithubPlugin.create('https://github.com/hyperf/hyperf/blob/master/docs/'),
+        HyperfLocalization.loadPlugin
       ],
       plantuml: {
         skin: 'classic',

--- a/docs/plugin/localization.js
+++ b/docs/plugin/localization.js
@@ -5,8 +5,8 @@ window.HyperfLocalization = {
                 // zh-cn is the default so is not present
                 fullMatches = ['zh-tw', 'zh-hk'],
                 locale = (navigator.languages
-                ? navigator.languages[0]
-                : (navigator.language || navigator.userLanguage)).toLowerCase();
+                    ? navigator.languages[0]
+                    : (navigator.language || navigator.userLanguage)).toLowerCase();
 
             for (var i = 0; i < shortMatches.length; i++) {
                 if (locale.substr(0, 2) === shortMatches[i] && vm.route.path === '/') {

--- a/docs/plugin/localization.js
+++ b/docs/plugin/localization.js
@@ -1,0 +1,24 @@
+window.HyperfLocalization = {
+    loadPlugin: function(hook, vm) {
+        hook.beforeEach(function(to, from, next) {
+            var shortMatches = ['en'],
+                // zh-cn is the default so is not present
+                fullMatches = ['zh-tw', 'zh-hk'],
+                locale = (navigator.languages
+                ? navigator.languages[0]
+                : (navigator.language || navigator.userLanguage)).toLowerCase();
+
+            for (var i = 0; i < shortMatches.length; i++) {
+                if (locale.substr(0, 2) === shortMatches[i] && vm.route.path === '/') {
+                    window.location.hash = '/' + shortMatches[i] + '/';
+                }
+            }
+
+            for (i = 0; i < fullMatches.length; i++) {
+                if (locale === fullMatches[i] && vm.route.path === '/') {
+                    window.location.hash = '/' + fullMatches[i] + '/';
+                }
+            }
+        })
+    }
+};


### PR DESCRIPTION
...owser for en-*, zh-HK, zh-TW users.

At the moment if you load the Hyperf docs homepage (https://hyperf.wiki/) you will be redirected to (https://hyperf.wiki/2.2/#/) which is delivered in Chinese (zh-cn) regardless of the user's browser locale.

This PR adds a new (local) plugin in a new `/plugin` directory called `localization.js (HyperfLocalization)`. This plugin automatically detects the chosen locale of the user's browser, checks if they are on the homepage and then redirects them to the homepage of their chosen locale.

At the moment it supports the following locales (but it would be very easy to add more, simply add a new locale to the defined `shortMatches/fullMatches` arrays at the top of the plugin file):

* en-* (en-GB, en-US, etc)
* zh-TW
* zh-HK

To test this functionality:

* Load chrome://settings/languages in Google Chrome and update your preferred language to English
* Load https://hyperf.wiki/ and you will be automatically redirected to https://hyperf.wiki/2.2/#/en/
* Load chrome://settings/languages in Google Chrome and update your preferred language to Chinese (Hong Kong)
* Load https://hyperf.wiki/ and you will be automatically redirected to https://hyperf.wiki/2.2/#/zh-hk/
* Load chrome://settings/languages in Google Chrome and update your preferred language to Chinese 
* Load https://hyperf.wiki/ and you will land on https://hyperf.wiki/2.2/#/ as expected

(_This is my first substantial commit to the project following a small docs translation pull request which is in review. You have no `CONTRIBUTORS.md` file so if this PR doesn't follow some process I'm not aware of sorry about that - just push me in the right direction and I'll fix it._ :) )