### PR TITLE
Lock the version of `promphp/prometheus_client_php` to 2.2.*

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.9 - TBD
 
+## Fixed
+
+- [#4061](https://github.com/hyperf/hyperf/pull/4061) Fixed the conflict between the latest version of prometheus_client_php and `hyperf/metric`.
+
 # v2.2.8 - 2021-09-14
 
 ## Fixed

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^9.5",
         "predis/predis": "^1.1",
-        "promphp/prometheus_client_php": "^2.2",
+        "promphp/prometheus_client_php": "2.2.*",
         "reactivex/rxphp": "^2.0",
         "slickdeals/statsd": "^3.0.1",
         "smarty/smarty": "^3.1",

--- a/src/metric/composer.json
+++ b/src/metric/composer.json
@@ -15,7 +15,7 @@
         "hyperf/contract": "~2.2.0",
         "hyperf/guzzle": "~2.2.0",
         "hyperf/utils": "~2.2.0",
-        "promphp/prometheus_client_php": "^2.2",
+        "promphp/prometheus_client_php": "2.2.*",
         "psr/container": "^1.0|^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-message": "^1.0"


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/4055