### PR TITLE
fix variadic parameters in proxy classes

### DIFF
--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -179,18 +179,7 @@ class ProxyCallVisitor extends NodeVisitorAbstract
             ])),
             // A closure that wrapped original method code.
             new Arg(new Closure([
-                'params' => value(function () use ($node) {
-                    // Transfer the variadic variable to normal variable at closure argument. ...$params => $parms
-                    $params = $node->getParams();
-                    foreach ($params as $key => $param) {
-                        if ($param instanceof Node\Param && $param->variadic) {
-                            $newParam = clone $param;
-                            $newParam->variadic = false;
-                            $params[$key] = $newParam;
-                        }
-                    }
-                    return $params;
-                }),
+                'params' => value($node->getParams()),
                 'uses' => [
                     new Variable('__function__'),
                     new Variable('__method__'),

--- a/src/di/src/Aop/ProxyTrait.php
+++ b/src/di/src/Aop/ProxyTrait.php
@@ -44,13 +44,26 @@ trait ProxyTrait
         $reflectParameters = $reflectMethod->getParameters();
         $leftArgCount = count($args);
         foreach ($reflectParameters as $key => $reflectionParameter) {
-            $arg = $reflectionParameter->isVariadic() ? $args : array_shift($args);
-            if (! isset($arg) && $leftArgCount <= 0) {
-                $arg = $reflectionParameter->getDefaultValue();
+            if (! $reflectionParameter->isVariadic()) {
+                $arg = array_shift($args);
+                if (! isset($arg) && $leftArgCount <= 0) {
+                    $arg = $reflectionParameter->getDefaultValue();
+                }
+                --$leftArgCount;
+                $map['keys'][$reflectionParameter->getName()] = $arg;
+                $map['order'][] = $reflectionParameter->getName();
+            } else {
+                // When a variable-length argument is in use, it is the last argument in the list. Since variable
+                // names can not start with a number, here we use integer values as "parameter names" and array keys.
+                //
+                // Since variable-length argument doesn't accept default values, we don't need to worry about that either.
+                $i = 0;
+                foreach ($args as $arg) {
+                    $map['keys'][$i] = $arg;
+                    $map['order'][] = $i;
+                    ++$i;
+                }
             }
-            --$leftArgCount;
-            $map['keys'][$reflectionParameter->getName()] = $arg;
-            $map['order'][] = $reflectionParameter->getName();
         }
         return $map;
     }

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -119,7 +119,9 @@ class Bar5
         $aspect = BarAspect::class;
 
         AspectCollector::setAround($aspect, [
-            Bar4::class . '::toRewriteMethodString',
+            Bar4::class . '::toRewriteMethodString1',
+            Bar4::class . '::toRewriteMethodString2',
+            Bar4::class . '::toRewriteMethodString3',
         ], []);
 
         $ast = new Ast();
@@ -139,11 +141,27 @@ class Bar4
     {
         return __METHOD__;
     }
-    public function toRewriteMethodString() : string
+    public function toRewriteMethodString1(int $count) : string
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int $count) use($__function__, $__method__) {
+            return $__method__;
+        });
+    }
+    public function toRewriteMethodString2(int $count, string ...$params) : string
+    {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int $count, string ...$params) use($__function__, $__method__) {
+            return $__method__;
+        });
+    }
+    public function toRewriteMethodString3(int &$count) : string
+    {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int &$count) use($__function__, $__method__) {
             return $__method__;
         });
     }

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -122,6 +122,7 @@ class Bar5
             Bar4::class . '::toRewriteMethodString1',
             Bar4::class . '::toRewriteMethodString2',
             Bar4::class . '::toRewriteMethodString3',
+            Bar4::class . '::toRewriteMethodString4',
         ], []);
 
         $ast = new Ast();
@@ -141,6 +142,9 @@ class Bar4
     {
         return __METHOD__;
     }
+    /**
+     * To test method parameters (with type declaration in use).
+     */
     public function toRewriteMethodString1(int $count) : string
     {
         $__function__ = __FUNCTION__;
@@ -149,19 +153,36 @@ class Bar4
             return $__method__;
         });
     }
-    public function toRewriteMethodString2(int $count, string ...$params) : string
-    {
-        $__function__ = __FUNCTION__;
-        $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int $count, string ...$params) use($__function__, $__method__) {
-            return $__method__;
-        });
-    }
-    public function toRewriteMethodString3(int &$count) : string
+    /**
+     * To test passing by references.
+     */
+    public function toRewriteMethodString2(int &$count) : string
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
         return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int &$count) use($__function__, $__method__) {
+            return $__method__;
+        });
+    }
+    /**
+     * To test variadic parameters (without type declaration).
+     */
+    public function toRewriteMethodString3(...$params) : string
+    {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (...$params) use($__function__, $__method__) {
+            return $__method__;
+        });
+    }
+    /**
+     * To test variadic parameters with type declaration.
+     */
+    public function toRewriteMethodString4(int &$count, string ...$params) : string
+    {
+        $__function__ = __FUNCTION__;
+        $__method__ = __METHOD__;
+        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int &$count, string ...$params) use($__function__, $__method__) {
             return $__method__;
         });
     }

--- a/src/di/tests/Stub/Ast/Bar4.php
+++ b/src/di/tests/Stub/Ast/Bar4.php
@@ -18,7 +18,18 @@ class Bar4
         return __METHOD__;
     }
 
-    public function toRewriteMethodString(): string
+    public function toRewriteMethodString1(int $count): string
+    {
+        return __METHOD__;
+    }
+
+    public function toRewriteMethodString2(int $count, string ...$params): string
+    {
+        return __METHOD__;
+    }
+
+
+    public function toRewriteMethodString3(int &$count): string
     {
         return __METHOD__;
     }

--- a/src/di/tests/Stub/Ast/Bar4.php
+++ b/src/di/tests/Stub/Ast/Bar4.php
@@ -18,18 +18,34 @@ class Bar4
         return __METHOD__;
     }
 
+    /**
+     * To test method parameters (with type declaration in use).
+     */
     public function toRewriteMethodString1(int $count): string
     {
         return __METHOD__;
     }
 
-    public function toRewriteMethodString2(int $count, string ...$params): string
+    /**
+     * To test passing by references.
+     */
+    public function toRewriteMethodString2(int &$count): string
     {
         return __METHOD__;
     }
 
+    /**
+     * To test variadic parameters (without type declaration).
+     */
+    public function toRewriteMethodString3(...$params): string
+    {
+        return __METHOD__;
+    }
 
-    public function toRewriteMethodString3(int &$count): string
+    /**
+     * To test variadic parameters with type declaration.
+     */
+    public function toRewriteMethodString4(int &$count, string ...$params): string
     {
         return __METHOD__;
     }


### PR DESCRIPTION
To fix methods generated in proxy classes when variadic parameters are in used:

```php
    public function toRewriteMethodString2(int $count, string ...$params): string
    {
        return __METHOD__;
    }
```

The bug is found during code debugging, although I don't see this type of method is been used by any annotations for now.