### PR TITLE
fixbug auth failed when password has special charsets

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.11 - TBD
 
+## Fixed
+
+- [#4101](https://github.com/hyperf/hyperf/pull/4101) Fixed bug that auth failed when password has special charsets.
+
 # v2.2.10 - 2021-09-26
 
 ## Fixed

--- a/src/nacos/src/Provider/AuthProvider.php
+++ b/src/nacos/src/Provider/AuthProvider.php
@@ -21,9 +21,11 @@ class AuthProvider extends AbstractProvider
     {
         return $this->client()->request('POST', '/nacos/v1/auth/users/login', [
             RequestOptions::QUERY => [
-                'username' => $username,
-                'password' => $password,
+                'username' => $username
             ],
+            RequestOptions::FORM_PARAMS => [
+                "password" => $password
+            ]
         ]);
     }
 }

--- a/src/nacos/src/Provider/AuthProvider.php
+++ b/src/nacos/src/Provider/AuthProvider.php
@@ -21,11 +21,11 @@ class AuthProvider extends AbstractProvider
     {
         return $this->client()->request('POST', '/nacos/v1/auth/users/login', [
             RequestOptions::QUERY => [
-                'username' => $username
+                'username' => $username,
             ],
             RequestOptions::FORM_PARAMS => [
-                "password" => $password
-            ]
+                'password' => $password,
+            ],
         ]);
     }
 }


### PR DESCRIPTION
当密码中包含特殊字符时，nacos登录失败。

原因是将password放在query params中，会自动url_encode。
将password放在body中，则特殊字符不会被url_encode。