### PR TITLE
fixed model builder

### DIFF
--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -142,9 +142,8 @@ class Builder
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        call([$this->query, $method], $parameters);
+        return call([$this->query, $method], $parameters);
 
-        return $this;
     }
 
     /**


### PR DESCRIPTION
在使用 model 调用 insertOrIgnore 会返回整个 builder 对象，个人认为是不太合理的，实际上应该按照原样返回会更合理，而不是用 __call 去接管返回的结果之后，返回一个 builder