### PR TITLE
Fixed health check failed when using consul with token.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.14 - TBD
 
+## Fixed
+
+- [#4171](https://github.com/hyperf/hyperf/pull/4171) Fixed health check failed when using consul with token.
+
 # v2.2.13 - 2021-10-25
 
 ## Added

--- a/src/service-governance-consul/src/ConsulDriver.php
+++ b/src/service-governance-consul/src/ConsulDriver.php
@@ -208,7 +208,7 @@ class ConsulDriver implements DriverInterface
         $options = [
             'base_uri' => $baseUri,
         ];
-        
+
         if (! empty($token)) {
             $options['headers'] = [
                 'X-Consul-Token' => $token,


### PR DESCRIPTION
修改Hyperf\ServiceGovernanceConsul空间下的ConsulDriver类中的createConsulHealth方法，传入config中的token配置

fix https://github.com/hyperf/hyperf/issues/4170