### PR TITLE
Fixed bug that build phar failed when using composer `1.x`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -7,6 +7,7 @@
 ## Fixed
 
 - [#4171](https://github.com/hyperf/hyperf/pull/4171) Fixed health check failed when using consul with token.
+- [#4188](https://github.com/hyperf/hyperf/pull/4188) Fixed bug that build phar failed when using composer `1.x`.
 
 # v2.2.13 - 2021-10-25
 

--- a/src/phar/src/PharBuilder.php
+++ b/src/phar/src/PharBuilder.php
@@ -178,7 +178,13 @@ class PharBuilder
             // Package all of these dependent components into the packages
             foreach ($installedPackages as $package) {
                 // support custom install path
-                $dir = 'composer/' . $package['install-path'] . '/';
+                if(empty($package['install-path'] )) {
+                    $installPath = '../'.$package['name'];
+                }else{
+                    $installPath = $package['install-path'];
+                }
+                $dir = 'composer/' . $installPath . '/';
+
                 if (isset($package['target-dir'])) {
                     $dir .= trim($package['target-dir'], '/') . '/';
                 }

--- a/src/phar/src/PharBuilder.php
+++ b/src/phar/src/PharBuilder.php
@@ -178,11 +178,7 @@ class PharBuilder
             // Package all of these dependent components into the packages
             foreach ($installedPackages as $package) {
                 // support custom install path
-                if(empty($package['install-path'] )) {
-                    $installPath = '../'.$package['name'];
-                }else{
-                    $installPath = $package['install-path'];
-                }
+                $installPath = $package['install-path'] ?: '../' . $package['name'];
                 $dir = 'composer/' . $installPath . '/';
 
                 if (isset($package['target-dir'])) {

--- a/src/phar/src/PharBuilder.php
+++ b/src/phar/src/PharBuilder.php
@@ -178,8 +178,7 @@ class PharBuilder
             // Package all of these dependent components into the packages
             foreach ($installedPackages as $package) {
                 // support custom install path
-                $installPath = $package['install-path'] ?: '../' . $package['name'];
-                $dir = 'composer/' . $installPath . '/';
+                $dir = 'composer/' . ($package['install-path'] ?? '../' . $package['name']) . '/';
 
                 if (isset($package['target-dir'])) {
                     $dir .= trim($package['target-dir'], '/') . '/';

--- a/src/phar/tests/PackageTest.php
+++ b/src/phar/tests/PackageTest.php
@@ -104,9 +104,11 @@ class PackageTest extends TestCase
         $builder = new PharBuilder(__DIR__ . '/fixtures/07-composer-versions/2.x/composer.lock', $logger);
         $packages = $builder->getPackagesDependencies();
         $this->assertSame('hyperf/engine', $packages[0]->getName());
+        $this->assertStringContainsString('/2.x/vendor/hyperf/engine/', $packages[0]->getDirectory());
 
         $builder = new PharBuilder(__DIR__ . '/fixtures/07-composer-versions/1.x/composer.lock', $logger);
         $packages = $builder->getPackagesDependencies();
         $this->assertSame('hyperf/engine', $packages[0]->getName());
+        $this->assertStringContainsString('/1.x/vendor/hyperf/engine/', $packages[0]->getDirectory());
     }
 }

--- a/src/phar/tests/PackageTest.php
+++ b/src/phar/tests/PackageTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 namespace HyperfTest\Phar;
 
 use Hyperf\Phar\Package;
+use Hyperf\Phar\PharBuilder;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * @internal
@@ -20,6 +22,11 @@ use PHPUnit\Framework\TestCase;
  */
 class PackageTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        \Mockery::close();
+    }
+
     public function testDefaults()
     {
         $package = new Package([], 'dirs/');
@@ -89,5 +96,17 @@ class PackageTest extends TestCase
         $this->assertTrue($bundle->checkContains($dir . 'composer.json'));
         $this->assertTrue($bundle->checkContains($dir . 'src/composer.phar'));
         $this->assertTrue($bundle->checkContains($dir . 'src/phar-composer.phar'));
+    }
+
+    public function testInstallPathWhenGetPackagesDependencies()
+    {
+        $logger = \Mockery::mock(LoggerInterface::class);
+        $builder = new PharBuilder(__DIR__ . '/fixtures/07-composer-versions/2.x/composer.lock', $logger);
+        $packages = $builder->getPackagesDependencies();
+        $this->assertSame('hyperf/engine', $packages[0]->getName());
+
+        $builder = new PharBuilder(__DIR__ . '/fixtures/07-composer-versions/1.x/composer.lock', $logger);
+        $packages = $builder->getPackagesDependencies();
+        $this->assertSame('hyperf/engine', $packages[0]->getName());
     }
 }

--- a/src/phar/tests/fixtures/07-composer-versions/.gitignore
+++ b/src/phar/tests/fixtures/07-composer-versions/.gitignore
@@ -1,0 +1,4 @@
+!2.x/composer.lock
+!2.x/vendor/composer/installed.json
+!1.x/composer.lock
+!1.x/vendor/composer/installed.json

--- a/src/phar/tests/fixtures/07-composer-versions/.gitignore
+++ b/src/phar/tests/fixtures/07-composer-versions/.gitignore
@@ -1,4 +1,2 @@
-!2.x/composer.lock
-!2.x/vendor/composer/installed.json
-!1.x/composer.lock
-!1.x/vendor/composer/installed.json
+!2.x/vendor
+!1.x/vendor

--- a/src/phar/tests/fixtures/07-composer-versions/1.x/composer.json
+++ b/src/phar/tests/fixtures/07-composer-versions/1.x/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "hyperf/engine": "^1.1"
+    }
+}

--- a/src/phar/tests/fixtures/07-composer-versions/1.x/composer.lock
+++ b/src/phar/tests/fixtures/07-composer-versions/1.x/composer.lock
@@ -1,0 +1,66 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4f3fcb130f3e7286da5bd9f77ece9be3",
+    "packages": [
+        {
+            "name": "hyperf/engine",
+            "version": "v1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hyperf/engine.git",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hyperf/engine/zipball/f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.4",
+                "swoole/ide-helper": "dev-master"
+            },
+            "suggest": {
+                "ext-swoole": ">=4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hyperf\\Engine\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "hyperf",
+                "php"
+            ],
+            "time": "2021-07-11T10:22:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/src/phar/tests/fixtures/07-composer-versions/1.x/vendor/composer/installed.json
+++ b/src/phar/tests/fixtures/07-composer-versions/1.x/vendor/composer/installed.json
@@ -1,0 +1,51 @@
+[
+    {
+        "name": "hyperf/engine",
+        "version": "v1.1.6",
+        "version_normalized": "1.1.6.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/hyperf/engine.git",
+            "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/hyperf/engine/zipball/f583f01f458f8c69080e06e6dce715c86edc9f86",
+            "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=7.3"
+        },
+        "require-dev": {
+            "friendsofphp/php-cs-fixer": "^3.0",
+            "phpstan/phpstan": "^0.12",
+            "phpunit/phpunit": "^9.4",
+            "swoole/ide-helper": "dev-master"
+        },
+        "suggest": {
+            "ext-swoole": ">=4.5"
+        },
+        "time": "2021-07-11T10:22:13+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Hyperf\\Engine\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "keywords": [
+            "hyperf",
+            "php"
+        ]
+    }
+]

--- a/src/phar/tests/fixtures/07-composer-versions/2.x/composer.json
+++ b/src/phar/tests/fixtures/07-composer-versions/2.x/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "hyperf/engine": "^1.1"
+    }
+}

--- a/src/phar/tests/fixtures/07-composer-versions/2.x/composer.lock
+++ b/src/phar/tests/fixtures/07-composer-versions/2.x/composer.lock
@@ -1,0 +1,70 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4f3fcb130f3e7286da5bd9f77ece9be3",
+    "packages": [
+        {
+            "name": "hyperf/engine",
+            "version": "v1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hyperf/engine.git",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hyperf/engine/zipball/f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.4",
+                "swoole/ide-helper": "dev-master"
+            },
+            "suggest": {
+                "ext-swoole": ">=4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hyperf\\Engine\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "hyperf",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/hyperf/engine/issues",
+                "source": "https://github.com/hyperf/engine/tree/v1.1.6"
+            },
+            "time": "2021-07-11T10:22:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/src/phar/tests/fixtures/07-composer-versions/2.x/vendor/composer/installed.json
+++ b/src/phar/tests/fixtures/07-composer-versions/2.x/vendor/composer/installed.json
@@ -1,0 +1,60 @@
+{
+    "packages": [
+        {
+            "name": "hyperf/engine",
+            "version": "v1.1.6",
+            "version_normalized": "1.1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hyperf/engine.git",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hyperf/engine/zipball/f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "reference": "f583f01f458f8c69080e06e6dce715c86edc9f86",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.4",
+                "swoole/ide-helper": "dev-master"
+            },
+            "suggest": {
+                "ext-swoole": ">=4.5"
+            },
+            "time": "2021-07-11T10:22:13+00:00",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "Hyperf\\Engine\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "hyperf",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/hyperf/engine/issues",
+                "source": "https://github.com/hyperf/engine/tree/v1.1.6"
+            },
+            "install-path": "../hyperf/engine"
+        }
+    ],
+    "dev": true,
+    "dev-package-names": []
+}


### PR DESCRIPTION
当使用Phar 打包器进行打包时,installed.json中如果不存在install-path字段会打包失败

修复vendor\composer\installed.json中没有install-path的异常报错