### PR TITLE
Skip class file does not exist at scan time

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,10 @@
 
 - [#4252](https://github.com/hyperf/hyperf/pull/4252) Added method `getServiceName` for rpc client.
 
+## Optimized
+
+- [#4253](https://github.com/hyperf/hyperf/pull/4253) Skip class which is not found by class loader at scan time.
+
 # v2.2.15 - 2021-11-08
 
 ## Fixed

--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -344,6 +344,7 @@ class Scanner
         foreach ($classes as $class) {
             $file = $this->classloader->getComposerClassLoader()->findFile($class);
             if ($file === false) {
+                echo sprintf('Skip class %s, because it does not exist in composer class loader.', $class) . PHP_EOL;
                 continue;
             }
             if ($lastCacheModified <= $this->filesystem->lastModified($file)) {

--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -343,6 +343,9 @@ class Scanner
         }
         foreach ($classes as $class) {
             $file = $this->classloader->getComposerClassLoader()->findFile($class);
+            if ($file === false) {
+                continue;
+            }
             if ($lastCacheModified <= $this->filesystem->lastModified($file)) {
                 $changed[] = $class;
             }


### PR DESCRIPTION
`bin/hyperf.php`中再加载另外一个`autoload.php`，会出现这种情况

```bash
PHP Fatal error:  Uncaught TypeError: Hyperf\Utils\Filesystem\Filesystem::lastModified(): Argument #1 ($path) must be of type string, bool given, called in vendor/hyperf/di/src/Annotation/Scanner.php on line 346
```

后面会继续扫描到该文件，所以先跳过，避免这个异常