### PR TITLE
Fix `collector-reload` file not found when running `server:watch` with absolute path

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.19 - TBD
 
+## Fixed
+
+- [#4308](https://github.com/hyperf/hyperf/pull/4308) Fix `collector-reload` file not found when running `server:watch` with absolute path.
+
 # v2.2.18 - 2021-11-29
 
 ## Fixed

--- a/src/watcher/src/Watcher.php
+++ b/src/watcher/src/Watcher.php
@@ -124,7 +124,7 @@ class Watcher
                     $this->restart(false);
                 }
             } else {
-                $ret = System::exec($this->option->getBin() . ' vendor/hyperf/watcher/collector-reload.php ' . $file);
+                $ret = System::exec(sprintf('%s %s/vendor/hyperf/watcher/collector-reload.php %s', $this->option->getBin(), BASE_PATH, $file));
                 if ($ret['code'] === 0) {
                     $this->output->writeln('Class reload success.');
                 } else {


### PR DESCRIPTION
```bash
Could not open input file: vendor/hyperf/watcher/collector-reload.php
```