### PR TITLE
Fixed: 修复单元测试post带上路径参数无法执行路由方法

### DIFF
--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -199,6 +199,14 @@ class Client extends Server
         $headers = $options['headers'] ?? [];
         $multipart = $options['multipart'] ?? [];
 
+        $parsePath = parse_url($path);
+        $path = $parsePath['path'];
+        $uriPathQuery = $parsePath['query'] ?? [];
+        if (!empty($uriPathQuery)) {
+            parse_str($uriPathQuery, $pathQuery);
+            $query = array_merge($pathQuery, $query);
+        }
+        
         $data = $params;
 
         // Initialize PSR-7 Request and Response objects.


### PR DESCRIPTION
http单元测试如果是post方法在路由上带上路径参数无法执行路由方法