### PR TITLE
Fixed bug that the path with query params won't match route when using testing client.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.20 - TBD
 
+## Fixed
+
+- [#4338](https://github.com/hyperf/hyperf/pull/4338) Fixed bug that the path with query params won't match route when using testing client.
+
 ## Added
 
 - [#4330](https://github.com/hyperf/hyperf/pull/4330) Support pack vendor/bin files for `hyperf/phar`.

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -199,6 +199,14 @@ class Client extends Server
         $headers = $options['headers'] ?? [];
         $multipart = $options['multipart'] ?? [];
 
+        $parsePath = parse_url($path);
+        $path = $parsePath['path'];
+        $uriPathQuery = $parsePath['query'] ?? [];
+        if (!empty($uriPathQuery)) {
+            parse_str($uriPathQuery, $pathQuery);
+            $query = array_merge($pathQuery, $query);
+        }
+        
         $data = $params;
 
         // Initialize PSR-7 Request and Response objects.

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -202,11 +202,11 @@ class Client extends Server
         $parsePath = parse_url($path);
         $path = $parsePath['path'];
         $uriPathQuery = $parsePath['query'] ?? [];
-        if (!empty($uriPathQuery)) {
+        if (! empty($uriPathQuery)) {
             parse_str($uriPathQuery, $pathQuery);
             $query = array_merge($pathQuery, $query);
         }
-        
+
         $data = $params;
 
         // Initialize PSR-7 Request and Response objects.

--- a/src/testing/src/Debug.php
+++ b/src/testing/src/Debug.php
@@ -21,7 +21,7 @@ class Debug
 
         preg_match('/refcount\((\w+)\)/U', $data, $matched);
         $result = $matched[1];
-        if(is_numeric($result)){
+        if (is_numeric($result)) {
             return bcsub($result, '1');
         }
 


### PR DESCRIPTION
http单元测试如果是post方法在路由上带上路径参数无法执行路由方法