### PR TITLE
Fixed the metadata generation error caused by switching coroutine for snowflake.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0', '8.1' ]
-        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.3', 'master' ]
+        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.4', 'master' ]
         exclude:
           - php-version: '8.1'
             sw-version: 'v4.5.11'

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#4347](https://github.com/hyperf/hyperf/pull/4347) Fixed bug that amqp io has been bound to more than one coroutine when out of buffer.
+- [#4373](https://github.com/hyperf/hyperf/pull/4373) Fixed the metadata generation error caused by switching coroutine for snowflake.
 
 ## Added
 

--- a/src/snowflake/src/MetaGenerator.php
+++ b/src/snowflake/src/MetaGenerator.php
@@ -55,8 +55,9 @@ abstract class MetaGenerator implements MetaGeneratorInterface
         }
 
         $this->lastTimestamp = $timestamp;
+        $sequence = $this->sequence;
 
-        return new Meta($this->getDataCenterId(), $this->getWorkerId(), $this->sequence, $timestamp, $this->beginTimestamp);
+        return new Meta($this->getDataCenterId(), $this->getWorkerId(), $sequence, $timestamp, $this->beginTimestamp);
     }
 
     public function getBeginTimestamp(): int

--- a/src/snowflake/tests/MetaGeneratorTest.php
+++ b/src/snowflake/tests/MetaGeneratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Snowflake;
+
+use Hyperf\Snowflake\Configuration;
+use Hyperf\Snowflake\MetaGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class MetaGeneratorTest extends TestCase
+{
+    public function testGenerate()
+    {
+        $class = new class(new Configuration(), 0) extends MetaGenerator {
+            public function getDataCenterId(): int
+            {
+                return 1;
+            }
+
+            public function getWorkerId(): int
+            {
+                usleep(1000);
+                return 1;
+            }
+
+            public function getTimestamp(): int
+            {
+                return 0;
+            }
+
+            public function getNextTimestamp(): int
+            {
+                return 1;
+            }
+        };
+
+        $callbacks = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $callbacks[] = static function () use ($class) {
+                return $class->generate()->getSequence();
+            };
+        }
+
+        $res = parallel($callbacks);
+        ksort($res);
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], $res);
+    }
+}


### PR DESCRIPTION
业务场景需要开多协程并发生成雪花ID，发现会出现碰撞，追踪发现是因为sequence的值会被其他协程覆盖，导致碰撞，修改为变量传值OK
测试demo如下:
```php
$parallel    = new Parallel;
        $idGenerator =  ApplicationContext::getContainer()->get(IdGenerator\SnowflakeIdGenerator::class);
        $ip          = Network::Ip();
        $port        = getenv('HTTP_PORT',9801);
        $ip          = explode('.', $ip);
        foreach ($ip as &$v) {
            if (strlen($v) !== 3) {
                $v = str_pad($v, 3, (string)0, STR_PAD_LEFT);
            }
        }
        unset($v);
        $workId     = ($ip[2] . $ip[3] . $port) % 32;
        $datacenter = ($ip[0] . $ip[1]) % 32;
        for ($i = 0; $i < 100; $i++) {
            $parallel->add(function () use ($idGenerator, $workId, $datacenter) {
                $meta = $idGenerator->getMetaGenerator()->generate();
                echo 'out_sequence:' . $meta->getSequence() . PHP_EOL;
                $meta->setWorkerId($workId);
                $meta->setDataCenterId($datacenter);
                return $idGenerator->generate($meta);
            });
        }
        $arr = $parallel->wait();
        var_dump($arr);
        var_dump(count(array_unique($arr)));
```