### PR TITLE
fix: 修复补充selectOne返回值

### DIFF
--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -23,7 +23,7 @@ use Psr\Container\ContainerInterface;
  * DB Helper.
  * @method static Builder table(string $table)
  * @method static Expression raw($value)
- * @method static selectOne(string $query, array $bindings = [], bool $useReadPdo = true)
+ * @method static mixed selectOne(string $query, array $bindings = [], bool $useReadPdo = true)
  * @method static array select(string $query, array $bindings = [], bool $useReadPdo = true)
  * @method static Generator cursor(string $query, array $bindings = [], bool $useReadPdo = true)
  * @method static bool insert(string $query, array $bindings = [])


### PR DESCRIPTION
fix: 修复补充selectOne返回值,可以避免phpstan静态分析报错。