### PR TITLE
Support `SSL` for `Hyperf\Amqp\IO\SwooleIO`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -7,6 +7,7 @@
 ## Added
 
 - [#4411](https://github.com/hyperf/hyperf/pull/4411) Added `Hyperf\Tracer\Aspect\DbAspect` to log db records when using `hyperf/db`. 
+- [#4420](https://github.com/hyperf/hyperf/pull/4420) Support `SSL` for `Hyperf\Amqp\IO\SwooleIO`.
 
 ## Optimized
 

--- a/src/amqp/publish/amqp.php
+++ b/src/amqp/publish/amqp.php
@@ -16,7 +16,7 @@ return [
         'user' => env('AMQP_USER', 'guest'),
         'password' => env('AMQP_PASSWORD', 'guest'),
         'vhost' => env('AMQP_VHOST', '/'),
-        'open_ssl'   => env('AMQP_OPEN_SSL', false),
+        'open_ssl' => false,
         'concurrent' => [
             'limit' => 1,
         ],

--- a/src/amqp/publish/amqp.php
+++ b/src/amqp/publish/amqp.php
@@ -16,6 +16,7 @@ return [
         'user' => env('AMQP_USER', 'guest'),
         'password' => env('AMQP_PASSWORD', 'guest'),
         'vhost' => env('AMQP_VHOST', '/'),
+        'open_ssl'   => env('AMQP_OPEN_SSL', false),
         'concurrent' => [
             'limit' => 1,
         ],

--- a/src/amqp/src/ConnectionFactory.php
+++ b/src/amqp/src/ConnectionFactory.php
@@ -93,6 +93,7 @@ class ConnectionFactory
         $user = $config['user'] ?? 'guest';
         $password = $config['password'] ?? 'guest';
         $vhost = $config['vhost'] ?? '/';
+        $openSSL = $config['open_ssl'] ?? false;
 
         $params = new Params(Arr::get($config, 'params', []));
         $io = new SwooleIO(
@@ -100,6 +101,7 @@ class ConnectionFactory
             $port,
             $params->getConnectionTimeout(),
             $params->getReadWriteTimeout(),
+            $openSSL,
         );
 
         $connection = new AMQPConnection(

--- a/src/amqp/src/IO/SwooleIO.php
+++ b/src/amqp/src/IO/SwooleIO.php
@@ -131,7 +131,7 @@ class SwooleIO extends AbstractIO
     {
         $sock = new Socket(AF_INET, SOCK_STREAM, 0);
 
-        if($this->openSSL === true) {
+        if ($this->openSSL === true) {
             $sock->setProtocol(['open_ssl' => true]);
         }
 

--- a/src/amqp/src/IO/SwooleIO.php
+++ b/src/amqp/src/IO/SwooleIO.php
@@ -42,6 +42,11 @@ class SwooleIO extends AbstractIO
     protected $readWriteTimeout;
 
     /**
+     * @var bool
+     */
+    protected $openSSL;
+
+    /**
      * @var int
      */
     protected $heartbeat;
@@ -58,12 +63,14 @@ class SwooleIO extends AbstractIO
         string $host,
         int $port,
         int $connectionTimeout,
-        int $readWriteTimeout = 3
+        int $readWriteTimeout = 3,
+        bool $openSSL = false
     ) {
         $this->host = $host;
         $this->port = $port;
         $this->connectionTimeout = $connectionTimeout;
         $this->readWriteTimeout = $readWriteTimeout;
+        $this->openSSL = $openSSL;
     }
 
     /**
@@ -123,6 +130,11 @@ class SwooleIO extends AbstractIO
     protected function makeClient()
     {
         $sock = new Socket(AF_INET, SOCK_STREAM, 0);
+
+        if($this->openSSL === true) {
+            $sock->setProtocol(['open_ssl' => true]);
+        }
+
         if (! $sock->connect($this->host, $this->port, $this->connectionTimeout)) {
             throw new AMQPRuntimeException(
                 sprintf('Error Connecting to server: %s ', $sock->errMsg),


### PR DESCRIPTION
亚马逊需要使用amqps协议，必须加ssl参数

fix https://github.com/hyperf/hyperf/issues/4176
fix https://github.com/hyperf/hyperf/issues/4003