### PR TITLE
Model::insertOrIgnore应该返回影响行数 , 而不是Builder对象

### DIFF
--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -80,7 +80,7 @@ class Builder
      * @var array
      */
     protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'insert', 'insertGetId', 'getBindings', 'toSql', 'insertOrIgnore',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
     ];
 


### PR DESCRIPTION
问题如下图:
Model::insertOrIgnore 返回了个Builder对象  , 这个跟 mysql 的 insert ignore 返回值不同

![image](https://user-images.githubusercontent.com/3683362/130678841-60420238-d078-425c-8675-ef1e8ca25eec.png)

原因如下图:
![image](https://user-images.githubusercontent.com/3683362/130678887-c2b1b396-a1fe-410e-acf0-647416fad9bb.png)


我提交的修复方案:
把 insertOrIgnore 加入到 passthru 让它走这个逻辑即可 符合预期
```php
        if (in_array($method, $this->passthru)) {
            return $this->toBase()->{$method}(...$parameters);
        }
```

