### PR TITLE
修改UPDATED_AT 和CREATED_AT 返回值类型的注释

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "google/protobuf": "^3.6.1",
         "grpc/grpc": "^1.15",
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "hyperf/engine": "dev-master",
+        "hyperf/engine": "^1.2",
         "influxdb/influxdb-php": "^1.15.0",
         "ircmaxell/random-lib": "^1.2",
         "jcchavezs/zipkin-opentracing": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "elasticsearch/elasticsearch": "^7.0",
         "fig/http-message-util": "^1.1.2",
         "filp/whoops": "^2.7",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "3.4.0",
         "google/protobuf": "^3.6.1",
         "grpc/grpc": "^1.15",
         "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/src/database/src/Model/Model.php
+++ b/src/database/src/Model/Model.php
@@ -43,14 +43,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The name of the "created at" column.
      *
-     * @var string
+     * @var null|string
      */
     public const CREATED_AT = 'created_at';
 
     /**
      * The name of the "updated at" column.
      *
-     * @var string
+     * @var null|string
      */
     public const UPDATED_AT = 'updated_at';
 


### PR DESCRIPTION
子类常量=null 时 静态分析等级为5时 会报错不兼容
![image](https://user-images.githubusercontent.com/43372717/149748322-2ab4d26e-79fe-48ff-80dd-e09f96d3955b.png)
laravel 这2个常量的返回值类型是支持为null
![image](https://user-images.githubusercontent.com/43372717/149748429-896d22fb-4edb-46e8-a250-4b5199e4fa5f.png)
