### PR TITLE
修复在nacos2.0.4版本下服务注册bug

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.25 - TBD
 
+## Fixed
+
+- [#4484](https://github.com/hyperf/hyperf/pull/4484) Fixed bug that `NacosDriver::isRegistered` does not work when using nacos `2.0.4`.
+
 # v2.2.24 - 2022-01-24
 
 ## Fixed

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -143,16 +143,10 @@ class NacosDriver implements DriverInterface
             return false;
         }
 
-        if ($response->getStatusCode() === 500 && strpos((string) $response->getBody(), 'is not found') > 0) {
+        if ($response->getStatusCode() === 500 && strpos((string) $response->getBody(), 'not found') > 0) {
             return false;
         }
 
-        $result = (string) $response->getBody();
-        
-        if ($response->getStatusCode() === 500 && (strpos($result, 'is not found') > 0 || strpos($result, 'service not found') > 0)) {
-            return false;
-        }
-        
         if ($response->getStatusCode() !== 200) {
             throw new RequestException(sprintf('Failed to get nacos service %s!', $name), $response->getStatusCode());
         }

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -147,6 +147,12 @@ class NacosDriver implements DriverInterface
             return false;
         }
 
+        $result = (string) $response->getBody();
+        
+        if ($response->getStatusCode() === 500 && (strpos($result, 'is not found') > 0 || strpos($result, 'service not found') > 0)) {
+            return false;
+        }
+        
         if ($response->getStatusCode() !== 200) {
             throw new RequestException(sprintf('Failed to get nacos service %s!', $name), $response->getStatusCode());
         }


### PR DESCRIPTION
在nacos2.0.4版本下 查询服务详情接口服务不存在时，返回的提示由原来的”is not found xxx“ 更改成 ”service not found xxx“ 导致无法完成服务注册。