### PR TITLE
增加AbstractLoadBalancer类中刷新rpc节点定时器的异常捕获

### DIFF
--- a/src/load-balancer/src/AbstractLoadBalancer.php
+++ b/src/load-balancer/src/AbstractLoadBalancer.php
@@ -55,7 +55,7 @@ abstract class AbstractLoadBalancer implements LoadBalancerInterface
     public function removeNode(Node $node): bool
     {
         foreach ($this->nodes as $key => $activeNode) {
-            if ((string)$activeNode === (string)$node) {
+            if ($activeNode === $node) {
                 unset($this->nodes[$key]);
                 return true;
             }

--- a/src/load-balancer/src/AbstractLoadBalancer.php
+++ b/src/load-balancer/src/AbstractLoadBalancer.php
@@ -55,7 +55,7 @@ abstract class AbstractLoadBalancer implements LoadBalancerInterface
     public function removeNode(Node $node): bool
     {
         foreach ($this->nodes as $key => $activeNode) {
-            if ($activeNode === $node) {
+            if ((string)$activeNode === (string)$node) {
                 unset($this->nodes[$key]);
                 return true;
             }

--- a/src/load-balancer/src/Node.php
+++ b/src/load-balancer/src/Node.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\LoadBalancer;
 
 class Node


### PR DESCRIPTION
在使用consul过程中档consul节点请求超时或失联会导致work或process 错误重启
改为捕获错误输出到控制台