### PR TITLE
nacos配置中心支持拉取分组内的所有配置或者分组内某些key的配置

### DIFF
--- a/src/config-center/publish/config_center.php
+++ b/src/config-center/publish/config_center.php
@@ -44,6 +44,20 @@ return [
                 //     'data_id' => 'hyperf-service-config',
                 //     'group' => 'DEFAULT_GROUP',
                 // ],
+                // 'nacos_config' => [
+                //     'tenant' => 'tenant', // corresponding with service.namespaceId
+                //     'data_id' => '*',
+                //     'group' => 'DEFAULT_GROUP',
+                // ],
+                // 'nacos_config' => [
+                //     'tenant' => 'tenant', // corresponding with service.namespaceId
+                //     'data_ids' => [
+                //        'databases',
+                //        'amqp',
+                //        'redis',
+                //      ],
+                //     'group' => 'DEFAULT_GROUP',
+                // ],
                 // 'nacos_config.data' => [
                 //     'data_id' => 'hyperf-service-config-yml',
                 //     'group' => 'DEFAULT_GROUP',

--- a/src/config-nacos/src/Client.php
+++ b/src/config-nacos/src/Client.php
@@ -56,6 +56,7 @@ class Client implements ClientInterface
         $config = [];
         foreach ($listener as $key => $item) {
             $dataId = $item['data_id'];
+            $dataIds = $item['data_ids'] ?? [];
             $group = $item['group'];
             $tenant = $item['tenant'] ?? null;
             $type = $item['type'] ?? null;
@@ -64,7 +65,16 @@ class Client implements ClientInterface
                 $this->logger->error(sprintf('The config of %s read failed from Nacos.', $key));
                 continue;
             }
-            $config[$key] = $this->decode((string) $response->getBody(), $type);
+            if ($dataId === '*' || count($dataIds) > 0) {
+                $result = json_decode($response->getBody()->getContents(), true);
+                foreach ($result['pageItems'] ?? [] as $configItem) {
+                    if ($dataId === '*' || in_array($configItem['dataId'], $dataIds)) {
+                        $config[$configItem['dataId']] = $this->decode($configItem['content'], $configItem['type']);
+                    }
+                }
+            } else {
+                $config[$key] = $this->decode((string)$response->getBody(), $type);
+            }
         }
 
         return $config;

--- a/src/nacos/src/AbstractProvider.php
+++ b/src/nacos/src/AbstractProvider.php
@@ -81,7 +81,12 @@ abstract class AbstractProvider
                 $result[$key] = $value;
             }
         }
-
+        if ($result['dataId'] == '*' || $result['dataId'] === '') {
+            $result['dataId'] = '';
+            $result['search'] = 'accurate';
+            $result['pageNo'] = 1;
+            $result['pageSize'] = 200;
+        }
         return $result;
     }
 }


### PR DESCRIPTION
nacos配置中心支持拉取分组内的所有配置或者分组内某些key的配置
以前监听5个key,需要循环调用5次请求配置中心接口获取配置信息，优化后只需一次请求拉取分组列表，根据设置的key进行配置更新