### PR TITLE
Update bootcss cdn link

### DIFF
--- a/docs/en/socketio-server.md
+++ b/docs/en/socketio-server.md
@@ -92,7 +92,7 @@ class WebSocketController extends BaseNamespace
 Since the server only implements WebSocket communication, the client must add `{transports:["websocket"]}`.
 
 ```html
-<script src="https://cdn.bootcss.com/socket.io/2.3.0/socket.io.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script>
     var socket = io('ws://127.0.0.1:9502', {transports: ["websocket"] });
     socket.on('connect', data => {

--- a/docs/zh-cn/socketio-server.md
+++ b/docs/zh-cn/socketio-server.md
@@ -94,7 +94,7 @@ class WebSocketController extends BaseNamespace
 由于服务端只实现了 WebSocket 通讯，所以客户端要加上 `{transports:["websocket"]}` 。
 
 ```html
-<script src="https://cdn.bootcss.com/socket.io/2.3.0/socket.io.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script>
     var socket = io('ws://127.0.0.1:9502', { transports: ["websocket"] });
     socket.on('connect', data => {

--- a/docs/zh-hk/socketio-server.md
+++ b/docs/zh-hk/socketio-server.md
@@ -94,7 +94,7 @@ class WebSocketController extends BaseNamespace
 由於服務端只實現了 WebSocket 通訊，所以客户端要加上 `{transports:["websocket"]}` 。
 
 ```html
-<script src="https://cdn.bootcss.com/socket.io/2.3.0/socket.io.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script>
     var socket = io('ws://127.0.0.1:9502', { transports: ["websocket"] });
     socket.on('connect', data => {

--- a/docs/zh-tw/socketio-server.md
+++ b/docs/zh-tw/socketio-server.md
@@ -94,7 +94,7 @@ class WebSocketController extends BaseNamespace
 由於服務端只實現了 WebSocket 通訊，所以客戶端要加上 `{transports:["websocket"]}` 。
 
 ```html
-<script src="https://cdn.bootcss.com/socket.io/2.3.0/socket.io.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script>
     var socket = io('ws://127.0.0.1:9502', { transports: ["websocket"] });
     socket.on('connect', data => {

--- a/src/socketio-server/README.md
+++ b/src/socketio-server/README.md
@@ -91,7 +91,7 @@ class WebSocketController extends BaseNamespace
 由于服务端只实现了WebSocket通讯，所以客户端要加上 `{transports:["websocket"]}` 。
 
 ```html
-<script src="https://cdn.bootcss.com/socket.io/2.3.0/socket.io.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script>
     var socket = io('ws://127.0.0.1:9502', { transports: ["websocket"] });
     socket.on('connect', data => {


### PR DESCRIPTION
老域名 cdn.bootcss.com 将于 2022 年 3 月 31 日下线