### PR TITLE
Fixed bug that circuit breaker couldn't call fallback on `open` state when using `hyperf/retry`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#4648](https://github.com/hyperf/hyperf/pull/4648) Fixed bug that circuit breaker couldn't call fallback on `open` state when using `hyperf/retry`
+- [#4648](https://github.com/hyperf/hyperf/pull/4648) Fixed bug that circuit breaker couldn't call fallback on `open` state when using `hyperf/retry`.
 
 ## Added
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.30 - TBD
 
+## Fixed
+
+- [#4648](https://github.com/hyperf/hyperf/pull/4648) Fixed bug that circuit breaker couldn't call fallback on `open` state when using `hyperf/retry`
+
 ## Added
 
 - [#4646](https://github.com/hyperf/hyperf/pull/4646) Support setting `auth` for `RedisSentinel`.

--- a/src/retry/src/Policy/CircuitBreakerRetryPolicy.php
+++ b/src/retry/src/Policy/CircuitBreakerRetryPolicy.php
@@ -31,6 +31,7 @@ class CircuitBreakerRetryPolicy extends BaseRetryPolicy implements RetryPolicyIn
         if (! $this->state->isOpen()) {
             return true;
         }
+        $retryContext['retryExhausted'] = true;
         return false;
     }
 

--- a/src/retry/tests/CircuitBreakerAnotationAspectTest.php
+++ b/src/retry/tests/CircuitBreakerAnotationAspectTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace HyperfTest\Retry;
+
+use Hyperf\Di\Aop\AnnotationMetadata;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Hyperf\Di\Container;
+use Hyperf\Di\Definition\DefinitionSource;
+use Hyperf\Retry\Annotation\AbstractRetry;
+use Hyperf\Retry\Annotation\CircuitBreaker;
+use Hyperf\Retry\Aspect\RetryAnnotationAspect;
+use Hyperf\Retry\CircuitBreakerState;
+use Hyperf\Retry\FlatStrategy;
+use Hyperf\Retry\NoOpRetryBudget;
+use Hyperf\Retry\RetryBudgetInterface;
+use Hyperf\Utils\ApplicationContext;
+use HyperfTest\Retry\Stub\Foo;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class CircuitBreakerAnotationAspectTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $container = new Container(new DefinitionSource([]));
+
+        ApplicationContext::setContainer($container);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testFallbackWhenStateOpenFirst()
+    {
+        $aspect = new RetryAnnotationAspect();
+        $point = Mockery::mock(ProceedingJoinPoint::class);
+
+        $point->shouldReceive('getAnnotationMetadata')->andReturns(
+            new class() extends AnnotationMetadata {
+                public $method;
+
+                public function __construct()
+                {
+                    $state = Mockery::mock(
+                        CircuitBreakerState::class
+                    );
+                    $state->shouldReceive('isOpen')->andReturns(true);
+                    $state->shouldReceive('open')->andReturns();
+                    $retry = new CircuitBreaker(['circuitBreakerState' => $state]);
+                    $retry->sleepStrategyClass = FlatStrategy::class;
+                    $retry->fallback = Foo::class . '@fallbackWithThrowable';
+                    $this->method = [
+                        AbstractRetry::class => $retry,
+                    ];
+                }
+            }
+        );
+        $point->shouldReceive('getArguments')->andReturns([$string = uniqid()]);
+        $result = $aspect->process($point);
+
+        self::assertEquals($string.':fallback', $result);
+    }
+}

--- a/src/retry/tests/Stub/Foo.php
+++ b/src/retry/tests/Stub/Foo.php
@@ -27,6 +27,6 @@ class Foo
 
     public function fallbackWithThrowable(string $string, ?Throwable $throwable = null)
     {
-        return $string . ':' . $throwable->getMessage();
+        return $string . ':' . (!is_null($throwable) ? $throwable->getMessage() : 'fallback');
     }
 }


### PR DESCRIPTION
- fix: #4647 