### PR TITLE
Make `Hyperf\Utils\Stringable` implements `Stringable`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -38,6 +38,7 @@ php vendor/bin/regenerate-models.php $PWD/app/Model
 - [#4277](https://github.com/hyperf/hyperf/pull/4277) Added `Hyperf\Utils\IPReader` to get local IP.
 - [#4497](https://github.com/hyperf/hyperf/pull/4497) Added `Hyperf\Coordinator\Timer` which can be stopped safely.
 - [#4523](https://github.com/hyperf/hyperf/pull/4523) Support callback conditions for `Conditionable::when()` and `Conditionable::unless()`.
+- [#4663](https://github.com/hyperf/hyperf/pull/4663) Make `Hyperf\Utils\Stringable` implements `Stringable`.
 
 ## Optimized
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -55,3 +55,4 @@ parameters:
     - message: '#Match arm is unreachable because previous comparison is always true#'
       path: src/amqp/src/IO/IOFactory.php
     - '#.*TKey.*TValue#'
+    - '#Method Hyperf\\Utils\\Serializer\\Serializer::normalize\(\) should return array\|ArrayObject\|bool\|float\|int\|string\|null#'

--- a/src/utils/src/Stringable.php
+++ b/src/utils/src/Stringable.php
@@ -212,11 +212,15 @@ class Stringable implements JsonSerializable
     /**
      * Determine if the string is an exact match with the given value.
      *
-     * @param string $value
+     * @param string|Stringable $value
      * @return bool
      */
     public function exactly($value)
     {
+        if ($value instanceof Stringable) {
+            $value = $value->__toString();
+        }
+
         return $this->value === $value;
     }
 

--- a/src/utils/src/Stringable.php
+++ b/src/utils/src/Stringable.php
@@ -15,7 +15,7 @@ use Closure;
 use Hyperf\Macroable\Macroable;
 use JsonSerializable;
 
-class Stringable implements JsonSerializable
+class Stringable implements JsonSerializable, \Stringable
 {
     use Traits\Conditionable;
     use Macroable;
@@ -212,12 +212,12 @@ class Stringable implements JsonSerializable
     /**
      * Determine if the string is an exact match with the given value.
      *
-     * @param string|Stringable $value
+     * @param string|\Stringable $value
      * @return bool
      */
     public function exactly($value)
     {
-        if ($value instanceof Stringable) {
+        if ($value instanceof \Stringable) {
             $value = $value->__toString();
         }
 

--- a/src/utils/tests/StringableTest.php
+++ b/src/utils/tests/StringableTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace HyperfTest\Utils;
 
 use Hyperf\Utils\Exception\InvalidArgumentException;
-use Hyperf\Utils\Str;
+use Hyperf\Utils\Stringable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,100 +21,87 @@ use PHPUnit\Framework\TestCase;
  */
 class StringableTest extends TestCase
 {
+    public function testExactly()
+    {
+        $this->assertTrue($this->stringable('foo')->exactly($this->stringable('foo')));
+        $this->assertTrue($this->stringable('foo')->exactly('foo'));
+
+        $this->assertFalse($this->stringable('Foo')->exactly($this->stringable('foo')));
+        $this->assertFalse($this->stringable('Foo')->exactly('foo'));
+        $this->assertFalse($this->stringable('[]')->exactly([]));
+        $this->assertFalse($this->stringable('0')->exactly(0));
+    }
+
     public function testSlug()
     {
-        $str = Str::of('hyperf_')->slug('_')->__toString();
+        $str = $this->stringable('hyperf_')->slug('_')->__toString();
 
         $this->assertSame('hyperf', $str);
     }
 
     public function testMask()
     {
-        $str = Str::of('hyperf');
-
+        $str = $this->stringable('hyperf');
         $this->assertSame('******', $str->mask()->__toString());
-
         $this->assertSame('hyp***', $str->mask(3)->__toString());
-
         $this->assertSame('hyp*rf', $str->mask(3, 1)->__toString());
-
         $this->assertSame('***erf', $str->mask(0, 3)->__toString());
-
         $this->assertSame('------', $str->mask(0, 0, '-')->__toString());
-
         $this->assertSame('hyperf', $str->mask(6, 2)->__toString());
-
         $this->assertSame('hyperf', $str->mask(7)->__toString());
-
         $this->assertSame('hyp**********', $str->mask(3, 10)->__toString());
-
         $this->assertSame('***erf', $str->mask(-3)->__toString());
-
         $this->assertSame('hy*erf', $str->mask(-3, 1)->__toString());
-
         $this->assertSame('***erf', $str->mask(-3, 3)->__toString());
-
         $this->assertSame('*****erf', $str->mask(-3, 5)->__toString());
 
-        $str = Str::of('你好啊');
-
+        $str = $this->stringable('你好啊');
         $this->assertSame('***', $str->mask()->__toString());
 
-        $str = Str::of('你好世界');
-
+        $str = $this->stringable('你好世界');
         $this->assertSame('你好世*', $str->mask(3)->__toString());
-
         $this->assertSame('你好*界', $str->mask(2, 1)->__toString());
-
         $this->assertSame('***界', $str->mask(0, 3)->__toString());
-
         $this->assertSame('你*世界', $str->mask(1, 1)->__toString());
-
         $this->assertSame('----', $str->mask(0, 0, '-')->__toString());
-
         $this->assertSame('你好世界', $str->mask(6, 2)->__toString());
-
         $this->assertSame('你好世界', $str->mask(7)->__toString());
-
         $this->assertSame('你好世**********', $str->mask(3, 10)->__toString());
-
         $this->assertSame('***界', $str->mask(-1)->__toString());
-
         $this->assertSame('你好*界', $str->mask(-1, 1)->__toString());
-
         $this->assertSame('***好世界', $str->mask(-3, 3)->__toString());
 
         $this->expectException(InvalidArgumentException::class);
-        Str::of('hyperf')->mask(-1, -1);
+        $this->stringable('hyperf')->mask(-1, -1);
     }
 
     public function testStartsWith()
     {
-        $this->assertFalse(Str::of('hyperf.wiki')->startsWith('http://'));
-        $this->assertFalse(Str::of('hyperf.wiki')->startsWith(['http://', 'https://']));
-        $this->assertTrue(Str::of('http://www.hyperf.io')->startsWith('http://'));
-        $this->assertTrue(Str::of('https://www.hyperf.io')->startsWith(['http://', 'https://']));
+        $this->assertFalse($this->stringable('hyperf.wiki')->startsWith('http://'));
+        $this->assertFalse($this->stringable('hyperf.wiki')->startsWith(['http://', 'https://']));
+        $this->assertTrue($this->stringable('http://www.hyperf.io')->startsWith('http://'));
+        $this->assertTrue($this->stringable('https://www.hyperf.io')->startsWith(['http://', 'https://']));
     }
 
     public function testStripTags()
     {
-        $this->assertSame('beforeafter', (string) Str::of('before<br>after')->stripTags());
-        $this->assertSame('before<br>after', (string) Str::of('before<br>after')->stripTags('<br>'));
-        $this->assertSame('before<br>after', (string) Str::of('<strong>before</strong><br>after')->stripTags('<br>'));
-        $this->assertSame('<strong>before</strong><br>after', (string) Str::of('<strong>before</strong><br>after')->stripTags('<br><strong>'));
+        $this->assertSame('beforeafter', (string) $this->stringable('before<br>after')->stripTags());
+        $this->assertSame('before<br>after', (string) $this->stringable('before<br>after')->stripTags('<br>'));
+        $this->assertSame('before<br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br>'));
+        $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br><strong>'));
 
         if (PHP_VERSION_ID >= 70400) {
-            $this->assertSame('<strong>before</strong><br>after', (string) Str::of('<strong>before</strong><br>after')->stripTags(['<br>', '<strong>']));
+            $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags(['<br>', '<strong>']));
         }
 
         if (PHP_VERSION_ID >= 80000) {
-            $this->assertSame('beforeafter', (string) Str::of('before<br>after')->stripTags(null));
+            $this->assertSame('beforeafter', (string) $this->stringable('before<br>after')->stripTags(null));
         }
     }
 
     public function testWhenEmptyAndNot()
     {
-        $empty = Str::of('');
+        $empty = $this->stringable('');
         $this->assertTrue($empty->whenEmpty(function ($str, $value) {
             $this->assertTrue($value);
             return true;
@@ -127,7 +114,7 @@ class StringableTest extends TestCase
             return true;
         }));
 
-        $notEmpty = Str::of('123');
+        $notEmpty = $this->stringable('123');
         $this->assertTrue($notEmpty->whenEmpty(function ($str, $value) {
             $this->assertFalse($value);
             return false;
@@ -138,7 +125,7 @@ class StringableTest extends TestCase
 
     public function testWhenAndUnless()
     {
-        $str = Str::of('Hyperf is the best PHP framework');
+        $str = $this->stringable('Hyperf is the best PHP framework');
 
         $this->assertSame('Hyperf is the best PHP framework!!!', $str->when(fn ($str) => $str->contains('best'), function ($str) {
             return $str->append('!!!');
@@ -146,5 +133,14 @@ class StringableTest extends TestCase
         $this->assertSame('Hyperf is the best PHP framework!!!', $str->unless(fn ($str) => $str->contains('!!!'), function ($str) {
             return $str->append('!!!');
         })->__toString());
+    }
+
+    /**
+     * @param string $string
+     * @return Stringable
+     */
+    protected function stringable($string = '')
+    {
+        return new Stringable($string);
     }
 }


### PR DESCRIPTION
Before:

```php
$first = \Str::of('name');
$second = \Str::of('name');
$first->exactly($second); //  => false
```

After:

```php
$first = \Str::of('name');
$second = \Str::of('name');
$first->exactly($second); //  => true
```