### PR TITLE
Fixed bug that `Hyperf\ServiceGovernanceNacos\Client` invoked failed.

### DIFF
--- a/src/service-governance-nacos/src/ClientFactory.php
+++ b/src/service-governance-nacos/src/ClientFactory.php
@@ -12,13 +12,12 @@ declare(strict_types=1);
 namespace Hyperf\ServiceGovernanceNacos;
 
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Nacos\Application;
 use Hyperf\Nacos\Config;
 use Psr\Container\ContainerInterface;
 
 class ClientFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): Client
     {
         $config = $container->get(ConfigInterface::class)->get('services.drivers.nacos', []);
         if (! empty($config['uri'])) {
@@ -27,7 +26,7 @@ class ClientFactory
             $baseUri = sprintf('http://%s:%d', $config['host'] ?? '127.0.0.1', $config['port'] ?? 8848);
         }
 
-        return new Application(new Config([
+        return new Client(new Config([
             'base_uri' => $baseUri,
             'username' => $config['username'] ?? null,
             'password' => $config['password'] ?? null,


### PR DESCRIPTION
```Hyperf\ServiceGovernanceNacos\NacosDriver```中的client是 ```Hyperf\ServiceGovernanceNacos\Client```

```
    protected Client $client;

    public function __construct(protected ContainerInterface $container)
    {
        $this->client = $container->get(Client::class);
        $this->logger = $container->get(StdoutLoggerInterface::class);
        $this->config = $container->get(ConfigInterface::class);
    }
```

``` Hyperf\ServiceGovernanceNacos\ClientFactory```中返回的仍然是``` Hyperf\Nacos\Application```