### PR TITLE
路由配置未填写action时，默认调用__invoke方法

### DIFF
--- a/src/http-server/src/CoreMiddleware.php
+++ b/src/http-server/src/CoreMiddleware.php
@@ -192,7 +192,11 @@ class CoreMiddleware implements CoreMiddlewareInterface
             if (strpos($handler, '@') !== false) {
                 return explode('@', $handler);
             }
-            return explode('::', $handler);
+
+            $resolve = explode('::', $handler);
+            $resolve[1] = $resolve[1] ?? '__invoke';
+
+            return $resolve;
         }
         if (is_array($handler) && isset($handler[0], $handler[1])) {
             return $handler;


### PR DESCRIPTION
* 更推崇一个控制器只处理一个路由
* 在定义路由时不需要每次都写一个同样的action

```php

Router::get('/index',[\App\Controller\IndexCtrl::class,'__invoke']);

// 路由定义（修改后）
Router::get('/index',\App\Controller\IndexCtrl::class);

// 控制器
class IndexCtrl
{

    public function __invoke(ContainerInterface $container,Request $request)
    {

    }
}
```