### PR TITLE
Added the default value `null` for `$chan`.

### DIFF
--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -24,7 +24,7 @@ use Swoole\Coroutine;
 
 class Producer
 {
-    protected ?Channel $chan;
+    protected ?Channel $chan = null;
 
     protected LongLangProducer $producer;
 


### PR DESCRIPTION
在直接使用Hyperf/Kafka/Producer send方法投递消息时会出现如标题错误 故给$chan添加一个默认值
```
    protected function loop()
    {
        if ($this->chan != null) {
            return;
        }
        $this->chan = new Channel(1);
        Coroutine::create(function () {
            while (true) {
                $this->producer = $this->makeProducer();
                while (true) {
                    $closure = $this->chan->pop();
                    if (! $closure) {
                        break 2;
                    }
                    try {
                        $closure->call($this);
                    } catch (\Throwable) {
                        $this->producer->close();
                        break;
                    }
                }
            }
            /* @phpstan-ignore-next-line */
            $this->chan->close();
            $this->chan = null;
        });
```