### PR TITLE
Configuring a default groupId when it is null when using `hyperf/kafka`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,9 +1,15 @@
-# v2.2.32 - TBD
+# v2.2.33 - TBD
+
+# v2.2.32 - 2022-05-16
 
 ## Fixed
 
 - [#4745](https://github.com/hyperf/hyperf/pull/4745) Fixed null pointer exception when using `Producer::close`.
 - [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed the bug that monolog does not work in `2.6.0` by configuring `conflict` with `monolog>=2.6.0`.
+
+## Optimized
+
+- [#4738](https://github.com/hyperf/hyperf/pull/4738) Configuring a default groupId when it is null.
 
 # v2.2.31.1 - 2022-04-18
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -9,7 +9,7 @@
 
 ## Optimized
 
-- [#4738](https://github.com/hyperf/hyperf/pull/4738) Configuring a default groupId when it is null.
+- [#4738](https://github.com/hyperf/hyperf/pull/4738) Configuring a default groupId when it is null when using `hyperf/kafka`.
 
 # v2.2.31.1 - 2022-04-18
 

--- a/docs/zh-cn/changelog.md
+++ b/docs/zh-cn/changelog.md
@@ -1,5 +1,16 @@
 # 版本更新记录
 
+# v2.2.32 - 2022-05-16
+
+## 修复
+
+- [#4745](https://github.com/hyperf/hyperf/pull/4745) 当使用 `kafka` 组件的 `Producer::close` 方法时，修复可能抛出空指针异常的问题。
+- [#4754](https://github.com/hyperf/hyperf/pull/4754) 通过配置 `monolog>=2.6.0` 解决新版本的 `monolog` 无法正常工作的问题。
+
+## 优化
+
+- [#4738](https://github.com/hyperf/hyperf/pull/4738) 当使用 `kafka` 组件时，如果没有设置 `GroupID` 则自动配置一个。
+
 # v2.2.31 - 2022-04-18
 
 ## 修复

--- a/src/kafka/src/ConsumerManager.php
+++ b/src/kafka/src/ConsumerManager.php
@@ -168,7 +168,7 @@ class ConsumerManager
                 $consumerConfig->setTopic($this->consumer->getTopic());
                 $consumerConfig->setRebalanceTimeout($config['rebalance_timeout']);
                 $consumerConfig->setSendTimeout($config['send_timeout']);
-                $consumerConfig->setGroupId($this->consumer->getGroupId());
+                $consumerConfig->setGroupId($this->consumer->getGroupId() ?? uniqid('hyperf-kafka-'));
                 $consumerConfig->setGroupInstanceId(sprintf('%s-%s', $this->consumer->getGroupId(), uniqid()));
                 $consumerConfig->setMemberId($this->consumer->getMemberId() ?: '');
                 $consumerConfig->setInterval($config['interval']);


### PR DESCRIPTION
#4737 