### PR TITLE
Fixed null pointer exception when using `Producer::close`.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.32 - TBD
 
+## Fixed
+
+- [#4745](https://github.com/hyperf/hyperf/pull/4745) Fixed null pointer exception when using `Producer::close`.
+
 # v2.2.31.1 - 2022-04-18
 
 ## Fixed

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -114,7 +114,9 @@ class Producer
         if ($this->chan) {
             $this->chan->close();
         }
-        $this->producer->close();
+        if ($this->producer) {
+            $this->producer->close();
+        }
     }
 
     public function getConfig(): ProducerConfig

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -114,6 +114,7 @@ class Producer
         if ($this->chan) {
             $this->chan->close();
         }
+        /* @phpstan-ignore-next-line */
         if ($this->producer) {
             $this->producer->close();
         }


### PR DESCRIPTION
If the send method is not called to initialize the producer before calling the close method, a null pointer exception occurs.
```php
$producer = new Producer(new Config([]));
// $producer->send('mock-topic', 'mock-value');
$producer->close();
```
Error: Call to a member function close() on null