### PR TITLE
Fixed the bug that monolog does not work in `2.6.0` by configuring `conflict` with `monolog>=2.6.0`.

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: '0 2 * * *'
 env:
-  SW_VERSION: 'v4.8.7'
+  SW_VERSION: 'v4.8.10'
 jobs:
   database:
     name: Test for Database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0' ]
-        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.8', 'master' ]
+        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.10', 'master' ]
         exclude:
           - php-version: '7.4'
             sw-version: 'master'

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#4745](https://github.com/hyperf/hyperf/pull/4745) Fixed null pointer exception when using `Producer::close`.
+- [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed bug that monolog does not work in `2.6.0` by making conflict for `monolog:>=2.6.0`.
 
 # v2.2.31.1 - 2022-04-18
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#4745](https://github.com/hyperf/hyperf/pull/4745) Fixed null pointer exception when using `Producer::close`.
-- [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed bug that monolog does not work in `2.6.0` by making conflict for `monolog:>=2.6.0`.
+- [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed the bug that monolog does not work in `2.6.0` by configuring `conflict` with `monolog:>=2.6.0`.
 
 # v2.2.31.1 - 2022-04-18
 

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#4745](https://github.com/hyperf/hyperf/pull/4745) Fixed null pointer exception when using `Producer::close`.
-- [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed the bug that monolog does not work in `2.6.0` by configuring `conflict` with `monolog:>=2.6.0`.
+- [#4754](https://github.com/hyperf/hyperf/pull/4754) Fixed the bug that monolog does not work in `2.6.0` by configuring `conflict` with `monolog>=2.6.0`.
 
 # v2.2.31.1 - 2022-04-18
 

--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,9 @@
         "hyperf/websocket-client": "*",
         "hyperf/websocket-server": "*"
     },
+    "conflict": {
+        "monolog/monolog": ">=2.6.0"
+    },
     "suggest": {},
     "autoload": {
         "files": [

--- a/src/logger/composer.json
+++ b/src/logger/composer.json
@@ -22,6 +22,9 @@
         "hyperf/utils": "~2.2.0",
         "monolog/monolog": "^2.0"
     },
+    "conflict": {
+        "monolog/monolog": ">=2.6.0"
+    },
     "autoload": {
         "psr-4": {
             "Hyperf\\Logger\\": "src/"


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/4740