### PR TITLE
Fixed bug that graphql event collect failed.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,5 +1,9 @@
 # v2.2.33 - TBD
 
+## Fixed
+
+- [#4776](https://github.com/hyperf/hyperf/pull/4776) Fixed bug that graphql event collect failed.
+
 ## Added
 
 - [#4763](https://github.com/hyperf/hyperf/pull/4763) Added validation rule `array:key1,key2` which make sure the array has no keys other than `key1` and `key2`.

--- a/src/graphql/src/ClassCollector.php
+++ b/src/graphql/src/ClassCollector.php
@@ -11,27 +11,24 @@ declare(strict_types=1);
  */
 namespace Hyperf\GraphQL;
 
-use Hyperf\Utils\Filesystem\Filesystem;
+use Hyperf\Di\MetadataCollector;
 
-class ClassCollector
+class ClassCollector extends MetadataCollector
 {
-    private static $classes = [];
+    /**
+     * @var array
+     */
+    protected static $container = [];
 
     public static function collect(string $class)
     {
-        if (! in_array($class, self::$classes)) {
-            self::$classes[] = $class;
+        if (! in_array($class, self::$container)) {
+            self::$container[] = $class;
         }
-        $filesystem = new Filesystem();
-        $filesystem->put(BASE_PATH . '/runtime/container/graphql.cache', serialize(self::$classes));
     }
 
     public static function getClasses()
     {
-        $filesystem = new Filesystem();
-        if ($filesystem->exists(BASE_PATH . '/runtime/container/graphql.cache')) {
-            return unserialize($filesystem->get(BASE_PATH . '/runtime/container/graphql.cache'));
-        }
-        return self::$classes;
+        return self::$container;
     }
 }

--- a/src/graphql/src/ClassCollector.php
+++ b/src/graphql/src/ClassCollector.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  */
 namespace Hyperf\GraphQL;
 
+use Hyperf\Utils\Filesystem\Filesystem;
+
 class ClassCollector
 {
     private static $classes = [];
@@ -20,10 +22,16 @@ class ClassCollector
         if (! in_array($class, self::$classes)) {
             self::$classes[] = $class;
         }
+        $filesystem = new Filesystem();
+        $filesystem->put(BASE_PATH . '/runtime/container/graphql.cache', serialize(self::$classes));
     }
 
     public static function getClasses()
     {
+        $filesystem = new Filesystem();
+        if ($filesystem->exists(BASE_PATH . '/runtime/container/graphql.cache')) {
+            return unserialize($filesystem->get(BASE_PATH . '/runtime/container/graphql.cache'));
+        }
         return self::$classes;
     }
 }

--- a/src/graphql/src/ConfigProvider.php
+++ b/src/graphql/src/ConfigProvider.php
@@ -44,6 +44,9 @@ class ConfigProvider
                         __DIR__,
                     ],
                 ],
+                'collectors' => [
+                    ClassCollector::class,
+                ],
             ],
         ];
     }

--- a/src/graphql/src/ConfigProvider.php
+++ b/src/graphql/src/ConfigProvider.php
@@ -43,9 +43,9 @@ class ConfigProvider
                     'paths' => [
                         __DIR__,
                     ],
-                ],
-                'collectors' => [
-                    ClassCollector::class,
+                    'collectors' => [
+                        ClassCollector::class,
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
hyperf graphql 修复自定义type
hyperf graphql 依赖 classcollector进行注释收集，但是di的scanner是创建子进程扫描，使用classcollector::getclasses无法正确获得扫描注释，通过文件进行缓存后即可。