### PR TITLE
Fixed bug that rpn method `toRPNExpression` does not work in some cases.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#4776](https://github.com/hyperf/hyperf/pull/4776) Fixed bug that graphql event collect failed.
+- [#4790](https://github.com/hyperf/hyperf/pull/4790) Fixed bug that rpn method `toRPNExpression` does not work in some cases.
 
 ## Added
 

--- a/src/rpn/src/Calculator.php
+++ b/src/rpn/src/Calculator.php
@@ -109,7 +109,7 @@ class Calculator
                 }
                 continue;
             }
-            if ($match === '-' && ($key === 0 || in_array($matchs[0][$key - 1], ['+', '-', '*', '/', '(']))) {
+            if ($match === '-' && ($key === 0 || (isset($matchs[0][$key - 1]) && in_array($matchs[0][$key - 1], ['+', '-', '*', '/', '('])))) {
                 $numStack->push($match . ($matchs[0][$key + 1]));
                 unset($matchs[0][$key + 1]);
                 continue;

--- a/src/rpn/tests/CalculatorTest.php
+++ b/src/rpn/tests/CalculatorTest.php
@@ -89,5 +89,8 @@ class CalculatorTest extends AbstractTestCase
 
         $got = $calculator->toRPNExpression('12 -- 10 * 4.4 + 1');
         $this->assertSame('12 -10 4.4 * - 1 +', $got);
+
+        $got = $calculator->toRPNExpression('1 + 2 + 3 * 4 * -5 - 6');
+        $this->assertSame('1 2 + 3 4 -5 * * + 6 -', $got);
     }
 }


### PR DESCRIPTION
修复 $matchs[0][$key - 1] 不存在情况下的 Notice
测试用例：1 + 2 + 3 * 4 * -5 - 6