### PR TITLE
Adds static to return type

### DIFF
--- a/src/model-cache/src/Cacheable.php
+++ b/src/model-cache/src/Cacheable.php
@@ -137,6 +137,7 @@ trait Cacheable
 
     /**
      * @param bool $cache Whether to delete the model cache when batch update
+     * @return Builder|static
      */
     public static function query(bool $cache = false): Builder
     {


### PR DESCRIPTION
解决 scopeFunc 生成 IDE helper 代码提示问题

```php
/**
 *  @mixin \App_Model_Foo
 */
class Foo extends Model
{
    public function scopeBar($query) {}
}
```

用法：

```php
Foo::query()->bar()->get();
```