### PR TITLE
Fixed the lost description when using property `$description` and `$signature` for `hyperf/command`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -101,3 +101,4 @@ composer analyse
 ## Fixed
 
 - [#4549](https://github.com/hyperf/hyperf/pull/4549) Fixed bug that `PhpParser::getExprFromValue()` does not support assoc array.
+- [#4835](https://github.com/hyperf/hyperf/pull/4835) Fixed the lost description when using property `$description` and `$signature` for `hyperf/command`.

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -93,8 +93,9 @@ abstract class Command extends SymfonyCommand
             $this->configureUsingFluentDefinition();
         } else {
             parent::__construct($this->name);
-            ! empty($this->description) && $this->setDescription($this->description);
         }
+
+        ! empty($this->description) && $this->setDescription($this->description);
 
         $this->addDisableDispatcherOption();
     }


### PR DESCRIPTION
```php
class FooCommand extend HyperfCommand
{
    protected ?string $signature = 'foo:bar';

    protected string $description = 'The foo command';

    public function __construct(protected ContainerInterface $container)
    {
        parent::__construct();
    }

    public function handle() { /** */}
}
```