### PR TITLE
Changed `$value.timeout` to `$options.timeout` for annotation `CircuitBreaker`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -76,6 +76,7 @@ composer analyse
 - [#4669](https://github.com/hyperf/hyperf/pull/4669) Changed all annotations which only support `PHP` >= `8.0`.
 - [#4678](https://github.com/hyperf/hyperf/pull/4678) Support event dispatcher for command by default.
 - [#4680](https://github.com/hyperf/hyperf/pull/4680) Stop processes which controlled by `ProcessManager` when server shutdown.
+- [#4848](https://github.com/hyperf/hyperf/pull/4848) Changed `$value.timeout` to `$options.timeout` for `CircuitBreaker`.
 
 ## Swow Supported
 

--- a/docs/zh-cn/circuit-breaker.md
+++ b/docs/zh-cn/circuit-breaker.md
@@ -30,7 +30,7 @@ class UserService
     #[Inject]
     private UserServiceClient $client;
 
-    #[CircuitBreaker(timeout: 0.05, failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
+    #[CircuitBreaker(options: ['timeout' => 0.05], failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
     public function search($offset, $limit)
     {
         return $this->client->users($offset, $limit);

--- a/docs/zh-cn/upgrade/3.0.md
+++ b/docs/zh-cn/upgrade/3.0.md
@@ -69,4 +69,13 @@ class AppendRequestIdProcessor implements ProcessorInterface
 接下来只需要启动服务，就可以看到不适配的地方，逐一修改即可。
 
 - AMQP Consumer 和 Producer
+
+成员变量增加了类型
+
 - Listener 监听器
+
+`process` 方法增加了 `void` 返回值类型
+
+- 注解 CircuitBreaker
+
+将 `$timeout` 参数改为了 `$options.timeout`

--- a/docs/zh-hk/circuit-breaker.md
+++ b/docs/zh-hk/circuit-breaker.md
@@ -30,7 +30,7 @@ class UserService
     #[Inject]
     private UserServiceClient $client;
 
-    #[CircuitBreaker(timeout: 0.05, failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
+    #[CircuitBreaker(options: ['timeout' => 0.05], failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
     public function search($offset, $limit)
     {
         return $this->client->users($offset, $limit);

--- a/docs/zh-tw/circuit-breaker.md
+++ b/docs/zh-tw/circuit-breaker.md
@@ -30,7 +30,7 @@ class UserService
     #[Inject]
     private UserServiceClient $client;
 
-    #[CircuitBreaker(timeout: 0.05, failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
+    #[CircuitBreaker(options: ['timeout' => 0.05], failCounter: 1, successCounter: 1, fallback: "App\Service\UserService::searchFallback")]
     public function search($offset, $limit)
     {
         return $this->client->users($offset, $limit);

--- a/src/circuit-breaker/src/Annotation/CircuitBreaker.php
+++ b/src/circuit-breaker/src/Annotation/CircuitBreaker.php
@@ -25,7 +25,7 @@ class CircuitBreaker extends AbstractAnnotation
      * @param float $duration the duration required to reset to a half open or close state
      * @param int $successCounter the counter required to reset to a close state
      * @param int $failCounter the counter required to reset to an open state
-     * @param array $value ['timeout' => 1]
+     * @param array $options ['timeout' => 1]
      */
     public function __construct(
         public string $handler = TimeoutHandler::class,
@@ -33,7 +33,7 @@ class CircuitBreaker extends AbstractAnnotation
         public float $duration = 10.0,
         public int $successCounter = 10,
         public int $failCounter = 10,
-        public array $value = []
+        public array $options = []
     ) {
     }
 }

--- a/src/circuit-breaker/src/Annotation/CircuitBreaker.php
+++ b/src/circuit-breaker/src/Annotation/CircuitBreaker.php
@@ -25,7 +25,7 @@ class CircuitBreaker extends AbstractAnnotation
      * @param float $duration the duration required to reset to a half open or close state
      * @param int $successCounter the counter required to reset to a close state
      * @param int $failCounter the counter required to reset to an open state
-     * @param array $value ['timeout' => 1]
+     * @param int $timeout the timeout duration
      */
     public function __construct(
         public string $handler = TimeoutHandler::class,
@@ -33,7 +33,7 @@ class CircuitBreaker extends AbstractAnnotation
         public float $duration = 10.0,
         public int $successCounter = 10,
         public int $failCounter = 10,
-        public array $value = []
+        public int $timeout = 1
     ) {
     }
 }

--- a/src/circuit-breaker/src/Annotation/CircuitBreaker.php
+++ b/src/circuit-breaker/src/Annotation/CircuitBreaker.php
@@ -25,7 +25,7 @@ class CircuitBreaker extends AbstractAnnotation
      * @param float $duration the duration required to reset to a half open or close state
      * @param int $successCounter the counter required to reset to a close state
      * @param int $failCounter the counter required to reset to an open state
-     * @param int $timeout the timeout duration
+     * @param array $value ['timeout' => 1]
      */
     public function __construct(
         public string $handler = TimeoutHandler::class,
@@ -33,7 +33,7 @@ class CircuitBreaker extends AbstractAnnotation
         public float $duration = 10.0,
         public int $successCounter = 10,
         public int $failCounter = 10,
-        public int $timeout = 1
+        public array $value = []
     ) {
     }
 }

--- a/src/circuit-breaker/src/Handler/TimeoutHandler.php
+++ b/src/circuit-breaker/src/Handler/TimeoutHandler.php
@@ -22,7 +22,7 @@ class TimeoutHandler extends AbstractHandler
 
     protected function process(ProceedingJoinPoint $proceedingJoinPoint, CircuitBreakerInterface $breaker, Annotation $annotation)
     {
-        $timeout = $annotation->value['timeout'] ?? self::DEFAULT_TIMEOUT;
+        $timeout = $annotation->options['timeout'] ?? self::DEFAULT_TIMEOUT;
         $time = microtime(true);
 
         $result = $proceedingJoinPoint->process();

--- a/src/circuit-breaker/src/Handler/TimeoutHandler.php
+++ b/src/circuit-breaker/src/Handler/TimeoutHandler.php
@@ -22,7 +22,7 @@ class TimeoutHandler extends AbstractHandler
 
     protected function process(ProceedingJoinPoint $proceedingJoinPoint, CircuitBreakerInterface $breaker, Annotation $annotation)
     {
-        $timeout = $annotation->timeout ?? self::DEFAULT_TIMEOUT;
+        $timeout = $annotation->value['timeout'] ?? self::DEFAULT_TIMEOUT;
         $time = microtime(true);
 
         $result = $proceedingJoinPoint->process();

--- a/src/circuit-breaker/src/Handler/TimeoutHandler.php
+++ b/src/circuit-breaker/src/Handler/TimeoutHandler.php
@@ -22,7 +22,7 @@ class TimeoutHandler extends AbstractHandler
 
     protected function process(ProceedingJoinPoint $proceedingJoinPoint, CircuitBreakerInterface $breaker, Annotation $annotation)
     {
-        $timeout = $annotation->value['timeout'] ?? self::DEFAULT_TIMEOUT;
+        $timeout = $annotation->timeout ?? self::DEFAULT_TIMEOUT;
         $time = microtime(true);
 
         $result = $proceedingJoinPoint->process();

--- a/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
+++ b/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
@@ -22,7 +22,7 @@ class CircuitBreakerTest extends TestCase
 {
     public function testAttributeCollect()
     {
-        $breaker = new CircuitBreaker(value: ['timeout' => 1]);
-        $this->assertSame(['timeout' => 1], $breaker->value);
+        $breaker = new CircuitBreaker(options: ['timeout' => 1]);
+        $this->assertSame(['timeout' => 1], $breaker->options);
     }
 }

--- a/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
+++ b/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
@@ -22,7 +22,7 @@ class CircuitBreakerTest extends TestCase
 {
     public function testAttributeCollect()
     {
-        $breaker = new CircuitBreaker(timeout: 1);
-        $this->assertSame(1, $breaker->timeout);
+        $breaker = new CircuitBreaker(value: ['timeout' => 1]);
+        $this->assertSame(['timeout' => 1], $breaker->value);
     }
 }

--- a/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
+++ b/src/circuit-breaker/tests/Annotation/CircuitBreakerTest.php
@@ -22,7 +22,7 @@ class CircuitBreakerTest extends TestCase
 {
     public function testAttributeCollect()
     {
-        $breaker = new CircuitBreaker(value: ['timeout' => 1]);
-        $this->assertSame(['timeout' => 1], $breaker->value);
+        $breaker = new CircuitBreaker(timeout: 1);
+        $this->assertSame(1, $breaker->timeout);
     }
 }


### PR DESCRIPTION
fix #4844 