### PR TITLE
Fixed bug that the `$prefix` of `ZipkinTracerFactory` does not match the actual.

### DIFF
--- a/src/tracer/src/Adapter/ZipkinTracerFactory.php
+++ b/src/tracer/src/Adapter/ZipkinTracerFactory.php
@@ -21,7 +21,7 @@ use ZipkinOpenTracing\Tracer;
 
 class ZipkinTracerFactory implements NamedFactoryInterface
 {
-    private string $prefix = 'opentracing.zipkin.';
+    private string $prefix = 'opentracing.tracer.';
 
     private string $name = '';
 


### PR DESCRIPTION
正确的配置路径应该是：`opentracing.tracer.zipkin`