### PR TITLE
Use the original style when regenerating models.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -64,6 +64,7 @@ composer analyse
 - [#4715](https://github.com/hyperf/hyperf/pull/4715) Adjust the order of injections for controllers to avoid inject null preferentially.
 - [#4865](https://github.com/hyperf/hyperf/pull/4865) No need to check `Redis::isConnected()`, because it could be connected defer or reconnected after disconnected.
 - [#4874](https://github.com/hyperf/hyperf/pull/4874) Use `wait` instead of `parallel` for coroutine style tcp server.
+- [#4875](https://github.com/hyperf/hyperf/pull/4875) Use the original style when regenerating models.
 
 ## Changed
 

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -21,7 +21,10 @@ use Hyperf\Database\Model\Model;
 use Hyperf\Database\Schema\Builder;
 use Hyperf\Utils\CodeGen\Project;
 use Hyperf\Utils\Str;
+use PhpParser\Lexer;
+use PhpParser\Lexer\Emulative;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
@@ -38,6 +41,8 @@ class ModelCommand extends Command
 
     protected ?ConfigInterface $config = null;
 
+    protected Lexer $lexer;
+
     protected ?Parser $astParser = null;
 
     protected ?PrettyPrinterAbstract $printer = null;
@@ -52,7 +57,14 @@ class ModelCommand extends Command
     {
         $this->resolver = $this->container->get(ConnectionResolverInterface::class);
         $this->config = $this->container->get(ConfigInterface::class);
-        $this->astParser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
+        $this->lexer = new Emulative([
+            'usedAttributes' => [
+                'comments',
+                'startLine', 'endLine',
+                'startTokenPos', 'endTokenPos',
+            ],
+        ]);
+        $this->astParser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7, $this->lexer);
         $this->printer = new Standard();
 
         return parent::run($input, $output);
@@ -155,7 +167,6 @@ class ModelCommand extends Command
 
         $columns = $this->getColumns($class, $columns, $option->isForceCasts());
 
-        $stmts = $this->astParser->parse(file_get_contents($path));
         $traverser = new NodeTraverser();
         $traverser->addVisitor(make(ModelUpdateVisitor::class, [
             'class' => $class,
@@ -167,8 +178,13 @@ class ModelCommand extends Command
         foreach ($option->getVisitors() as $visitorClass) {
             $traverser->addVisitor(make($visitorClass, [$option, $data]));
         }
-        $stmts = $traverser->traverse($stmts);
-        $code = $this->printer->prettyPrintFile($stmts);
+
+        $traverser->addVisitor(new CloningVisitor());
+
+        $oldStmts = $this->astParser->parse(file_get_contents($path));
+        $oldTokens = $this->lexer->getTokens();
+        $newStmts = $traverser->traverse($oldStmts);
+        $code = $this->printer->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
 
         file_put_contents($path, $code);
         $this->output->writeln(sprintf('<info>Model %s was created.</info>', $class));

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -41,7 +41,7 @@ class ModelCommand extends Command
 
     protected ?ConfigInterface $config = null;
 
-    protected Lexer $lexer;
+    protected ?Lexer $lexer = null;
 
     protected ?Parser $astParser = null;
 
@@ -181,10 +181,10 @@ class ModelCommand extends Command
 
         $traverser->addVisitor(new CloningVisitor());
 
-        $oldStmts = $this->astParser->parse(file_get_contents($path));
-        $oldTokens = $this->lexer->getTokens();
-        $newStmts = $traverser->traverse($oldStmts);
-        $code = $this->printer->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
+        $originStmts = $this->astParser->parse(file_get_contents($path));
+        $originTokens = $this->lexer->getTokens();
+        $newStmts = $traverser->traverse($originStmts);
+        $code = $this->printer->printFormatPreserving($newStmts, $originStmts, $originTokens);
 
         file_put_contents($path, $code);
         $this->output->writeln(sprintf('<info>Model %s was created.</info>', $class));


### PR DESCRIPTION
Original model format:

```php
namespace App\Model

class User
{
    public function scopeSearch($query, $condition = [])
    {
        return $query
            ->when(isset($condition['phone_number']), fn ($query) => $query->where('phone_number', $condition['phone_number']))
            ->when(isset($condition['gateway']), fn ($query) => $query->where('gateway', $condition['gateway']))
            ->when(isset($condition['status']), fn ($query) => $query->where('status', $condition['status']))
            ->when(isset($condition['start_time']), fn ($query) => $query->where('created_at', '>=', $condition['start_time']))
            ->when(isset($condition['end_time']), fn ($query) => $query->where('created_at', '<=', $condition['end_time']));
    }
}
```

After execute `gen:model -RF user`:

```php
namespace App\Model

class User
{
    public function scopeSearch($query, $condition = [])
    {
        return $query->when(isset($condition['phone_number']), fn ($query) => $query->where('phone_number', $condition['phone_number']))->when(isset($condition['gateway']), fn ($query) => $query->where('gateway', $condition['gateway']))->when(isset($condition['status']), fn ($query) => $query->where('status', $condition['status']))->when(isset($condition['start_time']), fn ($query) => $query->where('created_at', '>=', $condition['start_time']))->when(isset($condition['end_time']), fn ($query) => $query->where('created_at', '<=', $condition['end_time']));
    }
}
```
The PR is fix that.