### PR TITLE
Fixed bug that `ProxyTrait::__getParamsMap` can not work when using trait alias.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -112,3 +112,4 @@ composer analyse
 - [#4835](https://github.com/hyperf/hyperf/pull/4835) Fixed the lost description when using property `$description` and `$signature` for `hyperf/command`.
 - [#4851](https://github.com/hyperf/hyperf/pull/4851) Fixed bug that prometheus server will not be closed automatically when using command which enable event dispatcher.
 - [#4854](https://github.com/hyperf/hyperf/pull/4854) Fixed bug that the `socket-io` client always reconnect when using coroutine style server.
+- [#4885](https://github.com/hyperf/hyperf/pull/4885) Fixed bug that `ProxyTrait::__getParamsMap` can not work when using trait alias.

--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -158,9 +158,9 @@ class ProxyCallVisitor extends NodeVisitorAbstract
             new Arg($this->getMagicConst()),
             // __FUNCTION__
             new Arg(new MagicConstFunction()),
-            // self::getParamMap(OriginalClass::class, __FUNCTION, func_get_args())
+            // self::getParamMap(__CLASS__, __FUNCTION__, func_get_args())
             new Arg(new StaticCall(new Name('self'), '__getParamsMap', [
-                new Arg(new MagicConstClass()),
+                new Arg($this->getMagicConst()),
                 new Arg(new MagicConstFunction()),
                 new Arg(new FuncCall(new Name('func_get_args'))),
             ])),

--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -159,6 +159,7 @@ class ProxyCallVisitor extends NodeVisitorAbstract
             // __FUNCTION__
             new Arg(new MagicConstFunction()),
             // self::getParamMap(__CLASS__, __FUNCTION__, func_get_args())
+            // self::getParamMap(__TRAIT__, __FUNCTION__, func_get_args())
             new Arg(new StaticCall(new Name('self'), '__getParamsMap', [
                 new Arg($this->getMagicConst()),
                 new Arg(new MagicConstFunction()),

--- a/src/di/src/ReflectionManager.php
+++ b/src/di/src/ReflectionManager.php
@@ -38,7 +38,7 @@ class ReflectionManager extends MetadataCollector
         $key = $className . '::' . $method;
         if (! isset(static::$container['method'][$key])) {
             // TODO check interface_exist
-            if (! class_exists($className)) {
+            if (! class_exists($className) && ! trait_exists($className)) {
                 throw new InvalidArgumentException("Class {$className} not exist");
             }
             static::$container['method'][$key] = static::reflectClass($className)->getMethod($method);

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -238,7 +238,7 @@ trait FooTrait
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
             return uniqid();
         });
     }
@@ -253,7 +253,7 @@ trait FooTrait
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
             return uniqid();
         });
     }

--- a/src/di/tests/ProxyTraitTest.php
+++ b/src/di/tests/ProxyTraitTest.php
@@ -48,6 +48,26 @@ class ProxyTraitTest extends TestCase
         $this->assertEquals(['id', 'str', 'num'], $obj->get3(1, 'hy')['order']);
     }
 
+    public function testGetParamsMapOnTraitAlias()
+    {
+        $obj = new ProxyTraitObject();
+
+        $this->assertEquals(['id' => null, 'str' => ''], $obj->getOnTrait(null)['keys']);
+        $this->assertEquals(['id', 'str'], $obj->getOnTrait(null)['order']);
+
+        $this->assertEquals(['id' => 1, 'str' => ''], $obj->get2OnTrait()['keys']);
+        $this->assertEquals(['id', 'str'], $obj->get2OnTrait()['order']);
+
+        $this->assertEquals(['id' => null, 'str' => ''], $obj->get2OnTrait(null)['keys']);
+        $this->assertEquals(['id', 'str'], $obj->get2OnTrait(null)['order']);
+
+        $this->assertEquals(['id' => 1, 'str' => '', 'num' => 1.0], $obj->get3OnTrait()['keys']);
+        $this->assertEquals(['id', 'str', 'num'], $obj->get3OnTrait()['order']);
+
+        $this->assertEquals(['id' => 1, 'str' => 'hy', 'num' => 1.0], $obj->get3OnTrait(1, 'hy')['keys']);
+        $this->assertEquals(['id', 'str', 'num'], $obj->get3OnTrait(1, 'hy')['order']);
+    }
+
     public function testProceedingJoinPointGetInstance()
     {
         $aspect = [];

--- a/src/di/tests/ReflectionTest.php
+++ b/src/di/tests/ReflectionTest.php
@@ -13,6 +13,7 @@ namespace HyperfTest\Di;
 
 use Hyperf\Di\ReflectionManager;
 use HyperfTest\Di\Stub\Ast\Bar;
+use HyperfTest\Di\Stub\Ast\FooTrait;
 use HyperfTest\Di\Stub\Foo;
 use HyperfTest\Di\Stub\FooInterface;
 use HyperfTest\Di\Stub\Inject\Foo3Trait;
@@ -87,6 +88,14 @@ class ReflectionTest extends TestCase
         $this->assertInstanceOf(ReflectionMethod::class, $reflection);
         $this->assertTrue($reflection->isPublic());
         $this->assertSame(ReflectionManager::getContainer()['method'][Foo::class . '::getFoo'], $reflection);
+    }
+
+    public function testReflectionTraitMethod()
+    {
+        $reflection = ReflectionManager::reflectMethod(FooTrait::class, 'getString');
+        $this->assertInstanceOf(ReflectionMethod::class, $reflection);
+        $this->assertTrue($reflection->isPublic());
+        $this->assertSame(ReflectionManager::getContainer()['method'][FooTrait::class . '::getString'], $reflection);
     }
 
     public function testReflectionManagerGetAllClasses()

--- a/src/di/tests/Stub/ProxyTraitObject.php
+++ b/src/di/tests/Stub/ProxyTraitObject.php
@@ -16,6 +16,14 @@ use Hyperf\Di\Aop\ProxyTrait;
 class ProxyTraitObject
 {
     use ProxyTrait;
+    use ProxyTraitOnTrait {
+        ProxyTraitOnTrait::get as getOnTrait;
+        ProxyTraitOnTrait::get2 as get2OnTrait;
+        ProxyTraitOnTrait::get3 as get3OnTrait;
+        ProxyTraitOnTrait::incr as incrOnTrait;
+        ProxyTraitOnTrait::getName as getNameOnTrait;
+        ProxyTraitOnTrait::getName2 as getName2OnTrait;
+    }
 
     /**
      * @var string

--- a/src/di/tests/Stub/ProxyTraitOnTrait.php
+++ b/src/di/tests/Stub/ProxyTraitOnTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Di\Stub;
+
+use Hyperf\Di\Aop\ProxyTrait;
+
+trait ProxyTraitOnTrait
+{
+    use ProxyTrait;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    public function __construct(string $name = 'Hyperf')
+    {
+        $this->name = $name;
+    }
+
+    public function get(?int $id, string $str = '')
+    {
+        return $this->__getParamsMap(__TRAIT__, 'get', func_get_args());
+    }
+
+    public function get2(?int $id = 1, string $str = '')
+    {
+        return $this->__getParamsMap(__TRAIT__, 'get2', func_get_args());
+    }
+
+    public function get3(?int $id = 1, string $str = '', float $num = 1.0)
+    {
+        return $this->__getParamsMap(__TRAIT__, 'get3', func_get_args());
+    }
+
+    public function incr()
+    {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+            return 1;
+        });
+    }
+
+    public function getName()
+    {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+            return 'HyperfCloud';
+        });
+    }
+
+    public function getName2()
+    {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+            return 'HyperfCloud';
+        });
+    }
+}

--- a/src/utils/src/Collection.php
+++ b/src/utils/src/Collection.php
@@ -1618,6 +1618,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function getCachingIterator(int $flags = CachingIterator::CALL_TOSTRING): CachingIterator
     {
+        /* @phpstan-ignore-next-line */
         return new CachingIterator($this->getIterator(), $flags);
     }
 


### PR DESCRIPTION
修复AOP 切入Trait 时, 使用alias 时报错的Bug