### PR TITLE
Optimization

### DIFF
--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -158,12 +158,8 @@ class ProxyCallVisitor extends NodeVisitorAbstract
             new Arg($this->getMagicConst()),
             // __FUNCTION__
             new Arg(new MagicConstFunction()),
-            // self::getParamMap(OriginalClass::class, __FUNCTION, func_get_args())
-            new Arg(new StaticCall(new Name('self'), '__getParamsMap', [
-                new Arg(new MagicConstClass()),
-                new Arg(new MagicConstFunction()),
-                new Arg(new FuncCall(new Name('func_get_args'))),
-            ])),
+            // func_get_args()
+            new Arg(new FuncCall(new Name('func_get_args'))),
             // A closure that wrapped original method code.
             new Arg(new Closure([
                 'params' => value(function () use ($node) {

--- a/src/di/src/Aop/ProxyTrait.php
+++ b/src/di/src/Aop/ProxyTrait.php
@@ -25,6 +25,7 @@ trait ProxyTrait
         array $arguments,
         Closure $closure
     ) {
+        $arguments = self::__getParamsMap($className, $method, $arguments);
         $proceedingJoinPoint = new ProceedingJoinPoint($closure, $className, $method, $arguments);
         $result = self::handleAround($proceedingJoinPoint);
         unset($proceedingJoinPoint);

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -149,7 +149,7 @@ class Bar4
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int $count) use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function (int $count) use($__function__, $__method__) {
             return $__method__;
         });
     }
@@ -160,7 +160,7 @@ class Bar4
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int &$count) use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function (int &$count) use($__function__, $__method__) {
             return $__method__;
         });
     }
@@ -171,7 +171,7 @@ class Bar4
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function ($params) use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function ($params) use($__function__, $__method__) {
             return $__method__;
         });
     }
@@ -182,7 +182,7 @@ class Bar4
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function (int &$count, $params) use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function (int &$count, $params) use($__function__, $__method__) {
             return $__method__;
         });
     }
@@ -220,7 +220,7 @@ class Bar3 extends Bar
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__CLASS__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function () use($__function__, $__method__) {
             return parent::getId();
         });
     }
@@ -238,7 +238,7 @@ trait FooTrait
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, func_get_args(), function () use($__function__, $__method__) {
             return uniqid();
         });
     }
@@ -253,7 +253,7 @@ trait FooTrait
     {
         $__function__ = __FUNCTION__;
         $__method__ = __METHOD__;
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__CLASS__, __FUNCTION__, func_get_args()), function () use($__function__, $__method__) {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, func_get_args(), function () use($__function__, $__method__) {
             return uniqid();
         });
     }

--- a/src/di/tests/Stub/ProxyTraitObject.php
+++ b/src/di/tests/Stub/ProxyTraitObject.php
@@ -29,36 +29,36 @@ class ProxyTraitObject
 
     public function get(?int $id, string $str = '')
     {
-        return $this->__getParamsMap(static::class, 'get', func_get_args());
+        return self::__getParamsMap(__CLASS__, 'get', func_get_args());
     }
 
     public function get2(?int $id = 1, string $str = '')
     {
-        return $this->__getParamsMap(static::class, 'get2', func_get_args());
+        return self::__getParamsMap(__CLASS__, 'get2', func_get_args());
     }
 
     public function get3(?int $id = 1, string $str = '', float $num = 1.0)
     {
-        return $this->__getParamsMap(static::class, 'get3', func_get_args());
+        return self::__getParamsMap(__CLASS__, 'get3', func_get_args());
     }
 
     public function incr()
     {
-        return self::__proxyCall(ProxyTraitObject::class, __FUNCTION__, self::__getParamsMap(ProxyTraitObject::class, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function () {
             return 1;
         });
     }
 
     public function getName()
     {
-        return self::__proxyCall(ProxyTraitObject::class, __FUNCTION__, self::__getParamsMap(ProxyTraitObject::class, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function () {
             return 'HyperfCloud';
         });
     }
 
     public function getName2()
     {
-        return self::__proxyCall(ProxyTraitObject::class, __FUNCTION__, self::__getParamsMap(ProxyTraitObject::class, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__CLASS__, __FUNCTION__, func_get_args(), function () {
             return 'HyperfCloud';
         });
     }

--- a/src/di/tests/Stub/ProxyTraitOnTrait.php
+++ b/src/di/tests/Stub/ProxyTraitOnTrait.php
@@ -44,21 +44,21 @@ trait ProxyTraitOnTrait
 
     public function incr()
     {
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, func_get_args(), function () {
             return 1;
         });
     }
 
     public function getName()
     {
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, func_get_args(), function () {
             return 'HyperfCloud';
         });
     }
 
     public function getName2()
     {
-        return self::__proxyCall(__TRAIT__, __FUNCTION__, self::__getParamsMap(__TRAIT__, __FUNCTION__, func_get_args()), function () {
+        return self::__proxyCall(__TRAIT__, __FUNCTION__, func_get_args(), function () {
             return 'HyperfCloud';
         });
     }


### PR DESCRIPTION
`ProxyTrait::__getParamsMap` 前两个参数和`ProxyTrait::__proxyCall` 完全一致, 不用生成在代理类中