### PR TITLE
Fixed bug that `RedisAdapter::mixSubscribe` cannot work cased by redis prefix.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -114,3 +114,4 @@ composer analyse
 - [#4851](https://github.com/hyperf/hyperf/pull/4851) Fixed bug that prometheus server will not be closed automatically when using command which enable event dispatcher.
 - [#4854](https://github.com/hyperf/hyperf/pull/4854) Fixed bug that the `socket-io` client always reconnect when using coroutine style server.
 - [#4885](https://github.com/hyperf/hyperf/pull/4885) Fixed bug that `ProxyTrait::__getParamsMap` can not work when using trait alias.
+- [#4892](https://github.com/hyperf/hyperf/pull/4892) Fixed bug that `RedisAdapter::mixSubscribe` cannot work cased by redis prefix when using `socketio-server`.

--- a/README-CN.md
+++ b/README-CN.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/hyperf/hyperf/releases"><img src="https://poser.pugx.org/hyperf/hyperf/v/stable" alt="Stable Version"></a>
-  <a href="https://www.php.net"><img src="https://img.shields.io/badge/php-%3E=7.4-brightgreen.svg?maxAge=2592000" alt="Php Version"></a>
+  <a href="https://www.php.net"><img src="https://img.shields.io/badge/php-%3E=8.0-brightgreen.svg?maxAge=2592000" alt="Php Version"></a>
   <a href="https://github.com/swoole/swoole-src"><img src="https://img.shields.io/badge/swoole-%3E=4.5-brightgreen.svg?maxAge=2592000" alt="Swoole Version"></a>
   <a href="https://github.com/hyperf/hyperf/blob/master/LICENSE"><img src="https://img.shields.io/github/license/hyperf/hyperf.svg?maxAge=2592000" alt="Hyperf License"></a>
 </p>
@@ -42,7 +42,7 @@ Hyperf 还提供了 `基于 PSR-11 的依赖注入容器`、`注解`、`AOP 面�
 # 运行环境
 
 - Linux, OS X or Cygwin, WSL, Windows
-- PHP 7.4+
+- PHP 8.0+
 - Swoole 4.5+ or Swow
 
 # 安全漏洞

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [中文](./README-CN.md)
 
 <p align="center">
   <a href="https://github.com/hyperf/hyperf/releases"><img src="https://poser.pugx.org/hyperf/hyperf/v/stable" alt="Stable Version"></a>
-  <a href="https://www.php.net"><img src="https://img.shields.io/badge/php-%3E=7.4-brightgreen.svg?maxAge=2592000" alt="Php Version"></a>
+  <a href="https://www.php.net"><img src="https://img.shields.io/badge/php-%3E=8.0-brightgreen.svg?maxAge=2592000" alt="Php Version"></a>
   <a href="https://github.com/swoole/swoole-src"><img src="https://img.shields.io/badge/swoole-%3E=4.5-brightgreen.svg?maxAge=2592000" alt="Swoole Version"></a>
   <a href="https://github.com/hyperf/hyperf/blob/master/LICENSE"><img src="https://img.shields.io/github/license/hyperf/hyperf.svg?maxAge=2592000" alt="Hyperf License"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 English | [中文](./README-CN.md)
 
-
 <p align="center"><a href="https://hyperf.io" target="_blank" rel="noopener noreferrer"><img width="70" src="https://cdn.jsdelivr.net/gh/hyperf/hyperf/docs/logo.png" alt="Hyperf Logo"></a></p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 English | [中文](./README-CN.md)
 
+
 <p align="center"><a href="https://hyperf.io" target="_blank" rel="noopener noreferrer"><img width="70" src="https://cdn.jsdelivr.net/gh/hyperf/hyperf/docs/logo.png" alt="Hyperf Logo"></a></p>
 
 <p align="center">

--- a/src/socketio-server/src/Room/RedisAdapter.php
+++ b/src/socketio-server/src/Room/RedisAdapter.php
@@ -331,7 +331,9 @@ class RedisAdapter implements AdapterInterface, EphemeralInterface
 
     private function mixSubscribe(Subscriber $sub)
     {
-        $sub->subscribe($this->getChannelKey());
+        $prefix = config('redis.'.$this->connection.'.options.'.Redis::OPT_PREFIX);
+        $channelKey = $prefix ? $prefix . $this->getChannelKey() : $this->getChannelKey();
+        $sub->subscribe($channelKey);
         $chan = $sub->channel();
         Coroutine::create(function () use ($sub) {
             CoordinatorManager::until(Constants::WORKER_EXIT)->yield();

--- a/src/socketio-server/src/Room/RedisAdapter.php
+++ b/src/socketio-server/src/Room/RedisAdapter.php
@@ -331,7 +331,7 @@ class RedisAdapter implements AdapterInterface, EphemeralInterface
 
     private function mixSubscribe(Subscriber $sub)
     {
-        $prefix = config('redis.'.$this->connection.'.options.'.Redis::OPT_PREFIX);
+        $prefix = config('redis.' . $this->connection . '.options.' . Redis::OPT_PREFIX);
         $channelKey = $prefix ? $prefix . $this->getChannelKey() : $this->getChannelKey();
         $sub->subscribe($channelKey);
         $chan = $sub->channel();


### PR DESCRIPTION
[使用 Subscriber 订阅时，频道名称不会被携带配置文件中的前缀，需要手动拼接](https://github.com/hyperf/socketio-server/commit/0eab002d8240a5bbf0b9786a6070625b89d6d36f)