### PR TITLE
Added `Db::beforeExecuting()` to register a hook which to be run just before a database query is executed.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -51,6 +51,7 @@ composer analyse
 - [#4700](https://github.com/hyperf/hyperf/pull/4700) Support coroutine style server for `socketio-server`.
 - [#4852](https://github.com/hyperf/hyperf/pull/4852) Added `NullDisableEventDispatcher` to disable event dispatcher by default.
 - [#4866](https://github.com/hyperf/hyperf/pull/4866) [#4869](https://github.com/hyperf/hyperf/pull/4869) Added Annotation `Scene` which use scene in FormRequest easily.
+- [#4908](https://github.com/hyperf/hyperf/pull/4908) Added `Db::beforeExecuting()` to register a hook which to be run just before a database query is executed.
 
 ## Optimized
 

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -507,7 +507,7 @@ class Connection implements ConnectionInterface
     /**
      * Clear all hooks which will be run before a database query.
      */
-    public function clearBeforeExecutingCallbacks(): void
+    public static function clearBeforeExecutingCallbacks(): void
     {
         self::$beforeExecutingCallbacks = [];
     }

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -501,7 +501,7 @@ class Connection implements ConnectionInterface
      */
     public static function beforeExecuting(Closure $callback): void
     {
-        self::$beforeExecutingCallbacks[] = $callback;
+        static::$beforeExecutingCallbacks[] = $callback;
     }
 
     /**
@@ -509,7 +509,7 @@ class Connection implements ConnectionInterface
      */
     public static function clearBeforeExecutingCallbacks(): void
     {
-        self::$beforeExecutingCallbacks = [];
+        static::$beforeExecutingCallbacks = [];
     }
 
     /**
@@ -1037,7 +1037,7 @@ class Connection implements ConnectionInterface
      */
     protected function run(string $query, array $bindings, Closure $callback)
     {
-        foreach (self::$beforeExecutingCallbacks as $beforeExecutingCallback) {
+        foreach (static::$beforeExecutingCallbacks as $beforeExecutingCallback) {
             $beforeExecutingCallback($query, $bindings, $this);
         }
 

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -499,7 +499,6 @@ class Connection implements ConnectionInterface
     /**
      * Register a hook to be run just before a database query is executed.
      *
-     * @param  \Closure  $callback
      * @return $this
      */
     public function beforeExecuting(Closure $callback)

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -498,14 +498,10 @@ class Connection implements ConnectionInterface
 
     /**
      * Register a hook to be run just before a database query is executed.
-     *
-     * @return $this
      */
-    public function beforeExecuting(Closure $callback)
+    public static function beforeExecuting(Closure $callback): void
     {
         self::$beforeExecutingCallbacks[] = $callback;
-
-        return $this;
     }
 
     /**

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -38,14 +38,14 @@ class Connection implements ConnectionInterface
     /**
      * The active PDO connection.
      *
-     * @var \Closure|\PDO
+     * @var Closure|PDO
      */
     protected $pdo;
 
     /**
      * The active PDO connection used for reads.
      *
-     * @var \Closure|\PDO
+     * @var Closure|PDO
      */
     protected $readPdo;
 
@@ -138,13 +138,6 @@ class Connection implements ConnectionInterface
     protected bool $pretending = false;
 
     /**
-     * All of the callbacks that should be invoked before a query is executed.
-     *
-     * @var \Closure[]
-     */
-    protected $beforeExecutingCallbacks = [];
-
-    /**
      * The instance of Doctrine connection.
      *
      * @var \Doctrine\DBAL\Connection
@@ -157,9 +150,16 @@ class Connection implements ConnectionInterface
     protected static array $resolvers = [];
 
     /**
+     * All the callbacks that should be invoked before a query is executed.
+     *
+     * @var Closure[]
+     */
+    protected static array $beforeExecutingCallbacks = [];
+
+    /**
      * Create a new database connection instance.
      *
-     * @param \Closure|\PDO $pdo
+     * @param Closure|PDO $pdo
      * @param string $database
      * @param string $tablePrefix
      */
@@ -503,9 +503,17 @@ class Connection implements ConnectionInterface
      */
     public function beforeExecuting(Closure $callback)
     {
-        $this->beforeExecutingCallbacks[] = $callback;
+        self::$beforeExecutingCallbacks[] = $callback;
 
         return $this;
+    }
+
+    /**
+     * Clear all hooks which will be run before a database query.
+     */
+    public function clearBeforeExecutingCallbacks(): void
+    {
+        self::$beforeExecutingCallbacks = [];
     }
 
     /**
@@ -642,7 +650,7 @@ class Connection implements ConnectionInterface
     /**
      * Set the PDO connection.
      *
-     * @param null|\Closure|\PDO $pdo
+     * @param null|Closure|PDO $pdo
      * @return $this
      */
     public function setPdo($pdo)
@@ -657,7 +665,7 @@ class Connection implements ConnectionInterface
     /**
      * Set the PDO connection used for reading.
      *
-     * @param null|\Closure|\PDO $pdo
+     * @param null|Closure|PDO $pdo
      * @return $this
      */
     public function setReadPdo($pdo)
@@ -1002,7 +1010,7 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback in "dry run" mode.
      *
-     * @param \Closure $callback
+     * @param Closure $callback
      * @return array
      */
     protected function withFreshQueryLog($callback)
@@ -1033,7 +1041,7 @@ class Connection implements ConnectionInterface
      */
     protected function run(string $query, array $bindings, Closure $callback)
     {
-        foreach ($this->beforeExecutingCallbacks as $beforeExecutingCallback) {
+        foreach (self::$beforeExecutingCallbacks as $beforeExecutingCallback) {
             $beforeExecutingCallback($query, $bindings, $this);
         }
 

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
  */
 namespace Hyperf\DbConnection;
 
+use Closure;
 use Generator;
+use Hyperf\Database\Connection as Conn;
 use Hyperf\Database\ConnectionInterface;
 use Hyperf\Database\ConnectionResolverInterface;
 use Hyperf\Database\Query\Builder;
@@ -33,13 +35,12 @@ use Psr\Container\ContainerInterface;
  * @method static int affectingStatement(string $query, array $bindings = [])
  * @method static bool unprepared(string $query)
  * @method static array prepareBindings(array $bindings)
- * @method static mixed transaction(\Closure $callback, int $attempts = 1)
+ * @method static mixed transaction(Closure $callback, int $attempts = 1)
  * @method static void beginTransaction()
- * @method static Connection beforeExecuting(\Closure $callback)
  * @method static void rollBack()
  * @method static void commit()
  * @method static int transactionLevel()
- * @method static array pretend(\Closure $callback)
+ * @method static array pretend(Closure $callback)
  * @method static ConnectionInterface connection(string $pool)
  */
 class Db
@@ -69,5 +70,10 @@ class Db
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
         return $resolver->connection($name);
+    }
+
+    public static function beforeExecuting(Closure $closure): void
+    {
+        Conn::beforeExecuting($closure);
     }
 }

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -35,6 +35,7 @@ use Psr\Container\ContainerInterface;
  * @method static array prepareBindings(array $bindings)
  * @method static mixed transaction(\Closure $callback, int $attempts = 1)
  * @method static void beginTransaction()
+ * @method static Connection beforeExecuting(\Closure $callback)
  * @method static void rollBack()
  * @method static void commit()
  * @method static int transactionLevel()


### PR DESCRIPTION
```php
Db::beforeExecuting(function($query, $bindings, $connection) {
    // your logic
});
```

Example:

```php
Db::beforeExecuting(function($query, $bindings, $connection) {
    if (Str::startsWith($query->sql, 'delete') && !Str::contains($query->sql, 'where')) {
        throw new Exception('Lost the condition!');
    }
});
```