### PR TITLE
Fixed bug that method `ComponentTagCompiler::escapeSingleQuotesOutsideOfPhpBlocks()` cannot work.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -119,3 +119,4 @@ composer analyse
 - [#4854](https://github.com/hyperf/hyperf/pull/4854) Fixed bug that the `socket-io` client always reconnect when using coroutine style server.
 - [#4885](https://github.com/hyperf/hyperf/pull/4885) Fixed bug that `ProxyTrait::__getParamsMap` can not work when using trait alias.
 - [#4892](https://github.com/hyperf/hyperf/pull/4892) [#4895](https://github.com/hyperf/hyperf/pull/4895) Fixed bug that `RedisAdapter::mixSubscribe` cannot work cased by redis prefix when using `socketio-server`.
+- [#4910](https://github.com/hyperf/hyperf/pull/4910) Fixed bug that method `ComponentTagCompiler::escapeSingleQuotesOutsideOfPhpBlocks()` cannot work.

--- a/src/view-engine/src/Compiler/ComponentTagCompiler.php
+++ b/src/view-engine/src/Compiler/ComponentTagCompiler.php
@@ -481,14 +481,8 @@ class ComponentTagCompiler
      */
     protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value): string
     {
-        return collect(\PhpToken::tokenize($value))->map(function ($token) {
-            if (! is_array($token)) {
-                return $token;
-            }
-
-            return $token[0] === T_INLINE_HTML
-                ? str_replace("'", "\\'", $token[1])
-                : $token[1];
+        return collect(\Phptoken::tokenize($value))->map(function (\PhpToken $token) {
+            return $token->id === T_INLINE_HTML ? str_replace("'", "\\'", $token->text) : $token->text;
         })->implode('');
     }
 

--- a/src/view-engine/src/Compiler/ComponentTagCompiler.php
+++ b/src/view-engine/src/Compiler/ComponentTagCompiler.php
@@ -481,7 +481,7 @@ class ComponentTagCompiler
      */
     protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value): string
     {
-        return collect(\Phptoken::tokenize($value))->map(function (\PhpToken $token) {
+        return collect(\PhpToken::tokenize($value))->map(function (\PhpToken $token) {
             return $token->id === T_INLINE_HTML ? str_replace("'", "\\'", $token->text) : $token->text;
         })->implode('');
     }


### PR DESCRIPTION
`\PhpToken::tokenize()` 方法返回的是 array<\PhpToken> 对象，导致在后续的集合 `implode` 时发生错误。