### PR TITLE
Fixed bug that the routing path is wrong (like `//foo`) when the routing prefix is end of '/'.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -124,3 +124,4 @@ composer analyse
 - [#4910](https://github.com/hyperf/hyperf/pull/4910) Fixed bug that method `ComponentTagCompiler::escapeSingleQuotesOutsideOfPhpBlocks()` cannot work.
 - [#4912](https://github.com/hyperf/hyperf/pull/4912) Fixed bug that websocket connection will be closed after 10s when using `Swow`.
 - [#4919](https://github.com/hyperf/hyperf/pull/4919) [#4921](https://github.com/hyperf/hyperf/pull/4921) Fixed bug that rpc connections can't refresh themselves after nodes changed when using `rpc-multiplex`.
+- [#4920](https://github.com/hyperf/hyperf/pull/4920) Fixed bug that the routing path is wrong (like `//foo`) when the routing prefix is end of '/'.

--- a/src/http-server/src/Router/DispatcherFactory.php
+++ b/src/http-server/src/Router/DispatcherFactory.php
@@ -188,12 +188,10 @@ class DispatcherFactory
                     } elseif ($mapping->path === '') {
                         $path = $prefix;
                     } elseif ($mapping->path[0] !== '/') {
-                        $path = $prefix . '/' . $mapping->path;
+                        $path = rtrim($prefix, '/') . '/' . $mapping->path;
                     } else {
                         $path = $mapping->path;
                     }
-
-                    $path = Str::replaceFirst('//', '/', $path);
 
                     $router->addRoute($mapping->methods, $path, [$className, $methodName], $methodOptions);
                 }

--- a/src/http-server/src/Router/DispatcherFactory.php
+++ b/src/http-server/src/Router/DispatcherFactory.php
@@ -193,6 +193,8 @@ class DispatcherFactory
                         $path = $mapping->path;
                     }
 
+                    $path = Str::replaceFirst('//', '/', $path);
+
                     $router->addRoute($mapping->methods, $path, [$className, $methodName], $methodOptions);
                 }
             }

--- a/src/http-server/tests/Router/DispatcherFactoryTest.php
+++ b/src/http-server/tests/Router/DispatcherFactoryTest.php
@@ -81,6 +81,27 @@ class DispatcherFactoryTest extends TestCase
         }
     }
 
+    public function testHandleControllerWithBackslash()
+    {
+        $factory = new DispatcherFactory();
+        $annotation = new Controller('/');
+        $methodMetadata = [
+            'demo' => [
+                GetMapping::class => new GetMapping(''),
+                PostMapping::class => new PostMapping('demo2'),
+                PutMapping::class => new PutMapping('/demo'),
+            ],
+        ];
+
+        $factory->handleController(DemoController::class, $annotation, $methodMetadata);
+        $router = $factory->getRouter('http');
+
+        [$routers] = $router->getData();
+        $this->assertSame('/demo', $routers['PUT']['/demo']->route);
+        $this->assertSame('/demo2', $routers['POST']['/demo2']->route);
+        $this->assertSame('/', $routers['GET']['/']->route);
+    }
+
     public function testMiddlewareInController()
     {
         $factory = new DispatcherFactory();

--- a/src/http-server/tests/Router/DispatcherFactoryTest.php
+++ b/src/http-server/tests/Router/DispatcherFactoryTest.php
@@ -81,7 +81,7 @@ class DispatcherFactoryTest extends TestCase
         }
     }
 
-    public function testHandleControllerWithBackslash()
+    public function testHandleControllerWithSlash()
     {
         $factory = new DispatcherFactory();
         $annotation = new Controller('/');


### PR DESCRIPTION
<img width="868" alt="image" src="https://user-images.githubusercontent.com/22728201/178414623-550e653b-9771-4ca6-89d8-a52d6a415357.png">

图里预期结果 url 应该是 `http://127.0.0.1:9501/buy`，但是这样的写法，buy 方法的路由前缀变成了 `//`。