### PR TITLE
Using parent::getActualClassNameForMorph() instead of Model::getActualClassNameForMorph() 

### DIFF
--- a/src/database/src/Model/Concerns/HasRelationships.php
+++ b/src/database/src/Model/Concerns/HasRelationships.php
@@ -697,7 +697,7 @@ trait HasRelationships
     protected function morphInstanceTo($target, $name, $type, $id, $ownerKey)
     {
         $instance = $this->newRelatedInstance(
-            static::getActualClassNameForMorph($target)
+            self::getActualClassNameForMorph($target)
         );
 
         return $this->newMorphTo(

--- a/src/database/src/Model/Concerns/HasRelationships.php
+++ b/src/database/src/Model/Concerns/HasRelationships.php
@@ -697,7 +697,7 @@ trait HasRelationships
     protected function morphInstanceTo($target, $name, $type, $id, $ownerKey)
     {
         $instance = $this->newRelatedInstance(
-            $this->child::getActualClassNameForMorph($target) ?: static::getActualClassNameForMorph($target)
+            static::getActualClassNameForMorph($target)
         );
 
         return $this->newMorphTo(

--- a/src/database/src/Model/Concerns/HasRelationships.php
+++ b/src/database/src/Model/Concerns/HasRelationships.php
@@ -697,7 +697,7 @@ trait HasRelationships
     protected function morphInstanceTo($target, $name, $type, $id, $ownerKey)
     {
         $instance = $this->newRelatedInstance(
-            self::getActualClassNameForMorph($target)
+            static::getActualClassNameForMorph($target)
         );
 
         return $this->newMorphTo(

--- a/src/database/src/Model/Concerns/HasRelationships.php
+++ b/src/database/src/Model/Concerns/HasRelationships.php
@@ -697,7 +697,7 @@ trait HasRelationships
     protected function morphInstanceTo($target, $name, $type, $id, $ownerKey)
     {
         $instance = $this->newRelatedInstance(
-            static::getActualClassNameForMorph($target)
+            $this->child::getActualClassNameForMorph($target) ?: static::getActualClassNameForMorph($target)
         );
 
         return $this->newMorphTo(

--- a/src/database/src/Model/Concerns/QueriesRelationships.php
+++ b/src/database/src/Model/Concerns/QueriesRelationships.php
@@ -388,7 +388,7 @@ trait QueriesRelationships
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
 
             foreach ($types as &$type) {
-                $type = $this->model::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
+                $type = $this->model::getActualClassNameForMorph($type);
             }
         }
 

--- a/src/database/src/Model/Concerns/QueriesRelationships.php
+++ b/src/database/src/Model/Concerns/QueriesRelationships.php
@@ -388,7 +388,7 @@ trait QueriesRelationships
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
 
             foreach ($types as &$type) {
-                $type = $relation->getChild()::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
+                $type = $this->model::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
             }
         }
 

--- a/src/database/src/Model/Concerns/QueriesRelationships.php
+++ b/src/database/src/Model/Concerns/QueriesRelationships.php
@@ -13,6 +13,7 @@ namespace Hyperf\Database\Model\Concerns;
 
 use Closure;
 use Hyperf\Database\Model\Builder;
+use Hyperf\Database\Model\Model;
 use Hyperf\Database\Model\Relations\MorphTo;
 use Hyperf\Database\Model\Relations\Relation;
 use Hyperf\Database\Query\Builder as QueryBuilder;
@@ -387,7 +388,7 @@ trait QueriesRelationships
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
 
             foreach ($types as &$type) {
-                $type = Relation::getMorphedModel($type) ?? $type;
+                $type = $relation->getChild()::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
             }
         }
 

--- a/src/database/src/Model/Relations/MorphTo.php
+++ b/src/database/src/Model/Relations/MorphTo.php
@@ -134,7 +134,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = Model::getActualClassNameForMorph($type);
+        $class = $this->parent::getActualClassNameForMorph($type);
 
         return new $class();
     }

--- a/src/database/tests/ModelMorphEagerLoadingTest.php
+++ b/src/database/tests/ModelMorphEagerLoadingTest.php
@@ -31,7 +31,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 class ModelMorphEagerLoadingTest extends TestCase
 {
     /**
-     * @var array
+     * @var Channel
      */
     protected $channel;
 
@@ -250,10 +250,12 @@ class ModelMorphEagerLoadingTest extends TestCase
 
     protected function getContainer()
     {
+        /** @var EventDispatcherInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $dispatcher */
         $dispatcher = Mockery::mock(EventDispatcherInterface::class);
         $dispatcher->shouldReceive('dispatch')->with(Mockery::any())->andReturnUsing(function ($event) {
             $this->channel->push($event);
         });
+        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $container */
         $container = ContainerStub::getContainer(function ($conn) use ($dispatcher) {
             $conn->setEventDispatcher($dispatcher);
         });

--- a/src/database/tests/ModelMorphEagerLoadingTest.php
+++ b/src/database/tests/ModelMorphEagerLoadingTest.php
@@ -250,12 +250,12 @@ class ModelMorphEagerLoadingTest extends TestCase
 
     protected function getContainer()
     {
-        /** @var EventDispatcherInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $dispatcher */
+        /** @var EventDispatcherInterface|\Mockery\LegacyMockInterface|\Mockery\MockInterface $dispatcher */
         $dispatcher = Mockery::mock(EventDispatcherInterface::class);
         $dispatcher->shouldReceive('dispatch')->with(Mockery::any())->andReturnUsing(function ($event) {
             $this->channel->push($event);
         });
-        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $container */
+        /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Psr\Container\ContainerInterface $container */
         $container = ContainerStub::getContainer(function ($conn) use ($dispatcher) {
             $conn->setEventDispatcher($dispatcher);
         });

--- a/src/database/tests/ModelMorphToLoadingTest.php
+++ b/src/database/tests/ModelMorphToLoadingTest.php
@@ -98,19 +98,20 @@ class ModelMorphToLoadingTest extends TestCase
         }
     }
 
-    // public function testMorphAssociationEmpty()
-    // {
-    //     $this->getContainer();
-    //     $images = Image::query()->whereHasMorph(
-    //         'imageable',
-    //         ['*'],
-    //         function (Builder $query) {
-    //             $query->where('imageable_id', 1);
-    //         }
-    //     )->get();
+    public function testMorphAssociationEmpty()
+    {
+        $this->markTestSkipped();
+        $this->getContainer();
+        $images = Image::query()->whereHasMorph(
+            'imageable',
+            ['*'],
+            function (Builder $query) {
+                $query->where('imageable_id', 1);
+            }
+        )->get();
 
-    //     $this->assertSame(2, $images->count());
-    // }
+        $this->assertSame(2, $images->count());
+    }
 
     public function testWhereHasMorph()
     {

--- a/src/database/tests/ModelMorphToLoadingTest.php
+++ b/src/database/tests/ModelMorphToLoadingTest.php
@@ -250,12 +250,12 @@ class ModelMorphToLoadingTest extends TestCase
 
     protected function getContainer()
     {
-        /** @var EventDispatcherInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $dispatcher */
+        /** @var EventDispatcherInterface|\Mockery\LegacyMockInterface|\Mockery\MockInterface $dispatcher */
         $dispatcher = Mockery::mock(EventDispatcherInterface::class);
         $dispatcher->shouldReceive('dispatch')->with(Mockery::any())->andReturnUsing(function ($event) {
             $this->channel->push($event);
         });
-        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $container */
+        /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Psr\Container\ContainerInterface $container */
         $container = ContainerStub::getContainer(function ($conn) use ($dispatcher) {
             $conn->setEventDispatcher($dispatcher);
         });

--- a/src/database/tests/ModelMorphToLoadingTest.php
+++ b/src/database/tests/ModelMorphToLoadingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database;
+
+use Hyperf\Database\Events\QueryExecuted;
+use Hyperf\Database\Model\Builder;
+use Hyperf\Database\Model\Relations\MorphTo;
+use Hyperf\Database\Model\Relations\Relation;
+use Hyperf\Engine\Channel;
+use HyperfTest\Database\Stubs\ContainerStub;
+use HyperfTest\Database\Stubs\Model\Morph\Book;
+use HyperfTest\Database\Stubs\Model\Morph\Image;
+use HyperfTest\Database\Stubs\Model\Morph\User;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ModelMorphToLoadingTest extends TestCase
+{
+    /**
+     * @var Channel
+     */
+    protected $channel;
+
+    protected function setUp(): void
+    {
+        // Relation::morphMap([
+        //     'user' => User::class,
+        //     'book' => Book::class,
+        // ]);
+        $this->channel = new Channel(999);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        // Relation::$morphMap = [];
+        $this->channel->close();
+    }
+
+    public function testMorphOne()
+    {
+        $this->getContainer();
+        $user = User::query()->find(1);
+        $image = $user->image;
+        $this->assertSame(1, $image->id);
+
+        $sqls = [
+            ['select * from `user` where `user`.`id` = ? limit 1', [1]],
+            ['select * from `images` where `images`.`imageable_id` = ? and `images`.`imageable_id` is not null and `images`.`imageable_type` = ? limit 1', [1, 'user']],
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame([$event->sql, $event->bindings], array_shift($sqls));
+            }
+        }
+    }
+
+    public function testMorphWith()
+    {
+        $this->getContainer();
+        $images = Image::query()->with([
+            'imageable' => function (MorphTo $morphTo) {
+                $morphTo->morphWith([
+                    Book::class => ['user'],
+                ]);
+            },
+        ])->get();
+
+        $this->assertInstanceOf(Book::class, $images[2]->imageable);
+        $this->assertSame(1, $images[2]->imageable->id);
+        $this->assertInstanceOf(User::class, $images[2]->imageable->user);
+        $this->assertSame(1, $images[2]->imageable->user->id);
+
+        $sqls = [
+            'select * from `images`',
+            'select * from `user` where `user`.`id` in (1, 2)',
+            'select * from `book` where `book`.`id` in (1, 2, 3)',
+            'select * from `user` where `user`.`id` in (1, 2)',
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame($event->sql, array_shift($sqls));
+            }
+        }
+    }
+
+    public function testMorphAssociationEmpty()
+    {
+        $this->getContainer();
+        $images = Image::query()->whereHasMorph(
+            'imageable',
+            ['*'],
+            function (Builder $query) {
+                $query->where('imageable_id', 1);
+            }
+        )->get();
+
+        $this->assertSame(2, $images->count());
+    }
+
+    public function testWhereHasMorph()
+    {
+        $this->getContainer();
+        $images = Image::query()->whereHasMorph(
+            'imageable',
+            [
+                User::class,
+                Book::class,
+            ],
+            function (Builder $query) {
+                $query->where('imageable_id', 1);
+            }
+        )->get();
+
+        $this->assertSame(2, $images->count());
+        $this->assertSame('user', $images[0]->imageable_type);
+        $this->assertSame('book', $images[1]->imageable_type);
+
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame('select * from `images` where ((`imageable_type` = ? and exists (select * from `user` where `images`.`imageable_id` = `user`.`id` and `imageable_id` = ?)) or (`imageable_type` = ? and exists (select * from `book` where `images`.`imageable_id` = `book`.`id` and `imageable_id` = ?)))', $event->sql);
+            }
+        }
+    }
+
+    public function testOrWhereHasMorph()
+    {
+        $this->getContainer();
+        $images = Image::query()
+            ->whereHasMorph(
+                'imageable',
+                [
+                    User::class,
+                ],
+                function (Builder $query) {
+                    $query->where('id', '=', 1);
+                }
+            )
+            ->orWhereHasMorph(
+                'imageable',
+                [
+                    Book::class,
+                ],
+                function (Builder $query) {
+                    $query->where('id', '=', 1);
+                }
+            )->get();
+        $this->assertSame(1, $images[0]->imageable->id);
+        $this->assertSame(1, $images[1]->imageable->id);
+        $sqls = [
+            ['select * from `images` where ((`imageable_type` = ? and exists (select * from `user` where `images`.`imageable_id` = `user`.`id` and `id` = ?))) or ((`imageable_type` = ? and exists (select * from `book` where `images`.`imageable_id` = `book`.`id` and `id` = ?)))', ['user', 1, 'book', 1]],
+            ['select * from `user` where `user`.`id` = ? limit 1', [1]],
+            ['select * from `book` where `book`.`id` = ? limit 1', [1]],
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame([$event->sql, $event->bindings], array_shift($sqls));
+            }
+        }
+    }
+
+    public function testWhereDoesntHaveMorph()
+    {
+        $this->getContainer();
+        $images = Image::query()
+            ->whereDoesntHaveMorph(
+                'imageable',
+                [
+                    User::class,
+                    Book::class,
+                ],
+                function (Builder $query, $type) {
+                    if ($type === User::class) {
+                        $query->where('id', '<>', 1);
+                    }
+                    if ($type === Book::class) {
+                        $query->where('id', '<>', 1);
+                    }
+                }
+            )
+            ->get();
+        $res = $images->every(function ($item, $key) {
+            return $item->imageable->id == 1;
+        });
+        $this->assertSame(true, $res);
+        $sqls = [
+            ['select * from `images` where ((`imageable_type` = ? and not exists (select * from `user` where `images`.`imageable_id` = `user`.`id` and `id` <> ?)) or (`imageable_type` = ? and not exists (select * from `book` where `images`.`imageable_id` = `book`.`id` and `id` <> ?)))', ['user', 1, 'book', 1]],
+            ['select * from `user` where `user`.`id` = ? limit 1', [1]],
+            ['select * from `book` where `book`.`id` = ? limit 1', [1]],
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame([$event->sql, $event->bindings], array_shift($sqls));
+            }
+        }
+    }
+
+    public function testOrWhereDoesntHaveMorph()
+    {
+        $this->getContainer();
+        $images = Image::query()
+            ->whereDoesntHaveMorph(
+                'imageable',
+                [
+                    User::class,
+                ],
+                function (Builder $query) {
+                    $query->where('id', '<>', 1);
+                }
+            )
+            ->orWhereDoesntHaveMorph(
+                'imageable',
+                [
+                    Book::class,
+                ],
+                function (Builder $query) {
+                    $query->where('id', '<>', 1);
+                }
+            )
+            ->get();
+        $res = $images->every(function ($item, $key) {
+            return $item->imageable->id == 1;
+        });
+        $this->assertSame(true, $res);
+        $sqls = [
+            ['select * from `images` where ((`imageable_type` = ? and not exists (select * from `user` where `images`.`imageable_id` = `user`.`id` and `id` <> ?))) or ((`imageable_type` = ? and not exists (select * from `book` where `images`.`imageable_id` = `book`.`id` and `id` <> ?)))', ['user', 1, 'book', 1]],
+            ['select * from `user` where `user`.`id` = ? limit 1', [1]],
+            ['select * from `book` where `book`.`id` = ? limit 1', [1]],
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame([$event->sql, $event->bindings], array_shift($sqls));
+            }
+        }
+    }
+
+    protected function getContainer()
+    {
+        /** @var EventDispatcherInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $dispatcher */
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')->with(Mockery::any())->andReturnUsing(function ($event) {
+            $this->channel->push($event);
+        });
+        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface */
+        $container = ContainerStub::getContainer(function ($conn) use ($dispatcher) {
+            $conn->setEventDispatcher($dispatcher);
+        });
+        $container->shouldReceive('get')->with(EventDispatcherInterface::class)->andReturn($dispatcher);
+
+        return $container;
+    }
+}

--- a/src/database/tests/ModelMorphToLoadingTest.php
+++ b/src/database/tests/ModelMorphToLoadingTest.php
@@ -98,19 +98,19 @@ class ModelMorphToLoadingTest extends TestCase
         }
     }
 
-    public function testMorphAssociationEmpty()
-    {
-        $this->getContainer();
-        $images = Image::query()->whereHasMorph(
-            'imageable',
-            ['*'],
-            function (Builder $query) {
-                $query->where('imageable_id', 1);
-            }
-        )->get();
+    // public function testMorphAssociationEmpty()
+    // {
+    //     $this->getContainer();
+    //     $images = Image::query()->whereHasMorph(
+    //         'imageable',
+    //         ['*'],
+    //         function (Builder $query) {
+    //             $query->where('imageable_id', 1);
+    //         }
+    //     )->get();
 
-        $this->assertSame(2, $images->count());
-    }
+    //     $this->assertSame(2, $images->count());
+    // }
 
     public function testWhereHasMorph()
     {
@@ -255,7 +255,7 @@ class ModelMorphToLoadingTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->with(Mockery::any())->andReturnUsing(function ($event) {
             $this->channel->push($event);
         });
-        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface */
+        /** @var \Psr\Container\ContainerInterface|\Mockery\MockInterface|\Mockery\LegacyMockInterface $container */
         $container = ContainerStub::getContainer(function ($conn) use ($dispatcher) {
             $conn->setEventDispatcher($dispatcher);
         });

--- a/src/database/tests/ModelMorphToLoadingTest.php
+++ b/src/database/tests/ModelMorphToLoadingTest.php
@@ -100,7 +100,6 @@ class ModelMorphToLoadingTest extends TestCase
 
     public function testMorphAssociationEmpty()
     {
-        $this->markTestSkipped();
         $this->getContainer();
         $images = Image::query()->whereHasMorph(
             'imageable',

--- a/src/database/tests/Stubs/Model/Morph/Book.php
+++ b/src/database/tests/Stubs/Model/Morph/Book.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database\Stubs\Model\Morph;
+
+use HyperfTest\Database\Stubs\Model\Model;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $title
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Book extends Model
+{
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'book';
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected array $fillable = ['id', 'user_id', 'title', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected array $casts = ['id' => 'integer', 'user_id' => 'integer', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    public function getMorphClass()
+    {
+        return 'book';
+    }
+
+    public function image()
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+}

--- a/src/database/tests/Stubs/Model/Morph/Image.php
+++ b/src/database/tests/Stubs/Model/Morph/Image.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Database\Stubs\Model\Morph;
 
+use Hyperf\Utils\Arr;
 use HyperfTest\Database\Stubs\Model\Model;
 
 /**
@@ -45,9 +46,11 @@ class Image extends Model
 
     public static function getActualClassNameForMorph($class)
     {
-        return [
+        $morphMap = [
             'user' => User::class,
             'book' => Book::class,
-        ][$class] ?? $class;
+        ];
+
+        return Arr::get($morphMap, $class, $class);
     }
 }

--- a/src/database/tests/Stubs/Model/Morph/Image.php
+++ b/src/database/tests/Stubs/Model/Morph/Image.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database\Stubs\Model\Morph;
+
+use HyperfTest\Database\Stubs\Model\Model;
+
+/**
+ * @property int $id
+ * @property string $url
+ * @property int $imageable_id
+ * @property string $imageable_type
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Image extends Model
+{
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'images';
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected array $fillable = ['id', 'url', 'imageable_id', 'imageable_type', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected array $casts = ['id' => 'integer', 'imageable_id' => 'integer', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+
+    public static function getActualClassNameForMorph($class)
+    {
+        return [
+            'user' => User::class,
+            'book' => Book::class,
+        ][$class] ?? $class;
+    }
+}

--- a/src/database/tests/Stubs/Model/Morph/User.php
+++ b/src/database/tests/Stubs/Model/Morph/User.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace HyperfTest\Database\Stubs\Model\Morph;
 
 use HyperfTest\Database\Stubs\Model\Model;
+use HyperfTest\Database\Stubs\Model\UserRolePivot;
 
 /**
  * @property int $id

--- a/src/database/tests/Stubs/Model/Morph/User.php
+++ b/src/database/tests/Stubs/Model/Morph/User.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database\Stubs\Model\Morph;
+
+use HyperfTest\Database\Stubs\Model\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property int $gender
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property \App\Model\Book $book
+ * @property \App\Model\Book[]|\Hyperf\Database\Model\Collection $books
+ */
+class User extends Model
+{
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'user';
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected array $fillable = ['id', 'name', 'gender', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected array $casts = ['id' => 'integer', 'gender' => 'integer', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    public function book()
+    {
+        return $this->hasOne(Book::class, 'user_id', 'id');
+    }
+
+    public function books()
+    {
+        return $this->hasMany(Book::class, 'user_id', 'id');
+    }
+
+    public function getMorphClass()
+    {
+        return 'user';
+    }
+
+    public function image()
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class, 'user_role', 'user_id', 'role_id', 'id', 'id')
+            ->using(UserRolePivot::class)->as('pivot')
+            ->withTimestamps();
+    }
+}


### PR DESCRIPTION
```php
class User extends Model
{
    public function foo()
    {
        return $this->morphOne(Foo::class);
    }

    public function getMorphClass()
    {
        return 'user';
    }
}

class Post extends Model
{
    public function foo()
    {
        return $this->morphOne(Foo::class);
    }

    public function getMorphClass()
    {
        return 'post';
    }
}

class Foo extends Model
{
    public function morphable()
    {
        return $this->morphTo();
    }

    public static function getActualClassNameForMorph($class)
    {
        $morphMap = [
            'user' => User::class,
            'post' => Post::class,
        ];
        return Arr::get($morphMap, $class, $class);
    }
}

Foo::with('morphable')->get();
```