### PR TITLE
增加自定义swow server的配置项

### DIFF
--- a/src/server/src/SwowServer.php
+++ b/src/server/src/SwowServer.php
@@ -110,6 +110,7 @@ class SwowServer implements ServerInterface
             $callbacks = array_replace($config->getCallbacks(), $server->getCallbacks());
 
             $this->server = $this->makeServer($type, $host, $port);
+            $this->serverExt($this->server, $config, $server);
 
             $this->bindServerCallbacks($this->server, $type, $name, $callbacks);
 
@@ -215,6 +216,21 @@ class SwowServer implements ServerInterface
         }
 
         throw new RuntimeException('Server type is invalid.');
+    }
+
+    protected function serverExt(HttpServer|BaseServer $server, ServerConfig $config, Port $serverConfig): void
+    {
+        $settings = array_replace($config->getSettings(), $serverConfig->getSettings());
+
+        $serverHttpExt = $settings['swow_http_server_ext'] ?? null;
+        if ($serverHttpExt instanceof \Closure && $server instanceof HttpServer) {
+            $serverHttpExt($server);
+        }
+
+        $serverBaseExt = $settings['swow_base_server_ext'] ?? null;
+        if ($serverBaseExt instanceof \Closure && $server instanceof BaseServer) {
+            $serverBaseExt($server);
+        }
     }
 
     private function writePid(): void


### PR DESCRIPTION
当前swow的server，还不能自定义配置，增加服务配置：通过闭包进行server的修改。
在settings里面添加swow的扩展项，如setMaxContentLength设置最大请求体

****优点****
- swow的配置不再是swoole的key-value形式，方法调用更加人性化
- swow底层增加配置项时，不需要更改该代码

****缺点****
- 闭包设置需要规范，即需要按照示例写法
- 开放性很高，如 $server->close() 会导致启动失效

示例：
```
<?php

declare(strict_types=1);
/**
 * This file is part of Hyperf.
 *
 * @link     https://www.hyperf.io
 * @document https://hyperf.wiki
 * @contact  group@hyperf.io
 * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
 */
use Hyperf\Server\Event;
use Hyperf\Server\Server;
use Hyperf\Engine\Http\Server as SwowHttpServer;
use Hyperf\Engine\Server as SwowBaseServer;

return [
    'type' => Hyperf\Server\SwowServer::class,
    'servers' => [
        [
            'name' => 'http',
            'type' => Server::SERVER_HTTP,
            'host' => '0.0.0.0',
            'port' => 9501,
            'callbacks' => [
                Event::ON_REQUEST => [Hyperf\HttpServer\Server::class, 'onRequest'],
            ],
            'settings' => [
                'swow_base_server_ext' => function (SwowBaseServer $server) {
                    $server->setTimeout(30);
                },
                'swow_http_server_ext' => function (SwowHttpServer $server) {
                    $server->setMaxContentLength(100 * 1024 * 1024);
                },
            ],
        ],
    ],
    // 全局配置，servers明细有设置时，这里无效
    'settings' => [
        'swow_base_server_ext' => function (SwowBaseServer $server) {
            $server->setTimeout(30);
        },
        'swow_http_server_ext' => function (SwowHttpServer $server) {
            $server->setMaxContentLength(100 * 1024 * 1024);
        },
    ],
];

```