### PR TITLE
Allow using static closures as callable for macros

### DIFF
--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -14,6 +14,7 @@ namespace Hyperf\Macroable;
 use BadMethodCallException;
 use Closure;
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 
 /**
@@ -75,7 +76,15 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $macro = $macro->bindTo($this, static::class);
+            $reflection = new ReflectionFunction($macro);
+
+            $bindable = $reflection->getClosureScopeClass() === null || $reflection->getClosureThis() !== null;
+
+            if ($bindable) {
+                $macro = $macro->bindTo($this, static::class);
+            } else {
+                $macro = $macro->bindTo(null, static::class);
+            }
         }
 
         return $macro(...$parameters);

--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -28,6 +28,8 @@ trait Macroable
      */
     protected static array $macros = [];
 
+    protected static array $bindable = [];
+
     /**
      * Dynamically handle calls to the class.
      *
@@ -76,11 +78,12 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $reflection = new ReflectionFunction($macro);
+            if (! isset(static::$bindable[$method])) {
+                $reflection = new ReflectionFunction($macro);
+                static::$bindable[$method] = $reflection->getClosureScopeClass() === null || $reflection->getClosureThis() !== null;
+            }
 
-            $bindable = $reflection->getClosureScopeClass() === null || $reflection->getClosureThis() !== null;
-
-            if ($bindable) {
+            if (static::$bindable[$method]) {
                 $macro = $macro->bindTo($this, static::class);
             } else {
                 $macro = $macro->bindTo(null, static::class);

--- a/src/macroable/tests/MacroableTest.php
+++ b/src/macroable/tests/MacroableTest.php
@@ -82,6 +82,18 @@ class MacroableTest extends TestCase
         $this->assertSame('foo', $instance->methodThree());
     }
 
+    public function testSettingMacroUsingStaticClosures()
+    {
+        TestMacroable::macro('staticFn', static function () {
+            return 'I am unbound.';
+        });
+        TestMacroable::macro('speed', static fn () => 'I am speed.');
+        $instance = new TestMacroable();
+
+        $this->assertSame('I am unbound.', $instance->staticFn());
+        $this->assertSame('I am speed.', $instance->speed());
+    }
+
     private function createObjectForTrait()
     {
         return new EmptyMacroable();


### PR DESCRIPTION
This PR allows using static closures as the callable when registering a macro.

```php
TestMacroable::macro('speed', static fn () => 'I am speed.');
echo (new TestMacroable)->speed(); // 'I am speed.'
```
