### PR TITLE
Added rpc-client cache

### DIFF
--- a/src/rpc-client/src/MetadataCollector.php
+++ b/src/rpc-client/src/MetadataCollector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\RpcClient;
+
+use Hyperf\Utils\Arr;
+
+class MetadataCollector implements MetadataCollectorInterface
+{
+    /**
+     * Subclass MUST override this property.
+     * @var array
+     */
+    protected static $container = [];
+
+    /**
+     * Retrieve the metadata via key.
+     * @param null|mixed $default
+     */
+    public static function get(string $key, $default = null)
+    {
+        return Arr::get(static::$container, $key) ?? $default;
+    }
+
+    /**
+     * Set the metadata to holder.
+     * @param mixed $value
+     */
+    public static function set(string $key, $value): void
+    {
+        Arr::set(static::$container, $key, $value);
+    }
+
+    /**
+     * Determine if the metadata exist.
+     * If exist will return true, otherwise return false.
+     */
+    public static function has(string $key): bool
+    {
+        return Arr::has(static::$container, $key);
+    }
+
+    public static function clear(?string $key = null): void
+    {
+        if ($key) {
+            Arr::forget(static::$container, [$key]);
+        } else {
+            static::$container = [];
+        }
+    }
+
+    /**
+     * Serialize the all metadata to a string.
+     */
+    public static function serialize(): string
+    {
+        return serialize(static::$container);
+    }
+
+    /**
+     * Deserialize the serialized metadata and set the metadata to holder.
+     */
+    public static function deserialize(string $metadata): bool
+    {
+        static::$container = unserialize($metadata);
+        return true;
+    }
+
+    public static function list(): array
+    {
+        return static::$container;
+    }
+}

--- a/src/rpc-client/src/MetadataCollectorInterface.php
+++ b/src/rpc-client/src/MetadataCollectorInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\RpcClient;
+
+interface MetadataCollectorInterface
+{
+    /**
+     * Retrieve the metadata via key.
+     * @param null|mixed $default
+     */
+    public static function get(string $key, $default = null);
+
+    /**
+     * Set the metadata to holder.
+     * @param mixed $value
+     */
+    public static function set(string $key, $value): void;
+
+    public static function clear(?string $key = null): void;
+
+    /**
+     * Serialize the all metadata to a string.
+     */
+    public static function serialize(): string;
+
+    /**
+     * Deserialize the serialized metadata and set the metadata to holder.
+     */
+    public static function deserialize(string $metadata): bool;
+
+    /**
+     * Return all metadata array.
+     */
+    public static function list(): array;
+}


### PR DESCRIPTION
该 pr 主要是为了解决swoole_compiler，过后 rpcInterface 的 md5变了，导致加密后的代码无法找到对应的类