### PR TITLE
Replace `ConsoleOutput` to fix the bug of `StdoutLogger`

### DIFF
--- a/src/framework/src/Logger/Output/ConsoleOutput.php
+++ b/src/framework/src/Logger/Output/ConsoleOutput.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Framework\Logger\Output;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\Output;
+
+class ConsoleOutput extends Output
+{
+    public function __construct(?int $verbosity = self::VERBOSITY_NORMAL, bool $decorated = true, OutputFormatterInterface $formatter = null)
+    {
+        parent::__construct($verbosity, $decorated, $formatter);
+    }
+
+    public function doWrite(string $message, bool $newline)
+    {
+        if ($newline) {
+            $message .= \PHP_EOL;
+        }
+        echo $message;
+    }
+}

--- a/src/framework/src/Logger/StdoutLogger.php
+++ b/src/framework/src/Logger/StdoutLogger.php
@@ -13,8 +13,8 @@ namespace Hyperf\Framework\Logger;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Framework\Logger\Output\ConsoleOutput;
 use Psr\Log\LogLevel;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use function sprintf;
 use function str_replace;

--- a/src/framework/tests/StdoutLoggerTest.php
+++ b/src/framework/tests/StdoutLoggerTest.php
@@ -13,11 +13,11 @@ namespace HyperfTest\Framework;
 
 use Hyperf\Config\Config;
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Framework\Logger\Output\ConsoleOutput;
 use Hyperf\Framework\Logger\StdoutLogger;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * @internal


### PR DESCRIPTION
Execute the command and paste the result below.

Command: `uname -a && php -v && composer info | grep hyperf && php --ri swoole`

```bash
Darwin her-catMacBook-Pro.local 21.6.0 Darwin Kernel Version 21.6.0: Sat Jun 18 17:07:25 PDT 2022; root:xnu-8020.140.41~1/RELEASE_X86_64 x86_64
PHP 8.0.21 (cli) (built: Jul  7 2022 13:13:21) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.21, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.21, Copyright (c), by Zend Technologies
hyperf/engine                      v1.2.1     

swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 4.6.1
Built => Aug  2 2022 12:35:28
coroutine => enabled with boost asm context
kqueue => enabled
rwlock => enabled
openssl => OpenSSL 3.0.5 5 Jul 2022
dtls => enabled
pcre => enabled
zlib => 1.2.11
brotli => E16777225/D16777225
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 262144 => 262144
```

### Description:

在协程中使用 `StdoutLogger` 会报错：

```
PHP Fatal error:  Uncaught Swoole\Error: Socket#1 has already been bound to another coroutine#2, writing of the same socket in coroutine#3 at the same time is not allowed in /Users/hexianghui/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php:76
```



### Steps To Reproduce:

运行以下单元测试：

```php
use Hyperf\Config\Config;
use Hyperf\Contract\StdoutLoggerInterface;
use Hyperf\Framework\Logger\StdoutLogger;
use Hyperf\Utils\Coroutine;
use Hyperf\Utils\Parallel;
use Hyperf\Utils\WaitGroup;
use PHPUnit\Framework\TestCase;
use Psr\Log\LogLevel;
use Symfony\Component\Console\Output\ConsoleOutput;

class MonologTest extends TestCase
{
    public function testMonologInCoroutine()
    {
        $config = new Config([
            StdoutLoggerInterface::class => [
                'log_level' => [
                    LogLevel::INFO,
                ],
            ],
        ]);

        $logger = new StdoutLogger($config, new ConsoleOutput());

        $parallel = new Parallel();
        for ($i = 0; $i < 2; ++$i) {
            $parallel->add(function () use ($logger) {
                while (true) {
                    $logger->info(str_repeat('A', 1000));
                }
            });
        }
        $parallel->wait();
    }

    public function testMonologInCoroutine2()
    {
        $config = new Config([
            StdoutLoggerInterface::class => [
                'log_level' => [
                    LogLevel::INFO,
                ],
            ],
        ]);

        $waitGroup = new WaitGroup();
        for ($i = 0; $i < 2; ++$i) {
            $waitGroup->add();
            Coroutine::create(function () use ($config, $waitGroup) {
                Coroutine::defer(fn () => $waitGroup->done());
                while (true) {
                    $logger = new StdoutLogger($config, new ConsoleOutput());
                    $logger->info(str_repeat('A', 1000));
                }
            });
        }
        $waitGroup->wait();
    }
}
```

### Result:

```
PHPUnit 9.5.21 #StandWithUkraine

[INFO] AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...省略
[INFO] AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...省略

Fatal error: Uncaught Swoole\Error: Socket#1 has already been bound to another coroutine#2, writing of the same socket in coroutine#3 at the same time is not allowed in /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php:76
Stack trace:
#0 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php(76): fwrite(Resource id #2, '\e[32m[INFO]\e[39...')
#1 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/Output.php(166): Symfony\Component\Console\Output\StreamOutput->doWrite('\e[32m[INFO]\e[39...', true)
#2 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/Output.php(132): Symfony\Component\Console\Output\Output->write(Array, true, 1)
#3 /Users/code/her-cat/hyperf/src/framework/src/Logger/StdoutLogger.php(99): Symfony\Component\Console\Output\Output->writeln('<info>[INFO]</>...')
#4 /Users/code/her-cat/hyperf/src/framework/src/Logger/StdoutLogger.php(72): Hyperf\Framework\Logger\StdoutLogger->log('info', '<info>[INFO]</>...', Array)
#5 /Users/code/her-cat/hyperf/src/framework/tests/MonologTest.php(44): Hyperf\Framework\Logger\StdoutLogger->info('AAAAAAAAAAAAAAA...')
#6 /Users/code/her-cat/hyperf/src/utils/src/Parallel.php(61): HyperfTest\Framework\MonologTest->HyperfTest\Framework\{closure}()
#7 /Users/code/her-cat/hyperf/src/utils/src/Coroutine.php(62): Hyperf\Utils\Parallel->Hyperf\Utils\{closure}()
#8 {main}
  thrown in /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php on line 76
PHP Fatal error:  Uncaught Swoole\Error: Socket#1 has already been bound to another coroutine#2, writing of the same socket in coroutine#3 at the same time is not allowed in /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php:76
Stack trace:
#0 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php(76): fwrite(Resource id #2, '\e[32m[INFO]\e[39...')
#1 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/Output.php(166): Symfony\Component\Console\Output\StreamOutput->doWrite('\e[32m[INFO]\e[39...', true)
#2 /Users/code/her-cat/hyperf/vendor/symfony/console/Output/Output.php(132): Symfony\Component\Console\Output\Output->write(Array, true, 1)
#3 /Users/code/her-cat/hyperf/src/framework/src/Logger/StdoutLogger.php(99): Symfony\Component\Console\Output\Output->writeln('<info>[INFO]</>...')
#4 /Users/code/her-cat/hyperf/src/framework/src/Logger/StdoutLogger.php(72): Hyperf\Framework\Logger\StdoutLogger->log('info', '<info>[INFO]</>...', Array)
#5 /Users/code/her-cat/hyperf/src/framework/tests/MonologTest.php(44): Hyperf\Framework\Logger\StdoutLogger->info('AAAAAAAAAAAAAAA...')
#6 /Users/code/her-cat/hyperf/src/utils/src/Parallel.php(61): HyperfTest\Framework\MonologTest->HyperfTest\Framework\{closure}()
#7 /Users/code/her-cat/hyperf/src/utils/src/Coroutine.php(62): Hyperf\Utils\Parallel->Hyperf\Utils\{closure}()
#8 {main}
  thrown in /Users/code/her-cat/hyperf/vendor/symfony/console/Output/StreamOutput.php on line 76
```