### PR TITLE
Support for SSL encrypted connection to Redis.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -56,6 +56,7 @@ composer analyse
 - [#4918](https://github.com/hyperf/hyperf/pull/4918) Added `LoadBalancerInterface::afterRefreshed()` to register a hook which to be run after refresh nodes.
 - [#4992](https://github.com/hyperf/hyperf/pull/4992) Added config `amqp.enable` which used to control amqp consumer whether to start automatically and producer whether to declare automatically.
 - [#4994](https://github.com/hyperf/hyperf/pull/4994) [#5016](https://github.com/hyperf/hyperf/pull/5016) Added component `hyperf/database-pgsql` which you can be used to connect pgsql server.
+- [#5007](https://github.com/hyperf/hyperf/pull/5007) Support for SSL encrypted connection to Redis.
 
 ## Optimized
 

--- a/src/redis/publish/redis.php
+++ b/src/redis/publish/redis.php
@@ -18,6 +18,7 @@ return [
         'timeout' => 0.0,
         'reserved' => null,
         'retry_interval' => 0,
+        'read_timeout' => 0.0,
         'cluster' => [
             'enable' => (bool) env('REDIS_CLUSTER_ENABLE', false),
             'name' => null,

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -268,7 +268,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             $config['read_timeout'] ?? 0.0,
         ];
 
-        if ($this->isSupportContext() && ! empty($config['context'])) {
+        if (! empty($config['context'])) {
             $parameters[] = $config['context'];
         }
 
@@ -277,10 +277,5 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             throw new ConnectionException('Connection reconnect failed.');
         }
         return $redis;
-    }
-
-    protected function isSupportContext(): bool
-    {
-        return (bool) version_compare(phpversion('redis'), '5.3.2', '>=');
     }
 }

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -34,12 +34,16 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         'auth' => null,
         'db' => 0,
         'timeout' => 0.0,
+        'read_timeout' => 0.0,
+        'reserved' => null,
+        'retry_interval' => 0,
         'cluster' => [
             'enable' => false,
             'name' => null,
             'seeds' => [],
             'read_timeout' => 0.0,
             'persistent' => false,
+            'context' => [],
         ],
         'sentinel' => [
             'enable' => false,
@@ -49,6 +53,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             'read_timeout' => 0,
         ],
         'options' => [],
+        'context' => [],
     ];
 
     /**
@@ -88,20 +93,21 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         return $this;
     }
 
+    /**
+     * @throws \RedisException
+     * @throws ConnectionException
+     */
     public function reconnect(): bool
     {
-        $host = $this->config['host'];
-        $port = $this->config['port'];
         $auth = $this->config['auth'];
         $db = $this->config['db'];
-        $timeout = $this->config['timeout'];
         $cluster = $this->config['cluster']['enable'] ?? false;
         $sentinel = $this->config['sentinel']['enable'] ?? false;
 
         $redis = match (true) {
             $cluster => $this->createRedisCluster(),
             $sentinel => $this->createRedisSentinel(),
-            default => $this->createRedis($host, $port, $timeout),
+            default => $this->createRedis($this->config),
         };
 
         $options = $this->config['options'] ?? [];
@@ -160,6 +166,9 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             if (isset($this->config['auth'])) {
                 $parameters[] = $this->config['auth'];
             }
+            if ($this->isSupportContext() && ! empty($this->config['cluster']['context'])) {
+                $parameters[] = $this->config['cluster']['context'];
+            }
 
             $redis = new \RedisCluster(...$parameters);
         } catch (\Throwable $e) {
@@ -185,6 +194,9 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         return $result;
     }
 
+    /**
+     * @throws ConnectionException
+     */
     protected function createRedisSentinel(): \Redis
     {
         try {
@@ -227,7 +239,13 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
                 throw new InvalidRedisConnectionException('Connect sentinel redis server failed.');
             }
 
-            $redis = $this->createRedis($host, $port, $timeout);
+            $redis = $this->createRedis([
+                'host' => $host,
+                'port' => $port,
+                'timeout' => $timeout,
+                'retry_interval' => $retryInterval,
+                'read_timeout' => $readTimeout,
+            ]);
         } catch (\Throwable $e) {
             throw new ConnectionException('Connection reconnect failed ' . $e->getMessage());
         }
@@ -236,16 +254,33 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
     }
 
     /**
-     * @param string $host
-     * @param int $port
-     * @param float $timeout
+     * @throws ConnectionException
+     * @throws \RedisException
      */
-    protected function createRedis($host, $port, $timeout): \Redis
+    protected function createRedis(array $config): \Redis
     {
+        $parameters = [
+            $config['host'] ?? '',
+            $config['port'] ?? 6379,
+            $config['timeout'] ?? 0.0,
+            $config['reserved'] ?? null,
+            $config['retry_interval'] ?? 0,
+            $config['read_timeout'] ?? 0.0,
+        ];
+
+        if ($this->isSupportContext() && ! empty($config['context'])) {
+            $parameters[] = $config['context'];
+        }
+
         $redis = new \Redis();
-        if (! $redis->connect((string) $host, (int) $port, $timeout)) {
+        if (! $redis->connect(...$parameters)) {
             throw new ConnectionException('Connection reconnect failed.');
         }
         return $redis;
+    }
+
+    protected function isSupportContext(): bool
+    {
+        return (bool) version_compare(phpversion('redis'), '5.3.2', '>=');
     }
 }

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -34,9 +34,9 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         'auth' => null,
         'db' => 0,
         'timeout' => 0.0,
-        'read_timeout' => 0.0,
         'reserved' => null,
         'retry_interval' => 0,
+        'read_timeout' => 0.0,
         'cluster' => [
             'enable' => false,
             'name' => null,

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -166,7 +166,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             if (isset($this->config['auth'])) {
                 $parameters[] = $this->config['auth'];
             }
-            if ($this->isSupportContext() && ! empty($this->config['cluster']['context'])) {
+            if (! empty($this->config['cluster']['context'])) {
                 $parameters[] = $this->config['cluster']['context'];
             }
 

--- a/src/redis/src/RedisProxy.php
+++ b/src/redis/src/RedisProxy.php
@@ -25,6 +25,12 @@ class RedisProxy extends Redis
         $this->poolName = $pool;
     }
 
+    /**
+     * WARN: Can't remove this function, because AOP need it.
+     * @see https://github.com/hyperf/hyperf/issues/1239
+     * @param string $name
+     * @param array $arguments
+     */
     public function __call($name, $arguments)
     {
         return parent::__call($name, $arguments);

--- a/src/redis/tests/RedisConnectionTest.php
+++ b/src/redis/tests/RedisConnectionTest.php
@@ -46,9 +46,9 @@ class RedisConnectionTest extends TestCase
             'auth' => 'redis',
             'db' => 0,
             'timeout' => 0.0,
-            'read_timeout' => 3.0,
             'reserved' => null,
             'retry_interval' => 5,
+            'read_timeout' => 3.0,
             'cluster' => [
                 'enable' => false,
                 'name' => null,

--- a/src/redis/tests/RedisConnectionTest.php
+++ b/src/redis/tests/RedisConnectionTest.php
@@ -46,6 +46,9 @@ class RedisConnectionTest extends TestCase
             'auth' => 'redis',
             'db' => 0,
             'timeout' => 0.0,
+            'read_timeout' => 3.0,
+            'reserved' => null,
+            'retry_interval' => 5,
             'cluster' => [
                 'enable' => false,
                 'name' => null,
@@ -54,6 +57,9 @@ class RedisConnectionTest extends TestCase
                 ],
                 'read_timeout' => 0.0,
                 'persistent' => false,
+                'context' => [
+                    'stream' => ['cafile' => 'foo-cafile', 'verify_peer' => true],
+                ],
             ],
             'sentinel' => [
                 'enable' => false,
@@ -63,6 +69,9 @@ class RedisConnectionTest extends TestCase
                 'read_timeout' => 0,
             ],
             'options' => [],
+            'context' => [
+                'stream' => ['cafile' => 'foo-cafile', 'verify_peer' => true],
+            ],
             'pool' => [
                 'min_connections' => 1,
                 'max_connections' => 30,
@@ -122,6 +131,12 @@ class RedisConnectionTest extends TestCase
                     'host' => 'redis',
                     'auth' => 'redis',
                     'port' => 16379,
+                    'read_timeout' => 3.0,
+                    'reserved' => null,
+                    'retry_interval' => 5,
+                    'context' => [
+                        'stream' => ['cafile' => 'foo-cafile', 'verify_peer' => true],
+                    ],
                     'pool' => [
                         'min_connections' => 1,
                         'max_connections' => 30,
@@ -135,6 +150,9 @@ class RedisConnectionTest extends TestCase
                         'name' => null,
                         'seeds' => [
                             '127.0.0.1:6379',
+                        ],
+                        'context' => [
+                            'stream' => ['cafile' => 'foo-cafile', 'verify_peer' => true],
                         ],
                     ],
                     'sentinel' => [

--- a/src/redis/tests/RedisTest.php
+++ b/src/redis/tests/RedisTest.php
@@ -54,7 +54,7 @@ class RedisTest extends TestCase
         $this->assertSame('timeout', $timeout->getName());
         $this->assertSame('retry_interval', $retryInterval->getName());
 
-        $this->assertTrue($redis->connect('127.0.0.1', 6379, 0.0));
+        $this->assertTrue($redis->connect('127.0.0.1', 6379, 0.0, null, 0, 0));
     }
 
     public function testRedisSelect()


### PR DESCRIPTION
relate issue: #4971

usage:

```php
return [
    'default' => [
        'host' => env('REDIS_HOST', 'localhost'),
        'auth' => env('REDIS_AUTH', null),
        'port' => (int) env('REDIS_PORT', 6379),
        'db' => (int) env('REDIS_DB', 0),
        'timeout' => 0.0,
        'reserved' => null,
        'retry_interval' => 0,
        'cluster' => [
            'enable' => (bool) env('REDIS_CLUSTER_ENABLE', false),
            'name' => null,
            'seeds' => [],
            'context' => [
                'stream' => ['cafile' => 'ApsaraDB-CA-Chain.pem', 'verify_peer' => true],
            ],
        ],
        'context' => [
            'stream' => ['cafile' => 'ApsaraDB-CA-Chain.pem', 'verify_peer' => true],
        ],
    ],
];
```