### PR TITLE
Removed array type of `Trace Annotation`, because don't support array.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -97,6 +97,7 @@ composer analyse
 - [#4934](https://github.com/hyperf/hyperf/pull/4934) Throw `NoNodesAvailableException` when cannot select any node from load balancer.
 - [#4952](https://github.com/hyperf/hyperf/pull/4952) Don't write pid when the `settings.pid_file` is null when using swow server.
 - [#4979](https://github.com/hyperf/hyperf/pull/4979) Don't support database commands by default, please require `hyperf/devtool` or set them in `autoload/commands`.
+- [#5008](https://github.com/hyperf/hyperf/pull/5008) Removed array type of `Trace Annotation`, because don't support array.
 
 ## Swow Supported
 

--- a/src/tracer/src/Annotation/Trace.php
+++ b/src/tracer/src/Annotation/Trace.php
@@ -17,7 +17,7 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class Trace extends AbstractAnnotation
 {
-    public function __construct(public string $name = '', public array|string $tag = 'source')
+    public function __construct(public string $name = '', public string $tag = 'source')
     {
     }
 }


### PR DESCRIPTION
```php
    /**
     * Adds a tag to the span.
     *
     * If there is a pre-existing tag set for key, it is overwritten.
     *
     * As an implementor, consider using "standard tags" listed in {@see \OpenTracing\Tags}
     *
     * If the span is already finished, a warning should be logged.
     *
     * @param string $key
     * @param string|bool|int|float $value
     * @return void
     */
    public function setTag(string $key, $value): void;
```

仅支持 string 类型，传入 array 会报错。