### PR TITLE
Check validity of file descriptor before sending message to it.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -76,6 +76,7 @@ composer analyse
 - [#4949](https://github.com/hyperf/hyperf/pull/4949) Removed useless `call()` from `Coroutine::create()`.
 - [#4961](https://github.com/hyperf/hyperf/pull/4961) Removed proxy mode from `Hyperf\Di\ClassLoader` and Optimized `Composer::getLoader()`.
 - [#4981](https://github.com/hyperf/hyperf/pull/4981) Confirm before proceeding with the action when using `ConfirmableTrait`, such as `migrate` command.
+- [#5017](https://github.com/hyperf/hyperf/pull/5017) Check validity of file descriptor before sending message to it when using `socketio-server`.
 
 ## Changed
 

--- a/src/socketio-server/src/SocketIO.php
+++ b/src/socketio-server/src/SocketIO.php
@@ -165,7 +165,10 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
                             'type' => Packet::ACK,
                             'data' => $data,
                         ]);
-                        $this->sender->push($frame->fd, Engine::MESSAGE . $this->encoder->encode($responsePacket));
+
+                        if ($this->sender->check($frame->fd)) {
+                            $this->sender->push($frame->fd, Engine::MESSAGE . $this->encoder->encode($responsePacket));
+                        }
                     };
                 }
                 $this->dispatch($frame->fd, $packet->nsp, ...$packet->data);


### PR DESCRIPTION
This fixes: Warning: Swoole\WebSocket\Server::push(): session#PD does not exists in /var/www/vendor/hyperf/socketio-server/src/SocketIO.php on line 166