### PR TITLE
Adds RedisConnection::isCluster()

### DIFF
--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -148,6 +148,11 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
         $this->database = $database;
     }
 
+    public function isCluster(): bool
+    {
+        return $this->connection instanceof \RedisCluster;
+    }
+
     protected function createRedisCluster(): \RedisCluster
     {
         try {


### PR DESCRIPTION
Call as:

```php
$redis = di(\Hyperf\Redis\Redis::class);
var_dump($redis->isCluster()); // Output true or false
```

Scene:

```php
$redis = di(\Hyperf\Redis\Redis::class);
$params = [];
if ($redis->isCluster()) {
    $params[] = $key;
}
$params[] = 'BITFIELD';
$params[] = 'set',
$params[] = 'u1';
$params[] = 1001;
$params[] = 1;
$redis->rawCommand(...$params);
```