### PR TITLE
Fix the bug that value of Inject not work

### DIFF
--- a/src/di/src/Annotation/Inject.php
+++ b/src/di/src/Annotation/Inject.php
@@ -27,15 +27,17 @@ class Inject extends AbstractAnnotation
     public function collectProperty(string $className, ?string $target): void
     {
         try {
-            $reflectionClass = ReflectionManager::reflectClass($className);
+            if (is_null($this->value)) {
+                $reflectionClass = ReflectionManager::reflectClass($className);
 
-            $reflectionProperty = $reflectionClass->getProperty($target);
+                $reflectionProperty = $reflectionClass->getProperty($target);
 
-            if (method_exists($reflectionProperty, 'hasType') && $reflectionProperty->hasType()) {
-                /* @phpstan-ignore-next-line */
-                $this->value = $reflectionProperty->getType()->getName();
-            } else {
-                $this->value = PhpDocReaderManager::getInstance()->getPropertyClass($reflectionProperty);
+                if (method_exists($reflectionProperty, 'hasType') && $reflectionProperty->hasType()) {
+                    /* @phpstan-ignore-next-line */
+                    $this->value = $reflectionProperty->getType()->getName();
+                } else {
+                    $this->value = PhpDocReaderManager::getInstance()->getPropertyClass($reflectionProperty);
+                }
             }
 
             if (empty($this->value)) {

--- a/src/di/src/Aop/RegisterInjectPropertyHandler.php
+++ b/src/di/src/Aop/RegisterInjectPropertyHandler.php
@@ -37,7 +37,11 @@ class RegisterInjectPropertyHandler
                     $reflectionProperty->setAccessible(true);
                     $container = ApplicationContext::getContainer();
                     if ($container->has($annotation->value)) {
-                        $reflectionProperty->setValue($object, $container->get($annotation->value));
+                        $entry = $container->get($annotation->value);
+                        if (method_exists($entry, '__invoke')) {
+                            $entry = $entry($container);
+                        }
+                        $reflectionProperty->setValue($object, $entry);
                     } elseif ($annotation->required) {
                         throw new NotFoundException("No entry or class found for '{$annotation->value}'");
                     }

--- a/src/di/src/Aop/RegisterInjectPropertyHandler.php
+++ b/src/di/src/Aop/RegisterInjectPropertyHandler.php
@@ -37,11 +37,7 @@ class RegisterInjectPropertyHandler
                     $reflectionProperty->setAccessible(true);
                     $container = ApplicationContext::getContainer();
                     if ($container->has($annotation->value)) {
-                        $entry = $container->get($annotation->value);
-                        if (method_exists($entry, '__invoke')) {
-                            $entry = $entry($container);
-                        }
-                        $reflectionProperty->setValue($object, $entry);
+                        $reflectionProperty->setValue($object, $container->get($annotation->value));
                     } elseif ($annotation->required) {
                         throw new NotFoundException("No entry or class found for '{$annotation->value}'");
                     }


### PR DESCRIPTION
#4716 

```php

interface BarInterface
{}

class Bar implements BarInterface
{}

# Inject by alias name
class Foo
{
    #[Inject('foo.bar')]
    public BarInterface $bar;
}

// dependencies.php
'foo.bar' => fn() => new Bar(),
```
