### PR TITLE
The child process exits unexpectedly.

### DIFF
--- a/src/di/src/ScanHandler/PcntlScanHandler.php
+++ b/src/di/src/ScanHandler/PcntlScanHandler.php
@@ -38,7 +38,7 @@ class PcntlScanHandler implements ScanHandlerInterface
         if ($pid) {
             pcntl_wait($status);
             if ($status !== 0) {
-                exit;
+                exit(1);
             }
             return new Scanned(true);
         }

--- a/src/di/src/ScanHandler/PcntlScanHandler.php
+++ b/src/di/src/ScanHandler/PcntlScanHandler.php
@@ -37,6 +37,9 @@ class PcntlScanHandler implements ScanHandlerInterface
         }
         if ($pid) {
             pcntl_wait($status);
+            if ($status !== 0) {
+                exit;
+            }
             return new Scanned(true);
         }
 


### PR DESCRIPTION
子进程异常退出时, 主进程终止

防止  误以为框架启动成功