### PR TITLE
fix: 解决使用表达式时报"Notice: Object of class Hyperf\Database\Query\Expression could not be converted to int "的问题

### DIFF
--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -870,6 +870,9 @@ trait HasAttributes
         switch ($castType) {
             case 'int':
             case 'integer':
+                if(is_object($value) && $value instanceof \Hyperf\Database\Query\Expression) {
+                    return $value->getValue();
+                }
                 return (int) $value;
             case 'real':
             case 'float':


### PR DESCRIPTION
解决使用DB::raw('number' + 1)表达式的时候报：Notice: Object of class Hyperf\Database\Query\Expression could not be converted to int 的问题