### PR TITLE
fix genereate-ide-helper error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.0', '8.1' ]
-        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.11', 'v5.0.0', 'master' ]
+        sw-version: [ 'v4.5.11', 'v4.6.7', 'v4.7.1', 'v4.8.12', 'v5.0.0', 'master' ]
         exclude:
           - php-version: '8.1'
             sw-version: 'v4.5.11'

--- a/src/graphql/src/ClassCollector.php
+++ b/src/graphql/src/ClassCollector.php
@@ -15,9 +15,6 @@ use Hyperf\Di\MetadataCollector;
 
 class ClassCollector extends MetadataCollector
 {
-    /**
-     * @var array
-     */
     protected static array $container = [];
 
     public static function collect(string $class)

--- a/src/graphql/src/ClassCollector.php
+++ b/src/graphql/src/ClassCollector.php
@@ -18,7 +18,7 @@ class ClassCollector extends MetadataCollector
     /**
      * @var array
      */
-    protected static $container = [];
+    protected static array $container = [];
 
     public static function collect(string $class)
     {


### PR DESCRIPTION
When I execute `./bin/generate-ide-helper`, the output is the following error:
```
PHP Fatal error:  Type of Hyperf\GraphQL\ClassCollector::$container must be array (as in class Hyperf\Di\MetadataCollector) in /home/circle33/code/hyperf/src/graphql/src/ClassCollector.php on line 16
```