### PR TITLE
Fixed bug that the exit code of command does not work when the exception code isn't int.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -160,3 +160,4 @@ composer analyse
 - [#4940](https://github.com/hyperf/hyperf/pull/4940) Fixed memory leak caused by an exception which occurred in `Parallel`.
 - [#5100](https://github.com/hyperf/hyperf/pull/5100) Fixed bug that the tag `continue` cannot work when using `view-engine`.
 - [#5121](https://github.com/hyperf/hyperf/pull/5121) Fixed bug that the SQL is not valid but the correct error message cannot be obtained when using `pgsql`.
+- [#5132](https://github.com/hyperf/hyperf/pull/5132) Fixed bug that the exit code of command does not work when the exception code isn't int.

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -433,7 +433,7 @@ abstract class Command extends SymfonyCommand
                 $this->output && $this->error($exception->getMessage());
 
                 $this->eventDispatcher->dispatch(new Event\FailToHandle($this, $exception));
-                return $this->exitCode = $exception->getCode();
+                return $this->exitCode = (int)$exception->getCode();
             } finally {
                 $this->eventDispatcher && $this->eventDispatcher->dispatch(new Event\AfterExecute($this));
             }

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\Command;
 
 use Hyperf\Contract\Arrayable;
@@ -69,10 +70,10 @@ abstract class Command extends SymfonyCommand
      */
     protected array $verbosityMap
         = [
-            'v' => OutputInterface::VERBOSITY_VERBOSE,
-            'vv' => OutputInterface::VERBOSITY_VERY_VERBOSE,
-            'vvv' => OutputInterface::VERBOSITY_DEBUG,
-            'quiet' => OutputInterface::VERBOSITY_QUIET,
+            'v'      => OutputInterface::VERBOSITY_VERBOSE,
+            'vv'     => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            'vvv'    => OutputInterface::VERBOSITY_DEBUG,
+            'quiet'  => OutputInterface::VERBOSITY_QUIET,
             'normal' => OutputInterface::VERBOSITY_NORMAL,
         ];
 
@@ -95,7 +96,7 @@ abstract class Command extends SymfonyCommand
             parent::__construct($this->name);
         }
 
-        ! empty($this->description) && $this->setDescription($this->description);
+        !empty($this->description) && $this->setDescription($this->description);
 
         $this->addDisableDispatcherOption();
     }
@@ -168,10 +169,11 @@ abstract class Command extends SymfonyCommand
      */
     public function choiceMultiple(
         string $question,
-        array $choices,
-        $default = null,
-        ?int $attempts = null
-    ): array {
+        array  $choices,
+               $default = null,
+        ?int   $attempts = null
+    ): array
+    {
         $question = new ChoiceQuestion($question, $choices, $default);
 
         $question->setMaxAttempts($attempts)->setMultiselect(true);
@@ -186,10 +188,11 @@ abstract class Command extends SymfonyCommand
      */
     public function choice(
         string $question,
-        array $choices,
-        $default = null,
-        ?int $attempts = null
-    ): mixed {
+        array  $choices,
+               $default = null,
+        ?int   $attempts = null
+    ): mixed
+    {
         return $this->choiceMultiple($question, $choices, $default, $attempts)[0];
     }
 
@@ -278,7 +281,7 @@ abstract class Command extends SymfonyCommand
      */
     public function warn($string, $verbosity = null)
     {
-        if (! $this->output->getFormatter()->hasStyle('warning')) {
+        if (!$this->output->getFormatter()->hasStyle('warning')) {
             $style = new OutputFormatterStyle('yellow');
             $this->output->getFormatter()->setStyle('warning', $style);
         }
@@ -333,7 +336,7 @@ abstract class Command extends SymfonyCommand
     {
         if (isset($this->verbosityMap[$level])) {
             $level = $this->verbosityMap[$level];
-        } elseif (! is_int($level)) {
+        } elseif (!is_int($level)) {
             $level = $this->verbosity;
         }
         return $level;
@@ -407,7 +410,7 @@ abstract class Command extends SymfonyCommand
     protected function configure()
     {
         parent::configure();
-        if (! isset($this->signature)) {
+        if (!isset($this->signature)) {
             $this->specifyParameters();
         }
     }
@@ -423,10 +426,10 @@ abstract class Command extends SymfonyCommand
                 $this->eventDispatcher && $this->eventDispatcher->dispatch(new Event\AfterHandle($this));
             } catch (\Throwable $exception) {
                 if (class_exists(ExitException::class) && $exception instanceof ExitException) {
-                    return $this->exitCode = (int) $exception->getStatus();
+                    return $this->exitCode = (int)$exception->getStatus();
                 }
 
-                if (! $this->eventDispatcher) {
+                if (!$this->eventDispatcher) {
                     throw $exception;
                 }
 
@@ -441,7 +444,7 @@ abstract class Command extends SymfonyCommand
             return 0;
         };
 
-        if ($this->coroutine && ! Coroutine::inCoroutine()) {
+        if ($this->coroutine && !Coroutine::inCoroutine()) {
             run($callback, $this->hookFlags);
             return $this->exitCode;
         }

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\Command;
 
 use Hyperf\Contract\Arrayable;
@@ -70,10 +69,10 @@ abstract class Command extends SymfonyCommand
      */
     protected array $verbosityMap
         = [
-            'v'      => OutputInterface::VERBOSITY_VERBOSE,
-            'vv'     => OutputInterface::VERBOSITY_VERY_VERBOSE,
-            'vvv'    => OutputInterface::VERBOSITY_DEBUG,
-            'quiet'  => OutputInterface::VERBOSITY_QUIET,
+            'v' => OutputInterface::VERBOSITY_VERBOSE,
+            'vv' => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            'vvv' => OutputInterface::VERBOSITY_DEBUG,
+            'quiet' => OutputInterface::VERBOSITY_QUIET,
             'normal' => OutputInterface::VERBOSITY_NORMAL,
         ];
 
@@ -96,7 +95,7 @@ abstract class Command extends SymfonyCommand
             parent::__construct($this->name);
         }
 
-        !empty($this->description) && $this->setDescription($this->description);
+        ! empty($this->description) && $this->setDescription($this->description);
 
         $this->addDisableDispatcherOption();
     }
@@ -169,11 +168,10 @@ abstract class Command extends SymfonyCommand
      */
     public function choiceMultiple(
         string $question,
-        array  $choices,
-               $default = null,
-        ?int   $attempts = null
-    ): array
-    {
+        array $choices,
+        $default = null,
+        ?int $attempts = null
+    ): array {
         $question = new ChoiceQuestion($question, $choices, $default);
 
         $question->setMaxAttempts($attempts)->setMultiselect(true);
@@ -188,11 +186,10 @@ abstract class Command extends SymfonyCommand
      */
     public function choice(
         string $question,
-        array  $choices,
-               $default = null,
-        ?int   $attempts = null
-    ): mixed
-    {
+        array $choices,
+        $default = null,
+        ?int $attempts = null
+    ): mixed {
         return $this->choiceMultiple($question, $choices, $default, $attempts)[0];
     }
 
@@ -281,7 +278,7 @@ abstract class Command extends SymfonyCommand
      */
     public function warn($string, $verbosity = null)
     {
-        if (!$this->output->getFormatter()->hasStyle('warning')) {
+        if (! $this->output->getFormatter()->hasStyle('warning')) {
             $style = new OutputFormatterStyle('yellow');
             $this->output->getFormatter()->setStyle('warning', $style);
         }
@@ -336,7 +333,7 @@ abstract class Command extends SymfonyCommand
     {
         if (isset($this->verbosityMap[$level])) {
             $level = $this->verbosityMap[$level];
-        } elseif (!is_int($level)) {
+        } elseif (! is_int($level)) {
             $level = $this->verbosity;
         }
         return $level;
@@ -410,7 +407,7 @@ abstract class Command extends SymfonyCommand
     protected function configure()
     {
         parent::configure();
-        if (!isset($this->signature)) {
+        if (! isset($this->signature)) {
             $this->specifyParameters();
         }
     }
@@ -426,17 +423,17 @@ abstract class Command extends SymfonyCommand
                 $this->eventDispatcher && $this->eventDispatcher->dispatch(new Event\AfterHandle($this));
             } catch (\Throwable $exception) {
                 if (class_exists(ExitException::class) && $exception instanceof ExitException) {
-                    return $this->exitCode = (int)$exception->getStatus();
+                    return $this->exitCode = (int) $exception->getStatus();
                 }
 
-                if (!$this->eventDispatcher) {
+                if (! $this->eventDispatcher) {
                     throw $exception;
                 }
 
                 $this->output && $this->error($exception->getMessage());
 
                 $this->eventDispatcher->dispatch(new Event\FailToHandle($this, $exception));
-                return $this->exitCode = (int)$exception->getCode();
+                return $this->exitCode = (int) $exception->getCode();
             } finally {
                 $this->eventDispatcher && $this->eventDispatcher->dispatch(new Event\AfterExecute($this));
             }
@@ -444,7 +441,7 @@ abstract class Command extends SymfonyCommand
             return 0;
         };
 
-        if ($this->coroutine && !Coroutine::inCoroutine()) {
+        if ($this->coroutine && ! Coroutine::inCoroutine()) {
             run($callback, $this->hookFlags);
             return $this->exitCode;
         }


### PR DESCRIPTION
$exception->getCode() 方法有可能返回字符串。详情见文档:https://www.php.net/manual/zh/exception.getcode.php