### PR TITLE
Fixed bug that `PGSqlSwooleConnection::affectingStatement()` can't work when the `sql` is wrong.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -168,3 +168,4 @@ composer analyse
 - [#5121](https://github.com/hyperf/hyperf/pull/5121) Fixed bug that the SQL is not valid but the correct error message cannot be obtained when using `pgsql`.
 - [#5132](https://github.com/hyperf/hyperf/pull/5132) Fixed bug that the exit code of command does not work when the exception code isn't int.
 - [#5199](https://github.com/hyperf/hyperf/pull/5199) Fixed bug that `RedisSentinel` can't support empty password.
+- [#5221](https://github.com/hyperf/hyperf/pull/5221) Fixed bug that `PGSqlSwooleConnection::affectingStatement()` can't work when the `sql` is wrong.

--- a/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
+++ b/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
@@ -88,7 +88,7 @@ class PostgreSqlSwooleExtConnection extends Connection
                 ($count = $statement->affectedRows($result)) > 0
             );
 
-            return $count;
+            return (int)$count;
         });
     }
 

--- a/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
+++ b/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
@@ -72,7 +72,7 @@ class PostgreSqlSwooleExtConnection extends Connection
      */
     public function affectingStatement(string $query, array $bindings = []): int
     {
-        return $this->run($query, $bindings, function ($query, $bindings) {
+        return (int)$this->run($query, $bindings, function ($query, $bindings) {
             if ($this->pretending()) {
                 return 0;
             }
@@ -88,7 +88,7 @@ class PostgreSqlSwooleExtConnection extends Connection
                 ($count = $statement->affectedRows($result)) > 0
             );
 
-            return (int)$count;
+            return $count;
         });
     }
 

--- a/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
+++ b/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
@@ -69,4 +69,24 @@ class PostgreSqlSwooleExtConnectionTest extends TestCase
         $this->assertIsNumeric($id);
         $this->assertIsNumeric($id2);
     }
+
+    public function testAffectingStatementWithWrongSql()
+    {
+        if (SWOOLE_MAJOR_VERSION < 5) {
+            $this->markTestSkipped('PostgreSql requires Swoole version >= 5.0.0');
+        }
+
+        $connection = $this->connectionFactory->make([
+            'driver' => 'pgsql-swoole',
+            'host' => '127.0.0.1',
+            'port' => 5432,
+            'database' => 'postgres',
+            'username' => 'postgres',
+            'password' => 'postgres',
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        $connection->affectingStatement('UPDATE xx SET x = 1 WHERE id = 1');
+    }
 }


### PR DESCRIPTION
`TypeError: Hyperf\Database\PgSQL\PostgreSqlSwooleExtConnection::affectingStatement(): Return value must be of type int, bool returned`

The hyperf database method has type hint 'int' but Swoole\Coroutine\PostgreSQLStatement::affectedRows() can return bool https://github.com/swoole/swoole-src/blob/master/ext-src/swoole_postgresql_coro.cc#L1242

Alternative code change: [Line 88](https://github.com/hyperf/hyperf/blob/master/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php#L88) `($count = (int)$statement->affectedRows($result)) > 0`