### PR TITLE
Fixed bug that `KeepaliveConnection::isTimeout()` can't work when using swow.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -169,3 +169,4 @@ composer analyse
 - [#5132](https://github.com/hyperf/hyperf/pull/5132) Fixed bug that the exit code of command does not work when the exception code isn't int.
 - [#5199](https://github.com/hyperf/hyperf/pull/5199) Fixed bug that `RedisSentinel` can't support empty password.
 - [#5221](https://github.com/hyperf/hyperf/pull/5221) Fixed bug that `PGSqlSwooleConnection::affectingStatement()` can't work when the `sql` is wrong.
+- [#5223](https://github.com/hyperf/hyperf/pull/5223) Fixed bug that `KeepaliveConnection::isTimeout()` can't work when using swow.

--- a/src/pool/src/KeepaliveConnection.php
+++ b/src/pool/src/KeepaliveConnection.php
@@ -134,7 +134,7 @@ abstract class KeepaliveConnection implements ConnectionInterface
     public function isTimeout(): bool
     {
         return $this->lastUseTime < microtime(true) - $this->pool->getOption()->getMaxIdleTime()
-            && $this->channel->length() > 0;
+            && $this->channel->getLength() > 0;
     }
 
     protected function addHeartbeat()


### PR DESCRIPTION
``Hyperf\Engine\Contract\ChannelInterface`` 未定义``length``函数，且``length()``是Swoole里独有的，在Swow驱动里未实现。如果在swow里使用了到了这部分就会报错

Contract:https://github.com/hyperf/engine-contract/blob/master/src/ChannelInterface.php#L35
Swow：https://github.com/hyperf/engine-swow/blob/master/src/Channel.php#L73
Swoole: https://github.com/hyperf/engine/blob/master/src/Channel.php#L38
