### PR TITLE
Remove dependencies of `hyperf/metric`

### DIFF
--- a/src/metric/composer.json
+++ b/src/metric/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": ">=8.0",
         "hyperf/contract": "~3.0.0",
-        "hyperf/engine": "^1.5|^2.3",
         "hyperf/guzzle": "~3.0.0",
         "hyperf/utils": "~3.0.0",
         "promphp/prometheus_client_php": "2.2.*",


### PR DESCRIPTION
In Swow:

```bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires hyperf/engine-swow ^2.3 -> satisfiable by hyperf/engine-swow[v2.3.0, 2.3.x-dev].
    - hyperf/metric dev-master requires hyperf/engine ^1.5|^2.3 -> satisfiable by hyperf/engine[v1.5.0, 1.x-dev, v2.3.0, 2.3.x-dev].
    - Only one of these can be installed: hyperf/engine[v1.1.0, ..., 1.x-dev, v2.0.0-beta.1, ..., 2.3.x-dev], hyperf/engine-swow[v2.3.0, 2.3.x-dev]. hyperf/engine-swow replaces hyperf/engine and thus cannot coexist with it.
    - Root composer.json requires hyperf/metric dev-master as 3.0.3 -> satisfiable by hyperf/metric[dev-master].
```