### PR TITLE
Fixed bug that kafka consumer cannot work when don't set `memberId` and so on.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,8 +2,9 @@
 
 ## Fixed
 
-- [#5318](https://github.com/hyperf/hyperf/pull/5318) Fixed bug that rate-limit cannot work when using php 8.1
+- [#5318](https://github.com/hyperf/hyperf/pull/5318) Fixed bug that rate-limit cannot work when using php `8.1`.
 - [#5324](https://github.com/hyperf/hyperf/pull/5324) Fixed bug that database cannot work when disconnect caused by connection reset by mysql.
+- [#5322](https://github.com/hyperf/hyperf/pull/5322) Fixed bug that kafka consumer cannot work when don't set `memberId` and so on.
 
 ## Added
 

--- a/src/kafka/src/AbstractConsumer.php
+++ b/src/kafka/src/AbstractConsumer.php
@@ -22,13 +22,13 @@ abstract class AbstractConsumer
     /**
      * @var string|string[]
      */
-    public string|array $topic;
+    public string|array $topic = [];
 
-    public ?string $groupId;
+    public ?string $groupId = null;
 
-    public ?string $memberId;
+    public ?string $memberId = null;
 
-    public ?string $groupInstanceId;
+    public ?string $groupInstanceId = null;
 
     public bool $autoCommit = true;
 

--- a/src/kafka/src/AbstractConsumer.php
+++ b/src/kafka/src/AbstractConsumer.php
@@ -64,7 +64,7 @@ abstract class AbstractConsumer
 
     public function getMemberId(): ?string
     {
-        return $this->memberId;
+        return $this->memberId ?? null;
     }
 
     public function setMemberId(?string $memberId): void

--- a/src/kafka/src/AbstractConsumer.php
+++ b/src/kafka/src/AbstractConsumer.php
@@ -64,7 +64,7 @@ abstract class AbstractConsumer
 
     public function getMemberId(): ?string
     {
-        return $this->memberId ?? null;
+        return $this->memberId;
     }
 
     public function setMemberId(?string $memberId): void


### PR DESCRIPTION
[bug] [ERROR] Error: Typed property Hyperf\Kafka\AbstractConsumer::$memberId must not be accessed before initialization 

当没设置memberId时 , 会报错