### PR TITLE
Fixed bug that PostgresSQL can't work when create connection timed out.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - [#5318](https://github.com/hyperf/hyperf/pull/5318) Fixed bug that rate-limit cannot work when using php `8.1`.
 - [#5324](https://github.com/hyperf/hyperf/pull/5324) Fixed bug that database cannot work when disconnect caused by connection reset by mysql.
 - [#5322](https://github.com/hyperf/hyperf/pull/5322) Fixed bug that kafka consumer cannot work when don't set `memberId` and so on.
+- [#5327](https://github.com/hyperf/hyperf/pull/5327) Fixed bug that PostgresSQL can't work when create connection timed out.
 
 ## Added
 

--- a/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
+++ b/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
@@ -57,7 +57,7 @@ class PostgresSqlSwooleExtConnector implements ConnectorInterface
         ));
 
         if ($result === false) {
-            throw new Exception($connection->error ?? 'Connection timed out, Please check the database configuration.');
+            throw new Exception($connection->error ?? 'Connection failed, Please check the database configuration.');
         }
 
         return $connection;

--- a/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
+++ b/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
@@ -57,7 +57,7 @@ class PostgresSqlSwooleExtConnector implements ConnectorInterface
         ));
 
         if ($result === false) {
-            throw new Exception($connection->error ?? 'Connection failed, Please check the database configuration.');
+            throw new Exception($connection->error ?? 'Create connection failed, Please check the database configuration.');
         }
 
         return $connection;

--- a/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
+++ b/src/database-pgsql/src/Connectors/PostgresSqlSwooleExtConnector.php
@@ -57,7 +57,7 @@ class PostgresSqlSwooleExtConnector implements ConnectorInterface
         ));
 
         if ($result === false) {
-            throw new Exception($connection->error);
+            throw new Exception($connection->error ?? 'Connection timed out, Please check the database configuration.');
         }
 
         return $connection;

--- a/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
+++ b/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
@@ -107,7 +107,7 @@ class PostgreSqlSwooleExtConnectionTest extends TestCase
         ]);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Connection timed out, Please check the database configuration.');
+        $this->expectExceptionMessage('Create connection failed, Please check the database configuration.');
 
         $connection->affectingStatement('UPDATE xx SET x = 1 WHERE id = 1');
     }

--- a/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
+++ b/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Database\PgSQL\Cases;
 
+use Exception;
 use Hyperf\Database\Connection;
 use Hyperf\Database\Connectors\ConnectionFactory;
 use Hyperf\Database\Exception\QueryException;
@@ -105,7 +106,7 @@ class PostgreSqlSwooleExtConnectionTest extends TestCase
             'password' => 'postgres',
         ]);
 
-        $this->expectException(QueryException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Connection timed out, Please check the database configuration.');
 
         $connection->affectingStatement('UPDATE xx SET x = 1 WHERE id = 1');

--- a/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
+++ b/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
@@ -89,4 +89,25 @@ class PostgreSqlSwooleExtConnectionTest extends TestCase
 
         $connection->affectingStatement('UPDATE xx SET x = 1 WHERE id = 1');
     }
+
+    public function testCreateConnectionTimedOut()
+    {
+        if (SWOOLE_MAJOR_VERSION < 5) {
+            $this->markTestSkipped('PostgreSql requires Swoole version >= 5.0.0');
+        }
+
+        $connection = $this->connectionFactory->make([
+            'driver' => 'pgsql-swoole',
+            'host' => 'non-existent-host.internal',
+            'port' => 5432,
+            'database' => 'postgres',
+            'username' => 'postgres',
+            'password' => 'postgres',
+        ]);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Connection timed out, Please check the database configuration.');
+
+        $connection->affectingStatement('UPDATE xx SET x = 1 WHERE id = 1');
+    }
 }


### PR DESCRIPTION
Fixed #5321 

连接数据库超时的时候，`connection` 中的错误信息为 null 导致抛出异常时报错。