### PR TITLE
Fixed bug that `PgSQLSwooleConnection::unprepared` cannot work.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- [#5332](https://github.com/hyperf/hyperf/pull/5332) Fixed bug that `PgSQLSwooleConnection::unprepared` cannot work.
 - [#5333](https://github.com/hyperf/hyperf/pull/5333) Fixed bug that database cannot work when disconnect failed.
 
 # v3.0.3 - 2023-01-16

--- a/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
+++ b/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
@@ -175,6 +175,21 @@ class PostgreSqlSwooleExtConnection extends Connection
         return substr_replace($haystack, $replace, $pos, strlen($needle));
     }
 
+    public function unprepared(string $query): bool
+    {
+        return $this->run($query, [], function ($query) {
+            if ($this->pretending()) {
+                return true;
+            }
+
+            $this->recordsHaveBeenModified(
+                $change = $this->getPdo()->query($query) !== false
+            );
+
+            return $change;
+        });
+    }
+
     /**
      * Get the default query grammar instance.
      * @return \Hyperf\Database\Grammar

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -387,7 +387,7 @@ class Connection implements ConnectionInterface
             }
 
             $this->recordsHaveBeenModified(
-                $change = $this->getPdo()->exec($query) !== false
+                $change = $this->getPdo()->query($query) !== false
             );
 
             return $change;

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -386,7 +386,7 @@ class Connection implements ConnectionInterface
             }
 
             $this->recordsHaveBeenModified(
-                $change = $this->getPdo()->query($query) !== false
+                $change = $this->getPdo()->exec($query) !== false
             );
 
             return $change;


### PR DESCRIPTION
Not sure what the correct fix should be... other PDO drivers might have `exec` method, but  [Swoole\Coroutine\PostgreSQL does not](https://github.com/swoole/swoole-src/blob/master/ext-src/swoole_postgresql_coro.cc#L396)

```log
[ERROR] Error: Call to undefined method Swoole\Coroutine\PostgreSQL::exec() in /opt/www/vendor/hyperf/database/src/Connection.php:390
Stack trace:
#0 /opt/www/vendor/hyperf/database/src/Connection.php(1054): Hyperf\Database\Connection->Hyperf\Database\{closure}()
#1 /opt/www/vendor/hyperf/database/src/Connection.php(1018): Hyperf\Database\Connection->runQueryCallback()
#2 /opt/www/vendor/hyperf/database/src/Connection.php(394): Hyperf\Database\Connection->run()
#3 /opt/www/vendor/hyperf/db-connection/src/Connection.php(48): Hyperf\Database\Connection->unprepared()
#4 /opt/www/vendor/hyperf/db-connection/src/Traits/DbConnection.php(76): Hyperf\DbConnection\Connection->__call()
#5 /opt/www/vendor/hyperf/db-connection/src/Db.php(66): Hyperf\DbConnection\Connection->unprepared()
#6 /opt/www/migrations/2023_01_18_181219_create_scrape_log_table.php(24): Hyperf\DbConnection\Db::__callStatic()
#7 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(451): CreateScrapeLogTable->up()
#8 /opt/www/vendor/hyperf/database-pgsql/src/Concerns/PostgreSqlSwooleExtManagesTransactions.php(34): Hyperf\Database\Migrations\Migrator->Hyperf\Database\Migrations\{closure}()
#9 /opt/www/vendor/hyperf/db-connection/src/Connection.php(48): Hyperf\Database\PgSQL\PostgreSqlSwooleExtConnection->transaction()
#10 /opt/www/vendor/hyperf/db-connection/src/Traits/DbConnection.php(86): Hyperf\DbConnection\Connection->__call()
#11 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(459): Hyperf\DbConnection\Connection->transaction()
#12 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(327): Hyperf\Database\Migrations\Migrator->runMigration()
#13 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(114): Hyperf\Database\Migrations\Migrator->runUp()
#14 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(80): Hyperf\Database\Migrations\Migrator->runPending()
#15 /opt/www/vendor/hyperf/database/src/Commands/Migrations/MigrateCommand.php(48): Hyperf\Database\Migrations\Migrator->run()
#16 /opt/www/vendor/hyperf/command/src/Command.php(423): Hyperf\Database\Commands\Migrations\MigrateCommand->handle()
#17 [internal function]: Hyperf\Command\Command->Hyperf\Command\{closure}()
#18 {main}
```

A few other calls in the source to consider:
- hyperf/database/src/Concerns/ManagesTransactions.php
    - [ManagesTransactions.php:182](https://github.com/hyperf/hyperf/blob/master/src/database/src/Concerns/ManagesTransactions.php#L182)
    - [ManagesTransactions.php:215](https://github.com/hyperf/hyperf/blob/master/src/database/src/Concerns/ManagesTransactions.php#L215)
- hyperf/database-pgsql/src/Concerns/PostgreSqlSwooleExtManagesTransactions.php
    - [PostgreSqlSwooleExtManagesTransactions.php:182](https://github.com/hyperf/hyperf/blob/master/src/database-pgsql/src/Concerns/PostgreSqlSwooleExtManagesTransactions.php#L182)
    - [PostgreSqlSwooleExtManagesTransactions.php:215](https://github.com/hyperf/hyperf/blob/master/src/database-pgsql/src/Concerns/PostgreSqlSwooleExtManagesTransactions.php#L215)