### PR TITLE
Fix the bug that nacos no output error log when heartbeat timed out.

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,4 +1,8 @@
-# v2.2.36 - TBD
+# v2.2.39 - TBD
+
+# v2.2.38 - 2023-02-09
+
+- [#5359](https://github.com/hyperf/hyperf/pull/5359) Fixed the bug that nacos no output error log when heartbeat timed out.
 
 # v2.2.35 - 2022-08-27
 


### PR DESCRIPTION
问题描述：当请求 nacos server 失败时 guzzlehttp 会抛出异常，然后被 retry 函数捕获到后直接进行重试，导致没有输出错误日志。

Fixed #5350 