### PR TITLE
Fixed bug that the current service XXX is persistent service, can't register ephemeral instance.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.6 - TBD
 
+## Fixed
+
+- [#5361](https://github.com/hyperf/hyperf/pull/5361) Fixed bug that the current service XXX is persistent service, can't register ephemeral instance.
+
 ## Added
 
 - [#5366](https://github.com/hyperf/hyperf/pull/5366) Added `forceDeleting` event to `hyperf/database`.

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -94,7 +94,7 @@ class NacosDriver implements DriverInterface
             'groupName' => $this->config->get('services.drivers.nacos.group_name'),
             'namespaceId' => $this->config->get('services.drivers.nacos.namespace_id'),
             'metadata' => $this->getMetadata($name),
-            'ephemeral' => $ephemeral ? 'true' : null,
+            'ephemeral' => $ephemeral ? 'true' : 'false',
         ]);
 
         if ($response->getStatusCode() !== 200 || (string) $response->getBody() !== 'ok') {


### PR DESCRIPTION
Fixed bug that the server response errCode: 400, errMsg: Current service XXX is persistent service, can't register ephemeral instance when register persistent service to the nacos server.