### PR TITLE
fix Fatal error: Uncaught Hyperf\Di\Exception\InvalidDefinitionExcept…

### DIFF
--- a/src/config-apollo/src/ApolloDriver.php
+++ b/src/config-apollo/src/ApolloDriver.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Hyperf\ConfigApollo;
 
 use Hyperf\ConfigCenter\AbstractDriver;
-use Hyperf\ConfigCenter\Contract\ClientInterface;
 use Hyperf\Coordinator\Constants;
 use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Engine\Channel;
@@ -26,11 +25,6 @@ class ApolloDriver extends AbstractDriver
     protected string $driverName = 'apollo';
 
     protected array $notifications = [];
-
-    /**
-     * @var \Hyperf\ConfigApollo\ClientInterface
-     */
-    protected ClientInterface $client;
 
     public function __construct(ContainerInterface $container)
     {


### PR DESCRIPTION
fix Fatal error: Uncaught Hyperf\Di\Exception\InvalidDefinitionException: Entry "Hyperf\ConfigApollo\ApolloDriver" cannot be resolved: Entry "Hyperf\ConfigCenter\Contract\ClientInterface" cannot be resolved: the class is not instantiable