### PR TITLE
fix: 修复redis中getAuth方法返回null与mixSubscribe参数类型不一致

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,8 +3,9 @@
 ## Fixed
 
 - [#5361](https://github.com/hyperf/hyperf/pull/5361) Fixed bug that the current service XXX is persistent service, can't register ephemeral instance.
-- [#5394](https://github.com/hyperf/hyperf/pull/5394) Fixed bug that `hyperf/config-apollo` cannot work.
+- [#5382](https://github.com/hyperf/hyperf/pull/5382) Fixed bug that mix-subscriber cannot work caused by the empty auth.
 - [#5386](https://github.com/hyperf/hyperf/pull/5386) Fixed bug that non-existing method `exec` called by `SwoolePostgresqlClient`.
+- [#5394](https://github.com/hyperf/hyperf/pull/5394) Fixed bug that `hyperf/config-apollo` cannot work.
 
 ## Added
 

--- a/src/socketio-server/src/Room/RedisAdapter.php
+++ b/src/socketio-server/src/Room/RedisAdapter.php
@@ -334,7 +334,7 @@ class RedisAdapter implements AdapterInterface, EphemeralInterface
         $sub = make(Subscriber::class, [
             'host' => $this->redis->getHost(),
             'port' => $this->redis->getPort(),
-            'password' => $this->redis->getAuth(),
+            'password' => $this->redis->getAuth() ?: '',
             'timeout' => 5,
         ]);
         $prefix = $this->redis->getOption(Redis::OPT_PREFIX);


### PR DESCRIPTION
当redis密码为空时，redis中getAuth返回值为null,而Subscriber参数类型限制为string，启动时报错:
[ERROR] TypeError: Mix\Redis\Subscriber\Subscriber::__construct(): Argument #3 ($password) must be of type string, null given, called in /***/vendor/hyperf/di/src/Resolver/ObjectResolver.php on line 84 and defined in /***/vendor/mix/redis-subscriber/src/Subscriber.php:65