### PR TITLE
Adds `mixin` method to `Model\Builder`

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - [#5042](https://github.com/hyperf/hyperf/pull/5402) Added `swagger.scan.paths` to rewrite `scan paths` for swagger.
 - [#5403](https://github.com/hyperf/hyperf/pull/5403) Support swoole server settings for swow server.
 - [#5404](https://github.com/hyperf/hyperf/pull/5404) Support multiport server for swagger.
+- [#5406](https://github.com/hyperf/hyperf/pull/5406) Added `mixin` method to `Hyperf\Database\Model\Builder`.
 
 # v3.0.6 - 2023-02-12
 

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -128,13 +128,13 @@ class Builder
             return static::registerMixin($parameters[0], $parameters[1] ?? true);
         }
 
-        if (isset($this->localMacros[$method])) {
+        if ($this->hasMacro($method)) {
             array_unshift($parameters, $this);
 
             return $this->localMacros[$method](...$parameters);
         }
 
-        if (isset(static::$macros[$method])) {
+        if (static::hasGlobalMacro($method)) {
             if (static::$macros[$method] instanceof Closure) {
                 return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
             }
@@ -175,7 +175,7 @@ class Builder
             return static::registerMixin($parameters[0], $parameters[1] ?? true);
         }
 
-        if (! isset(static::$macros[$method])) {
+        if (! static::hasGlobalMacro($method)) {
             static::throwBadMethodCallException($method);
         }
 

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -24,6 +24,8 @@ use Hyperf\Utils\Arr;
 use Hyperf\Utils\Str;
 use Hyperf\Utils\Traits\ForwardsCalls;
 use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @mixin \Hyperf\Database\Query\Builder
@@ -122,6 +124,10 @@ class Builder
             return;
         }
 
+        if ($method === 'mixin') {
+            return static::registerMixin($parameters[0], $parameters[1] ?? true);
+        }
+
         if (isset($this->localMacros[$method])) {
             array_unshift($parameters, $this);
 
@@ -163,6 +169,10 @@ class Builder
             static::$macros[$parameters[0]] = $parameters[1];
 
             return;
+        }
+
+        if ($method === 'mixin') {
+            return static::registerMixin($parameters[0], $parameters[1] ?? true);
         }
 
         if (! isset(static::$macros[$method])) {
@@ -1087,6 +1097,60 @@ class Builder
     public function getMacro($name)
     {
         return Arr::get($this->localMacros, $name);
+    }
+
+    /**
+     * Checks if a macro is registered.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function hasMacro($name)
+    {
+        return isset($this->localMacros[$name]);
+    }
+
+    /**
+     * Get the given global macro by name.
+     *
+     * @param string $name
+     * @return Closure
+     */
+    public static function getGlobalMacro($name)
+    {
+        return Arr::get(static::$macros, $name);
+    }
+
+    /**
+     * Checks if a global macro is registered.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public static function hasGlobalMacro($name)
+    {
+        return isset(static::$macros[$name]);
+    }
+
+    /**
+     * Register the given mixin with the builder.
+     *
+     * @param string $mixin
+     * @param bool $replace
+     */
+    protected static function registerMixin($mixin, $replace)
+    {
+        $methods = (new ReflectionClass($mixin))->getMethods(
+            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
+        );
+
+        foreach ($methods as $method) {
+            if ($replace || ! static::hasGlobalMacro($method->name)) {
+                $method->setAccessible(true);
+
+                static::macro($method->name, $method->invoke($mixin));
+            }
+        }
     }
 
     /**

--- a/src/database/tests/ModelBuilderTest.php
+++ b/src/database/tests/ModelBuilderTest.php
@@ -1174,6 +1174,14 @@ class ModelBuilderTest extends TestCase
         $builder->withCasts(['foo' => 'bar']);
     }
 
+    public function testMixin()
+    {
+        ModelStub::mixin(new UserMixin());
+
+        $this->assertInstanceOf(\Hyperf\Database\Model\Builder::class, ModelStub::whereFoo());
+        $this->assertInstanceOf(\Hyperf\Database\Model\Builder::class, ModelStub::whereBar());
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Hyperf\Database\Query\Grammars\\' . $database . 'Grammar';
@@ -1206,6 +1214,19 @@ class ModelBuilderTest extends TestCase
         $query->shouldReceive('from')->with('foo_table');
 
         return $query;
+    }
+}
+
+class UserMixin
+{
+    public function whereFoo()
+    {
+        return fn () => $this;
+    }
+
+    public function whereBar()
+    {
+        return fn () => $this;
     }
 }
 

--- a/src/database/tests/ModelBuilderTest.php
+++ b/src/database/tests/ModelBuilderTest.php
@@ -1176,7 +1176,10 @@ class ModelBuilderTest extends TestCase
 
     public function testMixin()
     {
-        ModelStub::mixin(new UserMixin());
+        \Hyperf\Database\Model\Builder::macro('testAbc', fn () => 'abc');
+        $this->assertEquals('abc', ModelStub::testAbc());
+
+        \Hyperf\Database\Model\Builder::mixin(new UserMixin());
 
         $this->assertInstanceOf(\Hyperf\Database\Model\Builder::class, ModelStub::whereFoo());
         $this->assertInstanceOf(\Hyperf\Database\Model\Builder::class, ModelStub::whereBar());


### PR DESCRIPTION
因为 `@mixin \Hyperf\Database\Query\Builder`，IDE 提示有 `mixin` 方法，但 `Hyperf\Database\Model\Builder` 并未实现，所以补充上。