### PR TITLE
Fix database about boolean types for where in the json type

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,7 +15,7 @@
 
 - [#5405](https://github.com/hyperf/hyperf/pull/5405) Fixed get local ip error when IPv6 exists.
 - [#5417](https://github.com/hyperf/hyperf/pull/5417) Fixed bug that database-pgsql does not support migration.
-- [#5421](https://github.com/hyperf/hyperf/pull/5421) Fix database about boolean types for where in the json type
+- [#5421](https://github.com/hyperf/hyperf/pull/5421) Fixed database about boolean types for where in the json type
 
 ## Optimized
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,6 +15,7 @@
 
 - [#5405](https://github.com/hyperf/hyperf/pull/5405) Fixed get local ip error when IPv6 exists.
 - [#5417](https://github.com/hyperf/hyperf/pull/5417) Fixed bug that database-pgsql does not support migration.
+- [#5421](https://github.com/hyperf/hyperf/pull/5421) Fix database about boolean types for where in the json type
 
 ## Optimized
 

--- a/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
@@ -33,24 +33,31 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an insert ignore statement into SQL.
+     *
+     * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values): string
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         return $this->compileInsert($query, $values) . ' on conflict do nothing';
     }
 
     /**
      * Compile an insert and get ID statement into SQL.
+     *
+     * @param array $values
+     * @param string $sequence
      */
-    public function compileInsertGetId(Builder $query, array $values, string $sequence): string
+    public function compileInsertGetId(Builder $query, $values, $sequence): string
     {
         return $this->compileInsert($query, $values) . ' returning ' . $this->wrap($sequence ?: 'id');
     }
 
     /**
      * Compile an update statement into SQL.
+     *
+     * @param mixed $values
      */
-    public function compileUpdate(Builder $query, array $values): string
+    public function compileUpdate(Builder $query, $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -68,8 +75,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an "upsert" statement into SQL.
+     *
+     * @return string
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update): string
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
         $sql = $this->compileInsert($query, $values);
 
@@ -86,8 +95,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Prepare the bindings for an update statement.
+     *
+     * @return array
      */
-    public function prepareBindingsForUpdateFrom(array $bindings, array $values): array
+    public function prepareBindingsForUpdateFrom(array $bindings, array $values)
     {
         $values = collect($values)->map(function ($value, $column) {
             return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
@@ -142,8 +153,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an update from statement into SQL.
+     *
+     * @return string
      */
-    protected function compileUpdateFrom(Builder $query): string
+    protected function compileUpdateFrom(Builder $query)
     {
         if (! isset($query->joins)) {
             return '';
@@ -159,13 +172,14 @@ class PostgresGrammar extends Grammar
         if (count($froms) > 0) {
             return ' from ' . implode(', ', $froms);
         }
-        return '';
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param array $where
      */
-    protected function whereBasic(Builder $query, array $where): string
+    protected function whereBasic(Builder $query, $where): string
     {
         if (Str::contains(strtolower($where['operator']), 'like')) {
             return sprintf(
@@ -181,8 +195,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "where date" clause.
+     *
+     * @param array $where
      */
-    protected function whereDate(Builder $query, array $where): string
+    protected function whereDate(Builder $query, $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -191,8 +207,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "where time" clause.
+     *
+     * @param array $where
      */
-    protected function whereTime(Builder $query, array $where): string
+    protected function whereTime(Builder $query, $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -201,8 +219,11 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a date based where clause.
+     *
+     * @param string $type
+     * @param array $where
      */
-    protected function dateBasedWhere(string $type, Builder $query, array $where): string
+    protected function dateBasedWhere($type, Builder $query, $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -211,8 +232,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the "select *" portion of the query.
+     *
+     * @param array $columns
      */
-    protected function compileColumns(Builder $query, array $columns): ?string
+    protected function compileColumns(Builder $query, $columns): ?string
     {
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
@@ -234,8 +257,11 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "JSON contains" statement into SQL.
+     *
+     * @param string $column
+     * @param string $value
      */
-    protected function compileJsonContains(string $column, string $value): string
+    protected function compileJsonContains($column, $value): string
     {
         $column = str_replace('->>', '->', $this->wrap($column));
 
@@ -244,8 +270,12 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "JSON length" statement into SQL.
+     *
+     * @param string $column
+     * @param string $operator
+     * @param string $value
      */
-    protected function compileJsonLength(string $column, string $operator, string $value): string
+    protected function compileJsonLength($column, $operator, $value): string
     {
         $column = str_replace('->>', '->', $this->wrap($column));
 
@@ -254,8 +284,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the lock into SQL.
+     *
+     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, bool|string $value): string
+    protected function compileLock(Builder $query, $value): string
     {
         if (! is_string($value)) {
             return $value ? 'for update' : 'for share';
@@ -266,8 +298,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the columns for an update statement.
+     *
+     * @return string
      */
-    protected function compileUpdateColumns(Builder $query, array $values): string
+    protected function compileUpdateColumns(Builder $query, array $values)
     {
         return collect($values)->map(function ($value, $key) {
             $column = last(explode('.', $key));
@@ -282,8 +316,12 @@ class PostgresGrammar extends Grammar
 
     /**
      * Prepares a JSON column being updated using the JSONB_SET function.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return string
      */
-    protected function compileJsonUpdateColumn(string $key, mixed $value): string
+    protected function compileJsonUpdateColumn($key, $value)
     {
         $segments = explode('->', $key);
 
@@ -296,8 +334,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the additional where clauses for updates with joins.
+     *
+     * @return string
      */
-    protected function compileUpdateWheres(Builder $query): string
+    protected function compileUpdateWheres(Builder $query)
     {
         $baseWheres = $this->compileWheres($query);
 
@@ -319,8 +359,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the "join" clause where clauses for an update.
+     *
+     * @return string
      */
-    protected function compileUpdateJoinWheres(Builder $query): string
+    protected function compileUpdateJoinWheres(Builder $query)
     {
         $joinWheres = [];
 
@@ -340,8 +382,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an update statement with joins or limit into SQL.
+     *
+     * @return string
      */
-    protected function compileUpdateWithJoinsOrLimit(Builder $query, array $values): string
+    protected function compileUpdateWithJoinsOrLimit(Builder $query, array $values)
     {
         $table = $this->wrapTable($query->from);
 
@@ -356,8 +400,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a delete statement with joins or limit into SQL.
+     *
+     * @return string
      */
-    protected function compileDeleteWithJoinsOrLimit(Builder $query): string
+    protected function compileDeleteWithJoinsOrLimit(Builder $query)
     {
         $table = $this->wrapTable($query->from);
 
@@ -370,8 +416,10 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector.
+     *
+     * @param string $value
      */
-    protected function wrapJsonSelector(string $value): string
+    protected function wrapJsonSelector($value): string
     {
         $path = explode('->', $value);
 
@@ -390,8 +438,11 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector for boolean values.
+     *
+     * @param string $value
+     * @return string
      */
-    protected function wrapJsonBooleanSelector(string $value): string
+    protected function wrapJsonBooleanSelector($value)
     {
         $selector = str_replace(
             '->>',
@@ -404,16 +455,22 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON boolean value.
+     *
+     * @param string $value
+     * @return string
      */
-    protected function wrapJsonBooleanValue(string $value): string
+    protected function wrapJsonBooleanValue($value)
     {
         return "'" . $value . "'::jsonb";
     }
 
     /**
      * Wrap the attributes of the give JSON path.
+     *
+     * @param array $path
+     * @return array
      */
-    protected function wrapJsonPathAttributes(array $path): array
+    protected function wrapJsonPathAttributes($path)
     {
         return array_map(function ($attribute) {
             return filter_var($attribute, FILTER_VALIDATE_INT) !== false

--- a/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
@@ -33,31 +33,24 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an insert ignore statement into SQL.
-     *
-     * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values): string
     {
         return $this->compileInsert($query, $values) . ' on conflict do nothing';
     }
 
     /**
      * Compile an insert and get ID statement into SQL.
-     *
-     * @param array $values
-     * @param string $sequence
      */
-    public function compileInsertGetId(Builder $query, $values, $sequence): string
+    public function compileInsertGetId(Builder $query, array $values, string $sequence): string
     {
         return $this->compileInsert($query, $values) . ' returning ' . $this->wrap($sequence ?: 'id');
     }
 
     /**
      * Compile an update statement into SQL.
-     *
-     * @param mixed $values
      */
-    public function compileUpdate(Builder $query, $values): string
+    public function compileUpdate(Builder $query, array $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -75,10 +68,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an "upsert" statement into SQL.
-     *
-     * @return string
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update): string
     {
         $sql = $this->compileInsert($query, $values);
 
@@ -95,10 +86,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Prepare the bindings for an update statement.
-     *
-     * @return array
      */
-    public function prepareBindingsForUpdateFrom(array $bindings, array $values)
+    public function prepareBindingsForUpdateFrom(array $bindings, array $values): array
     {
         $values = collect($values)->map(function ($value, $column) {
             return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
@@ -153,10 +142,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an update from statement into SQL.
-     *
-     * @return string
      */
-    protected function compileUpdateFrom(Builder $query)
+    protected function compileUpdateFrom(Builder $query): string
     {
         if (! isset($query->joins)) {
             return '';
@@ -172,14 +159,13 @@ class PostgresGrammar extends Grammar
         if (count($froms) > 0) {
             return ' from ' . implode(', ', $froms);
         }
+        return '';
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @param array $where
      */
-    protected function whereBasic(Builder $query, $where): string
+    protected function whereBasic(Builder $query, array $where): string
     {
         if (Str::contains(strtolower($where['operator']), 'like')) {
             return sprintf(
@@ -195,10 +181,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "where date" clause.
-     *
-     * @param array $where
      */
-    protected function whereDate(Builder $query, $where): string
+    protected function whereDate(Builder $query, array $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -207,10 +191,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "where time" clause.
-     *
-     * @param array $where
      */
-    protected function whereTime(Builder $query, $where): string
+    protected function whereTime(Builder $query, array $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -219,11 +201,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a date based where clause.
-     *
-     * @param string $type
-     * @param array $where
      */
-    protected function dateBasedWhere($type, Builder $query, $where): string
+    protected function dateBasedWhere(string $type, Builder $query, array $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -232,10 +211,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the "select *" portion of the query.
-     *
-     * @param array $columns
      */
-    protected function compileColumns(Builder $query, $columns): ?string
+    protected function compileColumns(Builder $query, array $columns): ?string
     {
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
@@ -257,11 +234,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "JSON contains" statement into SQL.
-     *
-     * @param string $column
-     * @param string $value
      */
-    protected function compileJsonContains($column, $value): string
+    protected function compileJsonContains(string $column, string $value): string
     {
         $column = str_replace('->>', '->', $this->wrap($column));
 
@@ -270,12 +244,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a "JSON length" statement into SQL.
-     *
-     * @param string $column
-     * @param string $operator
-     * @param string $value
      */
-    protected function compileJsonLength($column, $operator, $value): string
+    protected function compileJsonLength(string $column, string $operator, string $value): string
     {
         $column = str_replace('->>', '->', $this->wrap($column));
 
@@ -284,10 +254,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the lock into SQL.
-     *
-     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, $value): string
+    protected function compileLock(Builder $query, bool|string $value): string
     {
         if (! is_string($value)) {
             return $value ? 'for update' : 'for share';
@@ -298,10 +266,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the columns for an update statement.
-     *
-     * @return string
      */
-    protected function compileUpdateColumns(Builder $query, array $values)
+    protected function compileUpdateColumns(Builder $query, array $values): string
     {
         return collect($values)->map(function ($value, $key) {
             $column = last(explode('.', $key));
@@ -316,12 +282,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Prepares a JSON column being updated using the JSONB_SET function.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @return string
      */
-    protected function compileJsonUpdateColumn($key, $value)
+    protected function compileJsonUpdateColumn(string $key, mixed $value): string
     {
         $segments = explode('->', $key);
 
@@ -334,10 +296,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the additional where clauses for updates with joins.
-     *
-     * @return string
      */
-    protected function compileUpdateWheres(Builder $query)
+    protected function compileUpdateWheres(Builder $query): string
     {
         $baseWheres = $this->compileWheres($query);
 
@@ -359,10 +319,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile the "join" clause where clauses for an update.
-     *
-     * @return string
      */
-    protected function compileUpdateJoinWheres(Builder $query)
+    protected function compileUpdateJoinWheres(Builder $query): string
     {
         $joinWheres = [];
 
@@ -382,10 +340,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile an update statement with joins or limit into SQL.
-     *
-     * @return string
      */
-    protected function compileUpdateWithJoinsOrLimit(Builder $query, array $values)
+    protected function compileUpdateWithJoinsOrLimit(Builder $query, array $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -400,10 +356,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a delete statement with joins or limit into SQL.
-     *
-     * @return string
      */
-    protected function compileDeleteWithJoinsOrLimit(Builder $query)
+    protected function compileDeleteWithJoinsOrLimit(Builder $query): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -416,10 +370,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector.
-     *
-     * @param string $value
      */
-    protected function wrapJsonSelector($value): string
+    protected function wrapJsonSelector(string $value): string
     {
         $path = explode('->', $value);
 
@@ -438,11 +390,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector for boolean values.
-     *
-     * @param string $value
-     * @return string
      */
-    protected function wrapJsonBooleanSelector($value)
+    protected function wrapJsonBooleanSelector(string $value): string
     {
         $selector = str_replace(
             '->>',
@@ -455,22 +404,16 @@ class PostgresGrammar extends Grammar
 
     /**
      * Wrap the given JSON boolean value.
-     *
-     * @param string $value
-     * @return string
      */
-    protected function wrapJsonBooleanValue($value)
+    protected function wrapJsonBooleanValue(string $value): string
     {
         return "'" . $value . "'::jsonb";
     }
 
     /**
      * Wrap the attributes of the give JSON path.
-     *
-     * @param array $path
-     * @return array
      */
-    protected function wrapJsonPathAttributes($path)
+    protected function wrapJsonPathAttributes(array $path): array
     {
         return array_map(function ($attribute) {
             return filter_var($attribute, FILTER_VALIDATE_INT) !== false

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -656,7 +656,7 @@ class Builder
         // is a boolean. If it is, we'll add the raw boolean string as an actual
         // value to the query to ensure this is properly handled by the query.
         if (Str::contains((string) $column, '->') && is_bool($value)) {
-            $value = new Expression($value ? 'true' : 'false');
+            $value = $value ? 'true' : 'false';
         }
 
         // Now that we are working with just a simple query we can put the elements

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -652,18 +652,22 @@ class Builder
             return $this->whereNull($column, $boolean, $operator !== '=');
         }
 
+        $type = 'Basic';
+
         // If the column is making a JSON reference we'll check to see if the value
         // is a boolean. If it is, we'll add the raw boolean string as an actual
         // value to the query to ensure this is properly handled by the query.
         if (Str::contains((string) $column, '->') && is_bool($value)) {
-            $value = $value ? 'true' : 'false';
+            $value = new Expression($value ? 'true' : 'false');
+
+            if (is_string($column)) {
+                $type = 'JsonBoolean';
+            }
         }
 
         // Now that we are working with just a simple query we can put the elements
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
-        $type = 'Basic';
-
         $this->wheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
         if (! $value instanceof Expression) {

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -78,16 +78,21 @@ class Grammar extends BaseGrammar
 
     /**
      * Prepare the binding for a "JSON contains" statement.
+     *
+     * @param mixed $binding
+     * @return string
      */
-    public function prepareBindingForJsonContains(mixed $binding): string
+    public function prepareBindingForJsonContains($binding)
     {
         return json_encode($binding);
     }
 
     /**
      * Compile the random statement into SQL.
+     *
+     * @param string $seed
      */
-    public function compileRandom(string $seed): string
+    public function compileRandom($seed): string
     {
         return 'RANDOM()';
     }
@@ -138,8 +143,11 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an insert and get ID statement into SQL.
+     *
+     * @param array $values
+     * @param string $sequence
      */
-    public function compileInsertGetId(Builder $query, array $values, string $sequence): string
+    public function compileInsertGetId(Builder $query, $values, $sequence): string
     {
         return $this->compileInsert($query, $values);
     }
@@ -154,8 +162,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an update statement into SQL.
+     *
+     * @param array $values
      */
-    public function compileUpdate(Builder $query, array $values): string
+    public function compileUpdate(Builder $query, $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -231,16 +241,20 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the SQL statement to define a savepoint.
+     *
+     * @param string $name
      */
-    public function compileSavepoint(string $name): string
+    public function compileSavepoint($name): string
     {
         return 'SAVEPOINT ' . $name;
     }
 
     /**
      * Compile the SQL statement to execute a savepoint rollback.
+     *
+     * @param string $name
      */
-    public function compileSavepointRollBack(string $name): string
+    public function compileSavepointRollBack($name): string
     {
         return 'ROLLBACK TO SAVEPOINT ' . $name;
     }
@@ -249,8 +263,9 @@ class Grammar extends BaseGrammar
      * Wrap a value in keyword identifiers.
      *
      * @param bool $prefixAlias
+     * @return string
      */
-    public function wrap(Expression|string $value, $prefixAlias = false): string
+    public function wrap(Expression|string $value, $prefixAlias = false)
     {
         if ($this->isExpression($value)) {
             return $this->getValue($value);
@@ -304,8 +319,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an aggregated select clause.
+     *
+     * @param array $aggregate
      */
-    protected function compileAggregate(Builder $query, array $aggregate): string
+    protected function compileAggregate(Builder $query, $aggregate): string
     {
         $column = $this->columnize($aggregate['columns']);
 
@@ -321,8 +338,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "select *" portion of the query.
+     *
+     * @param array $columns
      */
-    protected function compileColumns(Builder $query, array $columns): ?string
+    protected function compileColumns(Builder $query, $columns): ?string
     {
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
@@ -338,8 +357,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "from" portion of the query.
+     *
+     * @param string $table
      */
-    protected function compileFrom(Builder $query, string $table): string
+    protected function compileFrom(Builder $query, $table): string
     {
         if ($query->forceIndexes) {
             $forceIndexes = [];
@@ -354,8 +375,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "join" portions of the query.
+     *
+     * @param array $joins
      */
-    protected function compileJoins(Builder $query, array $joins): string
+    protected function compileJoins(Builder $query, $joins): string
     {
         return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
@@ -392,8 +415,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Get an array of all the where clauses for the query.
+     *
+     * @param \Hyperf\Database\Query\Builder $query
      */
-    protected function compileWheresToArray(Builder $query): array
+    protected function compileWheresToArray($query): array
     {
         return collect($query->wheres)->map(function ($where) use ($query) {
             return $where['boolean'] . ' ' . $this->{"where{$where['type']}"}($query, $where);
@@ -402,8 +427,11 @@ class Grammar extends BaseGrammar
 
     /**
      * Format the where clause statements into one string.
+     *
+     * @param \Hyperf\Database\Query\Builder $query
+     * @param array $sql
      */
-    protected function concatenateWhereClauses(Builder $query, array $sql): string
+    protected function concatenateWhereClauses($query, $sql): string
     {
         $conjunction = $query instanceof JoinClause ? 'on' : 'where';
 
@@ -412,16 +440,21 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a raw where clause.
+     *
+     * @param array $where
+     * @return string
      */
-    protected function whereRaw(Builder $query, array $where): string
+    protected function whereRaw(Builder $query, $where)
     {
         return $where['sql'];
     }
 
     /**
      * Compile a basic where clause.
+     *
+     * @param array $where
      */
-    protected function whereBasic(Builder $query, array $where): string
+    protected function whereBasic(Builder $query, $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -460,8 +493,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where in" clause.
+     *
+     * @param array $where
      */
-    protected function whereIn(Builder $query, array $where): string
+    protected function whereIn(Builder $query, $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' in (' . $this->parameterize($where['values']) . ')';
@@ -472,8 +507,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where not in" clause.
+     *
+     * @param array $where
      */
-    protected function whereNotIn(Builder $query, array $where): string
+    protected function whereNotIn(Builder $query, $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' not in (' . $this->parameterize($where['values']) . ')';
@@ -486,8 +523,10 @@ class Grammar extends BaseGrammar
      * Compile a "where not in raw" clause.
      *
      * For safety, whereIntegerInRaw ensures this method is only used with integer values.
+     *
+     * @param array $where
      */
-    protected function whereNotInRaw(Builder $query, array $where): string
+    protected function whereNotInRaw(Builder $query, $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' not in (' . implode(', ', $where['values']) . ')';
@@ -498,16 +537,20 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where in sub-select clause.
+     *
+     * @param array $where
      */
-    protected function whereInSub(Builder $query, array $where): string
+    protected function whereInSub(Builder $query, $where): string
     {
         return $this->wrap($where['column']) . ' in (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where not in sub-select clause.
+     *
+     * @param array $where
      */
-    protected function whereNotInSub(Builder $query, array $where): string
+    protected function whereNotInSub(Builder $query, $where): string
     {
         return $this->wrap($where['column']) . ' not in (' . $this->compileSelect($where['query']) . ')';
     }
@@ -516,8 +559,10 @@ class Grammar extends BaseGrammar
      * Compile a "where in raw" clause.
      *
      * For safety, whereIntegerInRaw ensures this method is only used with integer values.
+     *
+     * @param array $where
      */
-    protected function whereInRaw(Builder $query, array $where): string
+    protected function whereInRaw(Builder $query, $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' in (' . implode(', ', $where['values']) . ')';
@@ -528,24 +573,30 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where null" clause.
+     *
+     * @param array $where
      */
-    protected function whereNull(Builder $query, array $where): string
+    protected function whereNull(Builder $query, $where): string
     {
         return $this->wrap($where['column']) . ' is null';
     }
 
     /**
      * Compile a "where not null" clause.
+     *
+     * @param array $where
      */
-    protected function whereNotNull(Builder $query, array $where): string
+    protected function whereNotNull(Builder $query, $where): string
     {
         return $this->wrap($where['column']) . ' is not null';
     }
 
     /**
      * Compile a "between" where clause.
+     *
+     * @param array $where
      */
-    protected function whereBetween(Builder $query, array $where): string
+    protected function whereBetween(Builder $query, $where): string
     {
         $between = $where['not'] ? 'not between' : 'between';
 
@@ -558,48 +609,61 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where date" clause.
+     *
+     * @param array $where
      */
-    protected function whereDate(Builder $query, array $where): string
+    protected function whereDate(Builder $query, $where): string
     {
         return $this->dateBasedWhere('date', $query, $where);
     }
 
     /**
      * Compile a "where time" clause.
+     *
+     * @param array $where
      */
-    protected function whereTime(Builder $query, array $where): string
+    protected function whereTime(Builder $query, $where): string
     {
         return $this->dateBasedWhere('time', $query, $where);
     }
 
     /**
      * Compile a "where day" clause.
+     *
+     * @param array $where
      */
-    protected function whereDay(Builder $query, array $where): string
+    protected function whereDay(Builder $query, $where): string
     {
         return $this->dateBasedWhere('day', $query, $where);
     }
 
     /**
      * Compile a "where month" clause.
+     *
+     * @param array $where
      */
-    protected function whereMonth(Builder $query, array $where): string
+    protected function whereMonth(Builder $query, $where): string
     {
         return $this->dateBasedWhere('month', $query, $where);
     }
 
     /**
      * Compile a "where year" clause.
+     *
+     * @param array $where
      */
-    protected function whereYear(Builder $query, array $where): string
+    protected function whereYear(Builder $query, $where): string
     {
         return $this->dateBasedWhere('year', $query, $where);
     }
 
     /**
      * Compile a date based where clause.
+     *
+     * @param string $type
+     * @param array $where
      */
-    protected function dateBasedWhere(string $type, Builder $query, array $where): string
+    protected function dateBasedWhere($type, Builder $query, $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -608,16 +672,20 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where clause comparing two columns..
+     *
+     * @param array $where
      */
-    protected function whereColumn(Builder $query, array $where): string
+    protected function whereColumn(Builder $query, $where): string
     {
         return $this->wrap($where['first']) . ' ' . $where['operator'] . ' ' . $this->wrap($where['second']);
     }
 
     /**
      * Compile a nested where clause.
+     *
+     * @param array $where
      */
-    protected function whereNested(Builder $query, array $where): string
+    protected function whereNested(Builder $query, $where): string
     {
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
@@ -629,8 +697,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where condition with a sub-select.
+     *
+     * @param array $where
      */
-    protected function whereSub(Builder $query, array $where): string
+    protected function whereSub(Builder $query, $where): string
     {
         $select = $this->compileSelect($where['query']);
 
@@ -639,24 +709,30 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where exists clause.
+     *
+     * @param array $where
      */
-    protected function whereExists(Builder $query, array $where): string
+    protected function whereExists(Builder $query, $where): string
     {
         return 'exists (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where exists clause.
+     *
+     * @param array $where
      */
-    protected function whereNotExists(Builder $query, array $where): string
+    protected function whereNotExists(Builder $query, $where): string
     {
         return 'not exists (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where row values condition.
+     *
+     * @param array $where
      */
-    protected function whereRowValues(Builder $query, array $where): string
+    protected function whereRowValues(Builder $query, $where): string
     {
         $columns = $this->columnize($where['columns']);
 
@@ -667,8 +743,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where JSON contains" clause.
+     *
+     * @param array $where
      */
-    protected function whereJsonContains(Builder $query, array $where): string
+    protected function whereJsonContains(Builder $query, $where): string
     {
         $not = $where['not'] ? 'not ' : '';
 
@@ -681,17 +759,21 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "JSON contains" statement into SQL.
      *
+     * @param string $column
+     * @param string $value
      * @throws RuntimeException
      */
-    protected function compileJsonContains(string $column, string $value): string
+    protected function compileJsonContains($column, $value): string
     {
         throw new RuntimeException('This database engine does not support JSON contains operations.');
     }
 
     /**
      * Compile a "where JSON length" clause.
+     *
+     * @param array $where
      */
-    protected function whereJsonLength(Builder $query, array $where): string
+    protected function whereJsonLength(Builder $query, $where): string
     {
         return $this->compileJsonLength(
             $where['column'],
@@ -703,25 +785,32 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "JSON length" statement into SQL.
      *
+     * @param string $column
+     * @param string $operator
+     * @param string $value
      * @throws RuntimeException
      */
-    protected function compileJsonLength(string $column, string $operator, string $value): string
+    protected function compileJsonLength($column, $operator, $value): string
     {
         throw new RuntimeException('This database engine does not support JSON length operations.');
     }
 
     /**
      * Compile the "group by" portions of the query.
+     *
+     * @param array $groups
      */
-    protected function compileGroups(Builder $query, array $groups): string
+    protected function compileGroups(Builder $query, $groups): string
     {
         return 'group by ' . $this->columnize($groups);
     }
 
     /**
      * Compile the "having" portions of the query.
+     *
+     * @param array $havings
      */
-    protected function compileHavings(Builder $query, array $havings): string
+    protected function compileHavings(Builder $query, $havings): string
     {
         $sql = implode(' ', array_map([$this, 'compileHaving'], $havings));
 
@@ -748,8 +837,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a basic having clause.
+     *
+     * @param array $having
      */
-    protected function compileBasicHaving(array $having): string
+    protected function compileBasicHaving($having): string
     {
         $column = $this->wrap($having['column']);
 
@@ -760,8 +851,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "between" having clause.
+     *
+     * @param array $having
      */
-    protected function compileHavingBetween(array $having): string
+    protected function compileHavingBetween($having): string
     {
         $between = $having['not'] ? 'not between' : 'between';
 
@@ -776,8 +869,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "order by" portions of the query.
+     *
+     * @param array $orders
      */
-    protected function compileOrders(Builder $query, array $orders): string
+    protected function compileOrders(Builder $query, $orders): string
     {
         if (! empty($orders)) {
             return 'order by ' . implode(', ', $this->compileOrdersToArray($query, $orders));
@@ -788,8 +883,10 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the query orders to an array.
+     *
+     * @param array $orders
      */
-    protected function compileOrdersToArray(Builder $query, array $orders): array
+    protected function compileOrdersToArray(Builder $query, $orders): array
     {
         return array_map(function ($order) {
             return ! isset($order['sql'])
@@ -800,18 +897,22 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "limit" portions of the query.
+     *
+     * @param int $limit
      */
-    protected function compileLimit(Builder $query, int $limit): string
+    protected function compileLimit(Builder $query, $limit): string
     {
-        return 'limit ' . $limit;
+        return 'limit ' . (int) $limit;
     }
 
     /**
      * Compile the "offset" portions of the query.
+     *
+     * @param int $offset
      */
-    protected function compileOffset(Builder $query, int $offset): string
+    protected function compileOffset(Builder $query, $offset): string
     {
-        return 'offset ' . $offset;
+        return 'offset ' . (int) $offset;
     }
 
     /**
@@ -864,24 +965,30 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the lock into SQL.
+     *
+     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, bool|string $value): string
+    protected function compileLock(Builder $query, $value): string
     {
         return is_string($value) ? $value : '';
     }
 
     /**
      * Wrap the given JSON selector.
+     *
+     * @param string $value
      */
-    protected function wrapJsonSelector(string $value): string
+    protected function wrapJsonSelector($value): string
     {
         throw new RuntimeException('This database engine does not support JSON operations.');
     }
 
     /**
      * Split the given JSON selector into the field and the optional path and wrap them separately.
+     *
+     * @param string $column
      */
-    protected function wrapJsonFieldAndPath(string $column): array
+    protected function wrapJsonFieldAndPath($column): array
     {
         $parts = explode('->', $column, 2);
 
@@ -894,24 +1001,31 @@ class Grammar extends BaseGrammar
 
     /**
      * Wrap the given JSON path.
+     *
+     * @param string $value
+     * @param string $delimiter
      */
-    protected function wrapJsonPath(string $value, string $delimiter = '->'): string
+    protected function wrapJsonPath($value, $delimiter = '->'): string
     {
         return '\'$."' . str_replace($delimiter, '"."', $value) . '"\'';
     }
 
     /**
      * Determine if the given string is a JSON selector.
+     *
+     * @param string $value
      */
-    protected function isJsonSelector(string $value): bool
+    protected function isJsonSelector($value): bool
     {
         return Str::contains($value, '->');
     }
 
     /**
      * Concatenate an array of segments, removing empties.
+     *
+     * @param array $segments
      */
-    protected function concatenate(array $segments): string
+    protected function concatenate($segments): string
     {
         return implode(' ', array_filter($segments, function ($value) {
             return (string) $value !== '';
@@ -920,8 +1034,11 @@ class Grammar extends BaseGrammar
 
     /**
      * Remove the leading boolean from a statement.
+     *
+     * @param string $value
+     * @return string
      */
-    protected function removeLeadingBoolean(string $value): string
+    protected function removeLeadingBoolean($value)
     {
         return preg_replace('/and |or /i', '', $value, 1);
     }

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -465,8 +465,10 @@ class Grammar extends BaseGrammar
      * Compile a "where JSON boolean" clause.
      *
      * @param string $value
+     * @param array $where
+     * @return string
      */
-    protected function whereJsonBoolean(Builder $query, array $where): string
+    protected function whereJsonBoolean(Builder $query, $where)
     {
         $column = $this->wrapJsonBooleanSelector($where['column']);
 

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -78,21 +78,16 @@ class Grammar extends BaseGrammar
 
     /**
      * Prepare the binding for a "JSON contains" statement.
-     *
-     * @param mixed $binding
-     * @return string
      */
-    public function prepareBindingForJsonContains($binding)
+    public function prepareBindingForJsonContains(mixed $binding): string
     {
         return json_encode($binding);
     }
 
     /**
      * Compile the random statement into SQL.
-     *
-     * @param string $seed
      */
-    public function compileRandom($seed): string
+    public function compileRandom(string $seed): string
     {
         return 'RANDOM()';
     }
@@ -143,11 +138,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an insert and get ID statement into SQL.
-     *
-     * @param array $values
-     * @param string $sequence
      */
-    public function compileInsertGetId(Builder $query, $values, $sequence): string
+    public function compileInsertGetId(Builder $query, array $values, string $sequence): string
     {
         return $this->compileInsert($query, $values);
     }
@@ -162,10 +154,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an update statement into SQL.
-     *
-     * @param array $values
      */
-    public function compileUpdate(Builder $query, $values): string
+    public function compileUpdate(Builder $query, array $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -241,20 +231,16 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the SQL statement to define a savepoint.
-     *
-     * @param string $name
      */
-    public function compileSavepoint($name): string
+    public function compileSavepoint(string $name): string
     {
         return 'SAVEPOINT ' . $name;
     }
 
     /**
      * Compile the SQL statement to execute a savepoint rollback.
-     *
-     * @param string $name
      */
-    public function compileSavepointRollBack($name): string
+    public function compileSavepointRollBack(string $name): string
     {
         return 'ROLLBACK TO SAVEPOINT ' . $name;
     }
@@ -263,9 +249,8 @@ class Grammar extends BaseGrammar
      * Wrap a value in keyword identifiers.
      *
      * @param bool $prefixAlias
-     * @return string
      */
-    public function wrap(Expression|string $value, $prefixAlias = false)
+    public function wrap(Expression|string $value, $prefixAlias = false): string
     {
         if ($this->isExpression($value)) {
             return $this->getValue($value);
@@ -319,10 +304,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile an aggregated select clause.
-     *
-     * @param array $aggregate
      */
-    protected function compileAggregate(Builder $query, $aggregate): string
+    protected function compileAggregate(Builder $query, array $aggregate): string
     {
         $column = $this->columnize($aggregate['columns']);
 
@@ -338,10 +321,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "select *" portion of the query.
-     *
-     * @param array $columns
      */
-    protected function compileColumns(Builder $query, $columns): ?string
+    protected function compileColumns(Builder $query, array $columns): ?string
     {
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
@@ -357,10 +338,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "from" portion of the query.
-     *
-     * @param string $table
      */
-    protected function compileFrom(Builder $query, $table): string
+    protected function compileFrom(Builder $query, string $table): string
     {
         if ($query->forceIndexes) {
             $forceIndexes = [];
@@ -375,10 +354,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "join" portions of the query.
-     *
-     * @param array $joins
      */
-    protected function compileJoins(Builder $query, $joins): string
+    protected function compileJoins(Builder $query, array $joins): string
     {
         return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
@@ -415,10 +392,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Get an array of all the where clauses for the query.
-     *
-     * @param \Hyperf\Database\Query\Builder $query
      */
-    protected function compileWheresToArray($query): array
+    protected function compileWheresToArray(Builder $query): array
     {
         return collect($query->wheres)->map(function ($where) use ($query) {
             return $where['boolean'] . ' ' . $this->{"where{$where['type']}"}($query, $where);
@@ -427,11 +402,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Format the where clause statements into one string.
-     *
-     * @param \Hyperf\Database\Query\Builder $query
-     * @param array $sql
      */
-    protected function concatenateWhereClauses($query, $sql): string
+    protected function concatenateWhereClauses(Builder $query, array $sql): string
     {
         $conjunction = $query instanceof JoinClause ? 'on' : 'where';
 
@@ -440,21 +412,16 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a raw where clause.
-     *
-     * @param array $where
-     * @return string
      */
-    protected function whereRaw(Builder $query, $where)
+    protected function whereRaw(Builder $query, array $where): string
     {
         return $where['sql'];
     }
 
     /**
      * Compile a basic where clause.
-     *
-     * @param array $where
      */
-    protected function whereBasic(Builder $query, $where): string
+    protected function whereBasic(Builder $query, array $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -493,10 +460,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where in" clause.
-     *
-     * @param array $where
      */
-    protected function whereIn(Builder $query, $where): string
+    protected function whereIn(Builder $query, array $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' in (' . $this->parameterize($where['values']) . ')';
@@ -507,10 +472,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where not in" clause.
-     *
-     * @param array $where
      */
-    protected function whereNotIn(Builder $query, $where): string
+    protected function whereNotIn(Builder $query, array $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' not in (' . $this->parameterize($where['values']) . ')';
@@ -523,10 +486,8 @@ class Grammar extends BaseGrammar
      * Compile a "where not in raw" clause.
      *
      * For safety, whereIntegerInRaw ensures this method is only used with integer values.
-     *
-     * @param array $where
      */
-    protected function whereNotInRaw(Builder $query, $where): string
+    protected function whereNotInRaw(Builder $query, array $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' not in (' . implode(', ', $where['values']) . ')';
@@ -537,20 +498,16 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where in sub-select clause.
-     *
-     * @param array $where
      */
-    protected function whereInSub(Builder $query, $where): string
+    protected function whereInSub(Builder $query, array $where): string
     {
         return $this->wrap($where['column']) . ' in (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where not in sub-select clause.
-     *
-     * @param array $where
      */
-    protected function whereNotInSub(Builder $query, $where): string
+    protected function whereNotInSub(Builder $query, array $where): string
     {
         return $this->wrap($where['column']) . ' not in (' . $this->compileSelect($where['query']) . ')';
     }
@@ -559,10 +516,8 @@ class Grammar extends BaseGrammar
      * Compile a "where in raw" clause.
      *
      * For safety, whereIntegerInRaw ensures this method is only used with integer values.
-     *
-     * @param array $where
      */
-    protected function whereInRaw(Builder $query, $where): string
+    protected function whereInRaw(Builder $query, array $where): string
     {
         if (! empty($where['values'])) {
             return $this->wrap($where['column']) . ' in (' . implode(', ', $where['values']) . ')';
@@ -573,30 +528,24 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where null" clause.
-     *
-     * @param array $where
      */
-    protected function whereNull(Builder $query, $where): string
+    protected function whereNull(Builder $query, array $where): string
     {
         return $this->wrap($where['column']) . ' is null';
     }
 
     /**
      * Compile a "where not null" clause.
-     *
-     * @param array $where
      */
-    protected function whereNotNull(Builder $query, $where): string
+    protected function whereNotNull(Builder $query, array $where): string
     {
         return $this->wrap($where['column']) . ' is not null';
     }
 
     /**
      * Compile a "between" where clause.
-     *
-     * @param array $where
      */
-    protected function whereBetween(Builder $query, $where): string
+    protected function whereBetween(Builder $query, array $where): string
     {
         $between = $where['not'] ? 'not between' : 'between';
 
@@ -609,61 +558,48 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where date" clause.
-     *
-     * @param array $where
      */
-    protected function whereDate(Builder $query, $where): string
+    protected function whereDate(Builder $query, array $where): string
     {
         return $this->dateBasedWhere('date', $query, $where);
     }
 
     /**
      * Compile a "where time" clause.
-     *
-     * @param array $where
      */
-    protected function whereTime(Builder $query, $where): string
+    protected function whereTime(Builder $query, array $where): string
     {
         return $this->dateBasedWhere('time', $query, $where);
     }
 
     /**
      * Compile a "where day" clause.
-     *
-     * @param array $where
      */
-    protected function whereDay(Builder $query, $where): string
+    protected function whereDay(Builder $query, array $where): string
     {
         return $this->dateBasedWhere('day', $query, $where);
     }
 
     /**
      * Compile a "where month" clause.
-     *
-     * @param array $where
      */
-    protected function whereMonth(Builder $query, $where): string
+    protected function whereMonth(Builder $query, array $where): string
     {
         return $this->dateBasedWhere('month', $query, $where);
     }
 
     /**
      * Compile a "where year" clause.
-     *
-     * @param array $where
      */
-    protected function whereYear(Builder $query, $where): string
+    protected function whereYear(Builder $query, array $where): string
     {
         return $this->dateBasedWhere('year', $query, $where);
     }
 
     /**
      * Compile a date based where clause.
-     *
-     * @param string $type
-     * @param array $where
      */
-    protected function dateBasedWhere($type, Builder $query, $where): string
+    protected function dateBasedWhere(string $type, Builder $query, array $where): string
     {
         $value = $this->parameter($where['value']);
 
@@ -672,20 +608,16 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where clause comparing two columns..
-     *
-     * @param array $where
      */
-    protected function whereColumn(Builder $query, $where): string
+    protected function whereColumn(Builder $query, array $where): string
     {
         return $this->wrap($where['first']) . ' ' . $where['operator'] . ' ' . $this->wrap($where['second']);
     }
 
     /**
      * Compile a nested where clause.
-     *
-     * @param array $where
      */
-    protected function whereNested(Builder $query, $where): string
+    protected function whereNested(Builder $query, array $where): string
     {
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
@@ -697,10 +629,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where condition with a sub-select.
-     *
-     * @param array $where
      */
-    protected function whereSub(Builder $query, $where): string
+    protected function whereSub(Builder $query, array $where): string
     {
         $select = $this->compileSelect($where['query']);
 
@@ -709,30 +639,24 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a where exists clause.
-     *
-     * @param array $where
      */
-    protected function whereExists(Builder $query, $where): string
+    protected function whereExists(Builder $query, array $where): string
     {
         return 'exists (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where exists clause.
-     *
-     * @param array $where
      */
-    protected function whereNotExists(Builder $query, $where): string
+    protected function whereNotExists(Builder $query, array $where): string
     {
         return 'not exists (' . $this->compileSelect($where['query']) . ')';
     }
 
     /**
      * Compile a where row values condition.
-     *
-     * @param array $where
      */
-    protected function whereRowValues(Builder $query, $where): string
+    protected function whereRowValues(Builder $query, array $where): string
     {
         $columns = $this->columnize($where['columns']);
 
@@ -743,10 +667,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where JSON contains" clause.
-     *
-     * @param array $where
      */
-    protected function whereJsonContains(Builder $query, $where): string
+    protected function whereJsonContains(Builder $query, array $where): string
     {
         $not = $where['not'] ? 'not ' : '';
 
@@ -759,21 +681,17 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "JSON contains" statement into SQL.
      *
-     * @param string $column
-     * @param string $value
      * @throws RuntimeException
      */
-    protected function compileJsonContains($column, $value): string
+    protected function compileJsonContains(string $column, string $value): string
     {
         throw new RuntimeException('This database engine does not support JSON contains operations.');
     }
 
     /**
      * Compile a "where JSON length" clause.
-     *
-     * @param array $where
      */
-    protected function whereJsonLength(Builder $query, $where): string
+    protected function whereJsonLength(Builder $query, array $where): string
     {
         return $this->compileJsonLength(
             $where['column'],
@@ -785,32 +703,25 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "JSON length" statement into SQL.
      *
-     * @param string $column
-     * @param string $operator
-     * @param string $value
      * @throws RuntimeException
      */
-    protected function compileJsonLength($column, $operator, $value): string
+    protected function compileJsonLength(string $column, string $operator, string $value): string
     {
         throw new RuntimeException('This database engine does not support JSON length operations.');
     }
 
     /**
      * Compile the "group by" portions of the query.
-     *
-     * @param array $groups
      */
-    protected function compileGroups(Builder $query, $groups): string
+    protected function compileGroups(Builder $query, array $groups): string
     {
         return 'group by ' . $this->columnize($groups);
     }
 
     /**
      * Compile the "having" portions of the query.
-     *
-     * @param array $havings
      */
-    protected function compileHavings(Builder $query, $havings): string
+    protected function compileHavings(Builder $query, array $havings): string
     {
         $sql = implode(' ', array_map([$this, 'compileHaving'], $havings));
 
@@ -837,10 +748,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a basic having clause.
-     *
-     * @param array $having
      */
-    protected function compileBasicHaving($having): string
+    protected function compileBasicHaving(array $having): string
     {
         $column = $this->wrap($having['column']);
 
@@ -851,10 +760,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "between" having clause.
-     *
-     * @param array $having
      */
-    protected function compileHavingBetween($having): string
+    protected function compileHavingBetween(array $having): string
     {
         $between = $having['not'] ? 'not between' : 'between';
 
@@ -869,10 +776,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "order by" portions of the query.
-     *
-     * @param array $orders
      */
-    protected function compileOrders(Builder $query, $orders): string
+    protected function compileOrders(Builder $query, array $orders): string
     {
         if (! empty($orders)) {
             return 'order by ' . implode(', ', $this->compileOrdersToArray($query, $orders));
@@ -883,10 +788,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the query orders to an array.
-     *
-     * @param array $orders
      */
-    protected function compileOrdersToArray(Builder $query, $orders): array
+    protected function compileOrdersToArray(Builder $query, array $orders): array
     {
         return array_map(function ($order) {
             return ! isset($order['sql'])
@@ -897,22 +800,18 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the "limit" portions of the query.
-     *
-     * @param int $limit
      */
-    protected function compileLimit(Builder $query, $limit): string
+    protected function compileLimit(Builder $query, int $limit): string
     {
-        return 'limit ' . (int) $limit;
+        return 'limit ' . $limit;
     }
 
     /**
      * Compile the "offset" portions of the query.
-     *
-     * @param int $offset
      */
-    protected function compileOffset(Builder $query, $offset): string
+    protected function compileOffset(Builder $query, int $offset): string
     {
-        return 'offset ' . (int) $offset;
+        return 'offset ' . $offset;
     }
 
     /**
@@ -965,30 +864,24 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the lock into SQL.
-     *
-     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, $value): string
+    protected function compileLock(Builder $query, bool|string $value): string
     {
         return is_string($value) ? $value : '';
     }
 
     /**
      * Wrap the given JSON selector.
-     *
-     * @param string $value
      */
-    protected function wrapJsonSelector($value): string
+    protected function wrapJsonSelector(string $value): string
     {
         throw new RuntimeException('This database engine does not support JSON operations.');
     }
 
     /**
      * Split the given JSON selector into the field and the optional path and wrap them separately.
-     *
-     * @param string $column
      */
-    protected function wrapJsonFieldAndPath($column): array
+    protected function wrapJsonFieldAndPath(string $column): array
     {
         $parts = explode('->', $column, 2);
 
@@ -1001,31 +894,24 @@ class Grammar extends BaseGrammar
 
     /**
      * Wrap the given JSON path.
-     *
-     * @param string $value
-     * @param string $delimiter
      */
-    protected function wrapJsonPath($value, $delimiter = '->'): string
+    protected function wrapJsonPath(string $value, string $delimiter = '->'): string
     {
         return '\'$."' . str_replace($delimiter, '"."', $value) . '"\'';
     }
 
     /**
      * Determine if the given string is a JSON selector.
-     *
-     * @param string $value
      */
-    protected function isJsonSelector($value): bool
+    protected function isJsonSelector(string $value): bool
     {
         return Str::contains($value, '->');
     }
 
     /**
      * Concatenate an array of segments, removing empties.
-     *
-     * @param array $segments
      */
-    protected function concatenate($segments): string
+    protected function concatenate(array $segments): string
     {
         return implode(' ', array_filter($segments, function ($value) {
             return (string) $value !== '';
@@ -1034,11 +920,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Remove the leading boolean from a statement.
-     *
-     * @param string $value
-     * @return string
      */
-    protected function removeLeadingBoolean($value)
+    protected function removeLeadingBoolean(string $value): string
     {
         return preg_replace('/and |or /i', '', $value, 1);
     }

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -462,6 +462,36 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where JSON boolean" clause.
+     */
+    protected function whereJsonBoolean(Builder $query, array $where): string
+    {
+        $column = $this->wrapJsonBooleanSelector($where['column']);
+
+        $value = $this->wrapJsonBooleanValue(
+            $this->parameter($where['value'])
+        );
+
+        return $column . ' ' . $where['operator'] . ' ' . $value;
+    }
+
+    /**
+     * Wrap the given JSON selector for boolean values.
+     */
+    protected function wrapJsonBooleanSelector(string $value): string
+    {
+        return $this->wrapJsonSelector($value);
+    }
+
+    /**
+     * Wrap the given JSON boolean value.
+     */
+    protected function wrapJsonBooleanValue(string $value): string
+    {
+        return $value;
+    }
+
+    /**
      * Compile a "where in" clause.
      *
      * @param array $where

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -339,7 +339,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile the "from" portion of the query.
      */
-    protected function compileFrom(Builder $query, string|Expression $table): string
+    protected function compileFrom(Builder $query, string $table): string
     {
         if ($query->forceIndexes) {
             $forceIndexes = [];

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -463,6 +463,9 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile a "where JSON boolean" clause.
+     *
+     * @param string $value
+     * @return string
      */
     protected function whereJsonBoolean(Builder $query, array $where): string
     {
@@ -477,8 +480,11 @@ class Grammar extends BaseGrammar
 
     /**
      * Wrap the given JSON selector for boolean values.
+     *
+     * @param string $value
+     * @return string
      */
-    protected function wrapJsonBooleanSelector(string $value): string
+    protected function wrapJsonBooleanSelector($value)
     {
         return $this->wrapJsonSelector($value);
     }
@@ -486,7 +492,7 @@ class Grammar extends BaseGrammar
     /**
      * Wrap the given JSON boolean value.
      */
-    protected function wrapJsonBooleanValue(string $value): string
+    protected function wrapJsonBooleanValue($value)
     {
         return $value;
     }

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -339,7 +339,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile the "from" portion of the query.
      */
-    protected function compileFrom(Builder $query, string $table): string
+    protected function compileFrom(Builder $query, string|Expression $table): string
     {
         if ($query->forceIndexes) {
             $forceIndexes = [];

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -465,7 +465,6 @@ class Grammar extends BaseGrammar
      * Compile a "where JSON boolean" clause.
      *
      * @param string $value
-     * @return string
      */
     protected function whereJsonBoolean(Builder $query, array $where): string
     {
@@ -491,6 +490,7 @@ class Grammar extends BaseGrammar
 
     /**
      * Wrap the given JSON boolean value.
+     * @param mixed $value
      */
     protected function wrapJsonBooleanValue($value)
     {

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -304,4 +304,14 @@ class MySqlGrammar extends Grammar
 
         return 'json_unquote(json_extract(' . $field . $path . '))';
     }
+
+    /**
+     * Wrap the given JSON selector for boolean values.
+     */
+    protected function wrapJsonBooleanSelector(string $value): string
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
+
+        return 'json_extract(' . $field . $path . ')';
+    }
 }

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -67,16 +67,20 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile the random statement into SQL.
+     *
+     * @param string $seed
      */
-    public function compileRandom(string $seed): string
+    public function compileRandom($seed): string
     {
         return 'RAND(' . $seed . ')';
     }
 
     /**
      * Compile an update statement into SQL.
+     *
+     * @param array $values
      */
-    public function compileUpdate(Builder $query, array $values): string
+    public function compileUpdate(Builder $query, $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -160,8 +164,11 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a "JSON contains" statement into SQL.
+     *
+     * @param string $column
+     * @param string $value
      */
-    protected function compileJsonContains(string $column, string $value): string
+    protected function compileJsonContains($column, $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
@@ -170,8 +177,12 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a "JSON length" statement into SQL.
+     *
+     * @param string $column
+     * @param string $operator
+     * @param string $value
      */
-    protected function compileJsonLength(string $column, string $operator, string $value): string
+    protected function compileJsonLength($column, $operator, $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
@@ -190,8 +201,10 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile the lock into SQL.
+     *
+     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, bool|string $value): string
+    protected function compileLock(Builder $query, $value): string
     {
         if (! is_string($value)) {
             return $value ? 'for update' : 'lock in share mode';
@@ -202,8 +215,10 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile all of the columns for an update statement.
+     *
+     * @param array $values
      */
-    protected function compileUpdateColumns(array $values): string
+    protected function compileUpdateColumns($values): string
     {
         return collect($values)->map(function ($value, $key) {
             if ($this->isJsonSelector($key)) {
@@ -216,8 +231,10 @@ class MySqlGrammar extends Grammar
 
     /**
      * Prepares a JSON column being updated using the JSON_SET function.
+     *
+     * @param string $key
      */
-    protected function compileJsonUpdateColumn(string $key, JsonExpression $value): string
+    protected function compileJsonUpdateColumn($key, JsonExpression $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($key);
 
@@ -226,8 +243,12 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a delete query that does not use joins.
+     *
+     * @param \Hyperf\Database\Query\Builder $query
+     * @param string $table
+     * @param array $where
      */
-    protected function compileDeleteWithoutJoins(Builder $query, string $table, string $where): string
+    protected function compileDeleteWithoutJoins($query, $table, $where): string
     {
         $sql = trim("delete from {$table} {$where}");
 
@@ -247,8 +268,12 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a delete query that uses joins.
+     *
+     * @param \Hyperf\Database\Query\Builder $query
+     * @param string $table
+     * @param array $where
      */
-    protected function compileDeleteWithJoins(Builder $query, string $table, string $where): string
+    protected function compileDeleteWithJoins($query, $table, $where): string
     {
         $joins = ' ' . $this->compileJoins($query, $query->joins);
 
@@ -270,8 +295,10 @@ class MySqlGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector.
+     *
+     * @param string $value
      */
-    protected function wrapJsonSelector(string $value): string
+    protected function wrapJsonSelector($value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -67,20 +67,16 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile the random statement into SQL.
-     *
-     * @param string $seed
      */
-    public function compileRandom($seed): string
+    public function compileRandom(string $seed): string
     {
         return 'RAND(' . $seed . ')';
     }
 
     /**
      * Compile an update statement into SQL.
-     *
-     * @param array $values
      */
-    public function compileUpdate(Builder $query, $values): string
+    public function compileUpdate(Builder $query, array $values): string
     {
         $table = $this->wrapTable($query->from);
 
@@ -164,11 +160,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a "JSON contains" statement into SQL.
-     *
-     * @param string $column
-     * @param string $value
      */
-    protected function compileJsonContains($column, $value): string
+    protected function compileJsonContains(string $column, string $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
@@ -177,12 +170,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a "JSON length" statement into SQL.
-     *
-     * @param string $column
-     * @param string $operator
-     * @param string $value
      */
-    protected function compileJsonLength($column, $operator, $value): string
+    protected function compileJsonLength(string $column, string $operator, string $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
@@ -201,10 +190,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile the lock into SQL.
-     *
-     * @param bool|string $value
      */
-    protected function compileLock(Builder $query, $value): string
+    protected function compileLock(Builder $query, bool|string $value): string
     {
         if (! is_string($value)) {
             return $value ? 'for update' : 'lock in share mode';
@@ -215,10 +202,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile all of the columns for an update statement.
-     *
-     * @param array $values
      */
-    protected function compileUpdateColumns($values): string
+    protected function compileUpdateColumns(array $values): string
     {
         return collect($values)->map(function ($value, $key) {
             if ($this->isJsonSelector($key)) {
@@ -231,10 +216,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Prepares a JSON column being updated using the JSON_SET function.
-     *
-     * @param string $key
      */
-    protected function compileJsonUpdateColumn($key, JsonExpression $value): string
+    protected function compileJsonUpdateColumn(string $key, JsonExpression $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($key);
 
@@ -243,12 +226,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a delete query that does not use joins.
-     *
-     * @param \Hyperf\Database\Query\Builder $query
-     * @param string $table
-     * @param array $where
      */
-    protected function compileDeleteWithoutJoins($query, $table, $where): string
+    protected function compileDeleteWithoutJoins(Builder $query, string $table, string $where): string
     {
         $sql = trim("delete from {$table} {$where}");
 
@@ -268,12 +247,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Compile a delete query that uses joins.
-     *
-     * @param \Hyperf\Database\Query\Builder $query
-     * @param string $table
-     * @param array $where
      */
-    protected function compileDeleteWithJoins($query, $table, $where): string
+    protected function compileDeleteWithJoins(Builder $query, string $table, string $where): string
     {
         $joins = ' ' . $this->compileJoins($query, $query->joins);
 
@@ -295,10 +270,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector.
-     *
-     * @param string $value
      */
-    protected function wrapJsonSelector($value): string
+    protected function wrapJsonSelector(string $value): string
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -307,6 +307,9 @@ class MySqlGrammar extends Grammar
 
     /**
      * Wrap the given JSON selector for boolean values.
+     *
+     * @param string $value
+     * @return string
      */
     protected function wrapJsonBooleanSelector($value)
     {

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -308,7 +308,7 @@ class MySqlGrammar extends Grammar
     /**
      * Wrap the given JSON selector for boolean values.
      */
-    protected function wrapJsonBooleanSelector(string $value): string
+    protected function wrapJsonBooleanSelector($value)
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 

--- a/src/database/tests/QueryBuilderTest.php
+++ b/src/database/tests/QueryBuilderTest.php
@@ -2192,14 +2192,14 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = true', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = true and json_unquote(json_extract(`items`, \'$."active"\')) = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = ? and json_unquote(json_extract(`items`, \'$."active"\')) = ? and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJson()

--- a/src/database/tests/QueryBuilderTest.php
+++ b/src/database/tests/QueryBuilderTest.php
@@ -2192,14 +2192,14 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."available"\')) = ? and json_unquote(json_extract(`items`, \'$."active"\')) = ? and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJson()


### PR DESCRIPTION
## 问题

where json 查询，值为布尔类型时，生成的sql错误。正确应如下

- where  json_unquote(json_extract(`Field`, '$."JSON Field"')) = 'true'
- where  json_extract(`Field`, '$."JSON Field"') = true

按原有代码 `new Expression` 在`\Hyperf\Database\Query\Grammars\Grammar::whereBasic`处，获取Expression value 生成的sql为

-  where  json_unquote(json_extract(`Field`, '$."JSON Field"')) = true （缺失string引号）


## 其他方案

- laravel 中是分成俩个处理逻辑，布尔类型生成的语句不包含`json_unquote`，文件地址`\Illuminate\Database\Query\Grammars\MySqlGrammar::wrapJsonBooleanSelector`
- 在new Expression时传递的value为 `$value ? "'true'" :"'false'"`
