### PR TITLE
Fixed bug that the persistent service no need to send heartbeat.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.8 - TBD
 
+## Fixed
+
+- [#5433](https://github.com/hyperf/hyperf/pull/5433) Fixed bug that the persistent service no need to send heartbeat.
+
 # v3.0.7 - 2023-02-18
 
 ## Added

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -103,7 +103,9 @@ class NacosDriver implements DriverInterface
         }
 
         $this->serviceRegistered[$name] = true;
-        $this->registerHeartbeat($name, $host, $port);
+        if ($ephemeral) {
+            $this->registerHeartbeat($name, $host, $port);
+        }
     }
 
     public function isRegistered(string $name, string $host, int $port, array $metadata): bool


### PR DESCRIPTION
nacos永久实例是nacos服务端向客户端发送心跳
虽然不影响服务的正常注册和发现，但永久实例发送心跳nacos会返回错误信息，导致返回值解析json出错
```php
[ERROR] The nacos heartbeat failed, caused by JsonException: Syntax error in /opt/php/vendor/hyperf/utils/src/Codec/Json.php:49
Stack trace:
#0 /opt/php/vendor/hyperf/utils/src/Codec/Json.php(49): json_decode()
#1 /opt/php/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(222): Hyperf\Utils\Codec\Json::decode()
#2 /opt/php/vendor/hyperf/utils/src/Functions.php(82): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#3 /opt/php/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(248): retry()
#4 /opt/php/vendor/hyperf/utils/src/Coroutine.php(67): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#5 {main}

Next Hyperf\Utils\Exception\InvalidArgumentException: Syntax error in /opt/php/vendor/hyperf/utils/src/Codec/Json.php:51
Stack trace:
#0 /opt/php/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(222): Hyperf\Utils\Codec\Json::decode()
#1 /opt/php/vendor/hyperf/utils/src/Functions.php(82): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#2 /opt/php/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(248): retry()
#3 /opt/php/vendor/hyperf/utils/src/Coroutine.php(67): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#4 {main}
```