### PR TITLE
Remove unnecessary `if `statement in `Str::length`

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,6 +8,10 @@
 
 - [#5434](https://github.com/hyperf/hyperf/pull/5434) Support UDP Server for Swow.
 
+## Optimized
+
+- [#5437](https://github.com/hyperf/hyperf/pull/5437) Remove unnecessary `if `statement in `Str::length`.
+
 # v3.0.7 - 2023-02-18
 
 ## Added

--- a/src/utils/src/Str.php
+++ b/src/utils/src/Str.php
@@ -299,11 +299,7 @@ class Str
      */
     public static function length($value, $encoding = null)
     {
-        if ($encoding) {
-            return mb_strlen($value, $encoding);
-        }
-
-        return mb_strlen($value);
+        return mb_strlen($value, $encoding);
     }
 
     /**

--- a/src/utils/tests/StrTest.php
+++ b/src/utils/tests/StrTest.php
@@ -196,4 +196,10 @@ class StrTest extends TestCase
         $this->assertSame('Alien     ', Str::padRight('Alien', 10));
         $this->assertSame('❤MultiByte☆     ', Str::padRight('❤MultiByte☆', 16));
     }
+
+    public function testLength()
+    {
+        $this->assertEquals(11, Str::length('foo bar baz'));
+        $this->assertEquals(11, Str::length('foo bar baz', 'UTF-8'));
+    }
 }


### PR DESCRIPTION
Since PHP 8, the default value of encoding parameter of `mb_strlen` function is `null`, therefore the `if` statement here is not needed anymore.

Reference:
https://www.php.net/manual/en/function.mb-strlen.php