### PR TITLE
Fixed bug nacso persistent service heartbeat at function isRegistered()

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#5433](https://github.com/hyperf/hyperf/pull/5433) Fixed bug that the persistent service no need to send heartbeat.
+- [#5433](https://github.com/hyperf/hyperf/pull/5433) [#5438](https://github.com/hyperf/hyperf/pull/5438) Fixed bug that the persistent service no need to send heartbeat.
 
 ## Added
 

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -147,7 +147,10 @@ class NacosDriver implements DriverInterface
             throw new RequestException(sprintf('Failed to get nacos instance %s:%d for %s!', $host, $port, $name));
         }
         $this->serviceRegistered[$name] = true;
-        $this->registerHeartbeat($name, $host, $port);
+
+        if($this->config->get('services.drivers.nacos.ephemeral')){
+            $this->registerHeartbeat($name, $host, $port);
+        }
 
         return true;
     }

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -148,7 +148,7 @@ class NacosDriver implements DriverInterface
         }
         $this->serviceRegistered[$name] = true;
 
-        if($this->config->get('services.drivers.nacos.ephemeral')){
+        if ($this->config->get('services.drivers.nacos.ephemeral')) {
             $this->registerHeartbeat($name, $host, $port);
         }
 


### PR DESCRIPTION
#5433 中已经修复了，永久实例 无需发送心跳的问题， 但再次启动后hyperf项目后，NacosDrivers->isRegistered()会再次检测 并 发送心跳 到nacos服务端，依然会出现如下错误。

```ruby
[ERROR] The nacos heartbeat failed, caused by JsonException: Syntax error in /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Codec/Json.php:49
Stack trace:
#0 /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Codec/Json.php(49): json_decode('caused: errCode...', true, 512, 4194304)
#1 /home/www/hyperf-skeleton/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(226): Hyperf\Utils\Codec\Json::decode('caused: errCode...')
#2 /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Functions.php(82): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}(1)
#3 /home/www/hyperf-skeleton/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(253): retry(INF, Object(Closure))
#4 /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Coroutine.php(67): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#5 [internal function]: Hyperf\Utils\Coroutine::Hyperf\Utils\{closure}()
#6 {main}

Next Hyperf\Utils\Exception\InvalidArgumentException: Syntax error in /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Codec/Json.php:51
Stack trace:
#0 /home/www/hyperf-skeleton/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(226): Hyperf\Utils\Codec\Json::decode('caused: errCode...')
#1 /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Functions.php(82): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}(1)
#2 /home/www/hyperf-skeleton/vendor/hyperf/service-governance-nacos/src/NacosDriver.php(253): retry(INF, Object(Closure))
#3 /home/www/hyperf-skeleton/vendor/hyperf/utils/src/Coroutine.php(67): Hyperf\ServiceGovernanceNacos\NacosDriver->Hyperf\ServiceGovernanceNacos\{closure}()
#4 [internal function]: Hyperf\Utils\Coroutine::Hyperf\Utils\{closure}()
#5 {main}
```