### PR TITLE
Update Scanner.php，优化文件扫描相关逻辑

### DIFF
--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -119,6 +119,8 @@ class Scanner
         $lastCacheModified = $this->deserializeCachedCollectors($collectors);
         // TODO: The online mode won't init BetterReflectionManager when has cache.
         if ($lastCacheModified > 0 && $this->scanConfig->isCacheable()) {
+            // Init BetterReflectionManager when SCAN_CACHEABLE is true
+            BetterReflectionManager::initClassReflector([]);
             return [];
         }
 


### PR DESCRIPTION
在SCAN_CACHEABLE=true的情况下依旧初始化BetterReflectionManager，可以实现不扫描文件，但是代理类原文件有修改的情况即时更新代理类，避免BetterReflectionManager报“The class reflector object does not init yet”错误，加快框架启动速度。如果要更新注解收集器，实现注解更新，还是需要设置SCAN_CACHEABLE=false