### PR TITLE
Removed the default header `Server: Hyperf` from response.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.16 - TBD
 
+## Changed
+
+- [#5614](https://github.com/hyperf/hyperf/pull/5614) Removed the default header `Server: Hyperf` from response.
+
 # v3.0.15 - 2023-04-07
 
 ## Added

--- a/src/http-server/src/CoreMiddleware.php
+++ b/src/http-server/src/CoreMiddleware.php
@@ -96,7 +96,7 @@ class CoreMiddleware implements CoreMiddlewareInterface
         if (! $response instanceof ResponseInterface) {
             $response = $this->transferToResponse($response, $request);
         }
-        return $response->withAddedHeader('Server', 'Hyperf');
+        return $response;
     }
 
     public function getMethodDefinitionCollector(): MethodDefinitionCollectorInterface


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/5609