### PR TITLE
optimize(kafka): 调整堵塞位置,减少首次启动时间

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,6 +7,7 @@
 ## Optimized
 
 - [#5634](https://github.com/hyperf/hyperf/pull/5634) Use `Hyperf\Stringable\Str` instead of `Hyperf\Utils\Str`.
+- [#5636](https://github.com/hyperf/hyperf/pull/5636) Kafka first start time elapsed
 
 # v3.0.16 - 2023-04-12
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,7 +7,7 @@
 ## Optimized
 
 - [#5634](https://github.com/hyperf/hyperf/pull/5634) Use `Hyperf\Stringable\Str` instead of `Hyperf\Utils\Str`.
-- [#5636](https://github.com/hyperf/hyperf/pull/5636) Kafka first start time elapsed
+- [#5636](https://github.com/hyperf/hyperf/pull/5636) Reduce kafka first start time and handle stop consumer logic
 
 # v3.0.16 - 2023-04-12
 

--- a/src/kafka/src/ConsumerManager.php
+++ b/src/kafka/src/ConsumerManager.php
@@ -15,6 +15,7 @@ use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Coordinator\Constants;
 use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Kafka\Annotation\Consumer as ConsumerAnnotation;
 use Hyperf\Kafka\Event\AfterConsume;
@@ -132,6 +133,12 @@ class ConsumerManager
                         }, $config['consume_timeout'] ?? -1);
                     }
                 );
+
+                // stop consumer when worker exit
+                Coroutine::create(function () use ($longLangConsumer) {
+                    CoordinatorManager::until(Constants::WORKER_EXIT)->yield();
+                    $longLangConsumer->stop();
+                });
 
                 while (true) {
                     try {


### PR DESCRIPTION
- 从 https://github.com/hyperf/kafka/commit/ed770f461583237218efce3ef2e44ae2bdac4b9b 看到这个调整。意图是否将 `retry`次数从3次调整为无限次尝试？
- 目前首次启动 固定会堵塞10秒钟才会启动消费，速度很慢
- 调整后逻辑与原本 `retry` 一致  start失败才会堵塞10秒 再重试

