### PR TITLE
Fixed bug that the model cache cannot created when using `find many` to get non-exists models.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.17 - TBD
 
+## Fixed
+
+- [#5642](https://github.com/hyperf/hyperf/pull/5642) Fixed bug that the model cache cannot created when using `find many` to get non-exists models.
+
 ## Added
 
 - [#5634](https://github.com/hyperf/hyperf/pull/5634) Added `Hyperf\Stringable\str()` helper function.

--- a/src/model-cache/src/Manager.php
+++ b/src/model-cache/src/Manager.php
@@ -130,8 +130,17 @@ class Manager
             // Get ids that not exist in cache handler.
             $targetIds = array_diff($ids, $fetchIds);
             if ($targetIds) {
-                $models = $instance->newQuery()->whereIn($primaryKey, $targetIds)->get();
+                $models = $instance->newQuery()->whereIn($primaryKey, $targetIds)->get()->getDictionary();
                 $ttl = $this->getCacheTTL($instance, $handler);
+                $emptyTtl = $handler->getConfig()->getEmptyModelTtl();
+                foreach ($targetIds as $id) {
+                    $key = $this->getCacheKey($id, $instance, $handler->getConfig());
+                    if ($model = $models[$id] ?? null) {
+                        $handler->set($key, $this->formatModel($model), $ttl);
+                    } else {
+                        $handler->set($key, [], $emptyTtl);
+                    }
+                }
                 /** @var Model $model */
                 foreach ($models as $model) {
                     $id = $model->getKey();

--- a/src/model-cache/src/Manager.php
+++ b/src/model-cache/src/Manager.php
@@ -130,22 +130,18 @@ class Manager
             // Get ids that not exist in cache handler.
             $targetIds = array_diff($ids, $fetchIds);
             if ($targetIds) {
-                $models = $instance->newQuery()->whereIn($primaryKey, $targetIds)->get()->getDictionary();
+                /** @var Collection<int, Model> $models */
+                $models = $instance->newQuery()->whereIn($primaryKey, $targetIds)->get();
+                $dictionary = $models->getDictionary();
                 $ttl = $this->getCacheTTL($instance, $handler);
                 $emptyTtl = $handler->getConfig()->getEmptyModelTtl();
                 foreach ($targetIds as $id) {
                     $key = $this->getCacheKey($id, $instance, $handler->getConfig());
-                    if ($model = $models[$id] ?? null) {
+                    if ($model = $dictionary[$id] ?? null) {
                         $handler->set($key, $this->formatModel($model), $ttl);
                     } else {
                         $handler->set($key, [], $emptyTtl);
                     }
-                }
-                /** @var Model $model */
-                foreach ($models as $model) {
-                    $id = $model->getKey();
-                    $key = $this->getCacheKey($id, $instance, $handler->getConfig());
-                    $handler->set($key, $this->formatModel($model), $ttl);
                 }
 
                 $items = array_merge($items, $this->formatModels($models));

--- a/src/model-cache/tests/ModelCacheTest.php
+++ b/src/model-cache/tests/ModelCacheTest.php
@@ -167,6 +167,22 @@ class ModelCacheTest extends TestCase
         UserModel::query(true)->where('id', $id)->delete();
     }
 
+    public function testFindManyNullBeforeCreate()
+    {
+        $container = ContainerStub::mockContainer();
+
+        $id = 207;
+
+        $models = UserModel::findManyFromCache([$id]);
+        /** @var Redis $redis */
+        $redis = $container->make(RedisProxy::class, ['pool' => 'default']);
+        $this->assertEquals(1, $redis->exists('{mc:default:m:user}:id:' . $id));
+        $this->assertSame(0, $models->count());
+
+        $this->assertEquals(1, $redis->del('{mc:default:m:user}:id:' . $id));
+        UserModel::query(true)->where('id', $id)->delete();
+    }
+
     public function testIncrNotExist()
     {
         $container = ContainerStub::mockContainer();


### PR DESCRIPTION
…odel-cache to find many models.