### PR TITLE
Fixed bug that `pgsql-swoole` cannot throw exceptions when statement execution failed.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.18 - TBD
 
+## Fixed
+
+- [#5662](https://github.com/hyperf/hyperf/pull/5662) Fixed bug that `pgsql-swoole` cannot throw exceptions when statement execution failed.
+
 ## Optimized
 
 - [#5660](https://github.com/hyperf/hyperf/pull/5660) Split `hyperf/codec` from `hyperf/utils`.

--- a/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
+++ b/src/database-pgsql/src/PostgreSqlSwooleExtConnection.php
@@ -61,9 +61,14 @@ class PostgreSqlSwooleExtConnection extends Connection
 
             $statement = $this->prepare($query);
 
+            $result = $statement->execute($this->prepareBindings($bindings));
+            if ($result === false) {
+                throw new QueryException($query, $bindings, new Exception($statement->error, $statement->errCode));
+            }
+
             $this->recordsHaveBeenModified();
 
-            return $statement->execute($this->prepareBindings($bindings));
+            return true;
         });
     }
 

--- a/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
+++ b/src/database-pgsql/tests/Cases/PostgreSqlSwooleExtConnectionTest.php
@@ -101,6 +101,23 @@ class PostgreSqlSwooleExtConnectionTest extends TestCase
         $this->assertIsNumeric($id2);
     }
 
+    public function testThrowExceptionWhenStatementExecutionFails()
+    {
+        $connection = ApplicationContext::getContainer()->get(ConnectionResolverInterface::class)->connection();
+
+        $builder = new Builder($connection);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('ERROR:  duplicate key value violates unique constraint "users_email"');
+
+        $result = $builder->from('users')->insert(['email' => 'test@hyperf.io', 'name' => 'hyperf']);
+        $result2 = $builder->from('users')->insert(['email' => 'test@hyperf.io', 'name' => 'hyperf']);
+
+        // Never here
+        $this->assertFalse($result);
+        $this->assertFalse($result2);
+    }
+
     public function testAffectingStatementWithWrongSql()
     {
         $connection = ApplicationContext::getContainer()->get(ConnectionResolverInterface::class)->connection();


### PR DESCRIPTION
Fixed #5658 