### PR TITLE
Support for adding full-text index using `migration`.

### DIFF
--- a/src/database-pgsql/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/database-pgsql/src/Schema/Grammars/PostgresGrammar.php
@@ -184,7 +184,7 @@ class PostgresGrammar extends Grammar
      *
      * @throws RuntimeException
      */
-    public function compileFulltext(Blueprint $blueprint, Fluent $command): string
+    public function compileFullText(Blueprint $blueprint, Fluent $command): string
     {
         $language = $command->language ?: 'english';
 
@@ -369,7 +369,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop fulltext index command.
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command): string
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command): string
     {
         return $this->compileDropIndex($blueprint, $command);
     }

--- a/src/database-pgsql/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/database-pgsql/src/Schema/Grammars/PostgresGrammar.php
@@ -182,10 +182,9 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a fulltext index key command.
      *
-     * @return string
      * @throws RuntimeException
      */
-    public function compileFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileFulltext(Blueprint $blueprint, Fluent $command): string
     {
         $language = $command->language ?: 'english';
 
@@ -369,10 +368,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Compile a drop fulltext index command.
-     *
-     * @return string
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileDropFulltext(Blueprint $blueprint, Fluent $command): string
     {
         return $this->compileDropIndex($blueprint, $command);
     }

--- a/src/database-pgsql/tests/Cases/DatabasePostgresSchemaGrammarTest.php
+++ b/src/database-pgsql/tests/Cases/DatabasePostgresSchemaGrammarTest.php
@@ -274,20 +274,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
     }
 
-    public function testAddingFulltextIndex()
+    public function testAddingFullTextIndex()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->fulltext('body');
+        $blueprint->fullText('body');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
     }
 
-    public function testAddingFulltextIndexWithLanguage()
+    public function testAddingFullTextIndexWithLanguage()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->fulltext('body')->language('spanish');
+        $blueprint->fullText('body')->language('spanish');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -275,6 +275,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given fulltext index should be dropped.
+     *
+     * @param array|string $index
+     * @return Fluent
+     */
+    public function dropFullText($index)
+    {
+        return $this->dropIndexCommand('dropFullText', 'fulltext', $index);
+    }
+
+    /**
      * Indicate that the given spatial index should be dropped.
      *
      * @param array|string $index
@@ -1280,7 +1291,7 @@ class Blueprint
      * @param null|string $algorithm
      * @return Fluent
      */
-    public function fulltext($columns, $name = null, $algorithm = null)
+    public function fullText($columns, $name = null, $algorithm = null)
     {
         return $this->indexCommand('fulltext', $columns, $name, $algorithm);
     }
@@ -1385,7 +1396,7 @@ class Blueprint
     protected function addFluentIndexes()
     {
         foreach ($this->columns as $column) {
-            foreach (['primary', 'unique', 'index', 'spatialIndex'] as $index) {
+            foreach (['primary', 'unique', 'index', 'fullText', 'spatialIndex'] as $index) {
                 // If the index has been specified on the given column, but is simply equal
                 // to "true" (boolean), no name has been specified for this index so the
                 // index method can be called without a name and it will generate one.

--- a/src/database/src/Schema/ColumnDefinition.php
+++ b/src/database/src/Schema/ColumnDefinition.php
@@ -27,6 +27,7 @@ use Hyperf\Support\Fluent;
  * @method ColumnDefinition index(string $name = null) Add an index
  * @method ColumnDefinition nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method ColumnDefinition primary() Add a primary index
+ * @method ColumnDefinition fullText() Add a full-text index
  * @method ColumnDefinition spatialIndex() Add a spatial index
  * @method ColumnDefinition storedAs(string $expression) Create a stored generated column (MySQL)
  * @method ColumnDefinition unique(string $name = null) Add a unique index

--- a/src/database/src/Schema/Grammars/Grammar.php
+++ b/src/database/src/Schema/Grammars/Grammar.php
@@ -53,6 +53,24 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a fulltext index key command.
+     *
+     * @throws RuntimeException
+     */
+    public function compileFulltext(Blueprint $blueprint, Fluent $command): string
+    {
+        throw new RuntimeException('This database driver does not support fulltext index creation.');
+    }
+
+    /**
+     * Compile a drop fulltext index command.
+     */
+    public function compileDropFulltext(Blueprint $blueprint, Fluent $command): string
+    {
+        throw new RuntimeException('This database driver does not support fulltext index creation.');
+    }
+
+    /**
      * Compile a foreign key command.
      */
     public function compileForeign(Blueprint $blueprint, Fluent $command): string

--- a/src/database/src/Schema/Grammars/Grammar.php
+++ b/src/database/src/Schema/Grammars/Grammar.php
@@ -57,7 +57,7 @@ abstract class Grammar extends BaseGrammar
      *
      * @throws RuntimeException
      */
-    public function compileFulltext(Blueprint $blueprint, Fluent $command): string
+    public function compileFullText(Blueprint $blueprint, Fluent $command): string
     {
         throw new RuntimeException('This database driver does not support fulltext index creation.');
     }
@@ -65,7 +65,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Compile a drop fulltext index command.
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command): string
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command): string
     {
         throw new RuntimeException('This database driver does not support fulltext index creation.');
     }

--- a/src/database/src/Schema/Grammars/MySqlGrammar.php
+++ b/src/database/src/Schema/Grammars/MySqlGrammar.php
@@ -138,6 +138,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a fulltext index key command.
+     */
+    public function compileFullText(Blueprint $blueprint, Fluent $command): string
+    {
+        return $this->compileKey($blueprint, $command, 'fulltext');
+    }
+
+    /**
      * Compile a spatial index key command.
      *
      * @return string
@@ -211,6 +219,14 @@ class MySqlGrammar extends Grammar
         $index = $this->wrap($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop index {$index}";
+    }
+
+    /**
+     * Compile a drop fulltext index command.
+     */
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command): string
+    {
+        return $this->compileDropIndex($blueprint, $command);
     }
 
     /**

--- a/src/database/tests/MySqlSchemaGrammarTest.php
+++ b/src/database/tests/MySqlSchemaGrammarTest.php
@@ -1,0 +1,1104 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Database;
+
+use Hyperf\Database\Connection;
+use Hyperf\Database\Query\Expression;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Schema\ForeignIdColumnDefinition;
+use Hyperf\Database\Schema\Grammars\MySqlGrammar;
+use Mockery as m;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class MySqlSchemaGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testBasicCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
+    }
+
+    public function testEngineCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->engine = 'InnoDB';
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn('InnoDB');
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
+    }
+
+    public function testCharsetCollationCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->charset = 'utf8mb4';
+        $blueprint->collation = 'utf8mb4_unicode_ci';
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci'", $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
+    }
+
+    public function testBasicCreateTableWithPrefix()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $grammar = $this->getGrammar();
+        $grammar->setTablePrefix('prefix_');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $grammar);
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+    }
+
+    public function testCreateTemporaryTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+    }
+
+    public function testDropTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->drop();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop table `users`', $statements[0]);
+    }
+
+    public function testDropTableIfExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIfExists();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop table if exists `users`', $statements[0]);
+    }
+
+    public function testDropColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropColumn('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `foo`', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dropColumn(['foo', 'bar']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dropColumn('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+    }
+
+    public function testDropPrimary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop primary key', $statements[0]);
+    }
+
+    public function testDropUnique()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropUnique('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
+    }
+
+    public function testDropIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
+    }
+
+    public function testDropFullTextIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropFullText('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
+    }
+
+    public function testDropSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
+    }
+
+    public function testDropForeign()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropForeign('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop foreign key `foo`', $statements[0]);
+    }
+
+    public function testDropTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropTimestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+    }
+
+    public function testDropTimestampsTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropTimestampsTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+    }
+
+    public function testDropMorphs()
+    {
+        $blueprint = new Blueprint('photos');
+        $blueprint->dropMorphs('imageable');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
+        $this->assertSame('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
+    }
+
+    public function testRenameTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rename('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('rename table `users` to `foo`', $statements[0]);
+    }
+
+    public function testRenameIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->renameIndex('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` rename index `foo` to `bar`', $statements[0]);
+    }
+
+    public function testAddingPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->primary('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingPrimaryKeyWithAlgorithm()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->primary('foo', 'bar', 'hash');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
+    }
+
+    public function testAddingUniqueKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique('foo', 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
+    }
+
+    public function testAddingIndexWithAlgorithm()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], 'baz', 'hash');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
+    }
+
+    public function testAddingFullTextIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->fullText('body');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`)', $statements[0]);
+    }
+
+    public function testAddingFullTextIndexWithFluency()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('body')->fullText();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `body` varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`)', $statements[1]);
+    }
+
+    public function testAddingSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
+    }
+
+    public function testAddingFluentSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates')->spatialIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
+    }
+
+    public function testAddingRawIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawIndex('(function(column))', 'raw_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `raw_index`((function(column)))', $statements[0]);
+    }
+
+    public function testAddingForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
+    }
+
+    public function testAddingIncrementingID()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->increments('id');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingSmallIncrementingID()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->smallIncrements('id');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingID()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->id();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingBigIncrementingID()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->bigIncrements('id');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingColumnInTableFirst()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('name')->first();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null first', $statements[0]);
+    }
+
+    public function testAddingColumnAfterAnotherColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('name')->after('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
+    }
+
+    public function testAddingGeneratedColumn()
+    {
+        $blueprint = new Blueprint('products');
+        $blueprint->integer('price');
+        $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
+        $blueprint->integer('discounted_stored')->storedAs('price - 5');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
+    }
+
+    public function testAddingString()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(255) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo', 100);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(100) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo', 100)->nullable()->default('bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
+    }
+
+    public function testAddingText()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->text('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` text not null', $statements[0]);
+    }
+
+    public function testAddingBigInteger()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->bigInteger('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` bigint not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->bigInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingInteger()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` int not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingMediumInteger()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->mediumInteger('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` mediumint not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->mediumInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingSmallInteger()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->smallInteger('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` smallint not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->smallInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingTinyInteger()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->tinyInteger('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` tinyint not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->tinyInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
+    }
+
+    public function testAddingFloat()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->float('foo', 5, 2);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
+    }
+
+    public function testAddingDouble()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->double('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` double not null', $statements[0]);
+    }
+
+    public function testAddingDoubleSpecifyingPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->double('foo', 15, 8);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
+    }
+
+    public function testAddingDecimal()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->decimal('foo', 5, 2);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
+    }
+
+    public function testAddingBoolean()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->boolean('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
+    }
+
+    public function testAddingEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', ['member', 'admin']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+    }
+
+    public function testAddingJson()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->json('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
+    }
+
+    public function testAddingJsonb()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->jsonb('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
+    }
+
+    public function testAddingDate()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->date('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
+    }
+
+    public function testAddingYear()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->year('birth_year');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
+    }
+
+    public function testAddingDateTime()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('foo', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
+    }
+
+    public function testAddingTime()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimeTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
+    }
+
+    public function testAddingTimeTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimestamp()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
+    }
+
+    public function testAddingTimestampWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimestampWithDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+    }
+
+    public function testAddingTimestampTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimeStampTzWithDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+    }
+
+    public function testAddingTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+    }
+
+    public function testAddingTimestampsTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+    }
+
+    public function testAddingRememberToken()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rememberToken();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
+    }
+
+    public function testAddingBinary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->binary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
+    }
+
+    public function testAddingUuid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->uuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
+    }
+
+    public function testAddingForeignUuid()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignUuid = $blueprint->foreignUuid('foo');
+        $blueprint->foreignUuid('company_id')->constrained();
+        $blueprint->foreignUuid('laravel_idea_id')->constrained();
+        $blueprint->foreignUuid('team_id')->references('id')->on('teams');
+        $blueprint->foreignUuid('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertSame([
+            'alter table `users` add `foo` char(36) not null, add `company_id` char(36) not null, add `laravel_idea_id` char(36) not null, add `team_id` char(36) not null, add `team_column_id` char(36) not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingIpAddress()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ipAddress('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(45) not null', $statements[0]);
+    }
+
+    public function testAddingMacAddress()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->macAddress('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(17) not null', $statements[0]);
+    }
+
+    public function testAddingGeometry()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometry('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` geometry not null', $statements[0]);
+    }
+
+    public function testAddingPoint()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` point not null', $statements[0]);
+    }
+
+    public function testAddingPointWithSrid()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates', 4326);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` point not null srid 4326', $statements[0]);
+    }
+
+    public function testAddingLineString()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->linestring('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` linestring not null', $statements[0]);
+    }
+
+    public function testAddingPolygon()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->polygon('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` polygon not null', $statements[0]);
+    }
+
+    public function testAddingGeometryCollection()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometrycollection('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
+    }
+
+    public function testAddingMultiPoint()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipoint('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
+    }
+
+    public function testAddingMultiLineString()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multilinestring('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
+    }
+
+    public function testAddingMultiPolygon()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipolygon('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
+    }
+
+    public function testAddingComment()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo')->comment("Escape ' when using words like it's");
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+    }
+
+    public function testCreateTableWithVirtualAsColumn()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('my_column');
+        $blueprint->string('my_other_column')->virtualAs('my_column');
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`my_column` varchar(255) not null, `my_other_column` varchar(255) as (my_column)) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
+    }
+
+    public function testDropAllTables()
+    {
+        $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
+
+        $this->assertSame('drop table `alpha`,`beta`,`gamma`', $statement);
+    }
+
+    public function testDropAllViews()
+    {
+        $statement = $this->getGrammar()->compileDropAllViews(['alpha', 'beta', 'gamma']);
+
+        $this->assertSame('drop view `alpha`,`beta`,`gamma`', $statement);
+    }
+
+    public function testGrammarsAreMacroable()
+    {
+        // compileReplace macro.
+        $this->getGrammar()::macro('compileReplace', function () {
+            return true;
+        });
+
+        $this->assertTrue($this->getGrammar()::compileReplace());
+    }
+
+    public function getGrammar(): MySqlGrammar
+    {
+        return new MySqlGrammar();
+    }
+
+    protected function getConnection()
+    {
+        return m::mock(new Connection(m::mock(PDO::class)));
+    }
+}


### PR DESCRIPTION
`full-text` 是一个复合单词，早期 Laravel 实现全文索引的时候，连字符 `-` 后面的单词首字母是不大写的，所以方法名字都是 `fulltext` 和 `compileFulltext` 这种命名规则。但是在后来迭代过程中，又改成了 `fullText`  和 `compileFullText`，并且对原来的调用方式做了兼容。

我这次是以最新的命名规则实现的，由于之前 Hyperf 没有实现添加全文索引，所以不需要对此做兼容。

Closes #5549