### PR TITLE
Support Server instance as default

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,6 +8,7 @@
 ## Fixed
 
 - [#5709](https://github.com/hyperf/hyperf/pull/5709) Fixed bug that the error message is wrong when the logger group not found.
+- [#5713](https://github.com/hyperf/hyperf/pull/5713) Support Server instance as default.
 
 # v3.0.19 - 2023-05-06
 

--- a/src/super-globals/src/Proxy/Server.php
+++ b/src/super-globals/src/Proxy/Server.php
@@ -18,8 +18,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class Server extends Proxy
 {
-    public function __construct(protected array $default)
+    public function __construct(protected array|Server $default)
     {
+        if ($default instanceof Server) {
+            $this->default = $default->toArray();
+        }
     }
 
     public function toArray(): array

--- a/src/super-globals/tests/ProxyTest.php
+++ b/src/super-globals/tests/ProxyTest.php
@@ -125,6 +125,13 @@ class ProxyTest extends TestCase
         $this->assertSame('127.0.0.1', $proxy['HTTP_X_FORWARDED_FOR']);
         $this->assertSame('hyperf.io', $proxy['HTTP_HOST']);
 
+        $proxy = new Server($proxy);
+
+        $this->assertSame($name, $proxy['SERVER_NAME']);
+        $this->assertSame($token, $proxy['HTTP_X_TOKEN']);
+        $this->assertSame('127.0.0.1', $proxy['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame('hyperf.io', $proxy['HTTP_HOST']);
+
         (new Waiter())->wait(function () {
             $proxy = new Server([]);
             $this->assertSame([], $proxy->toArray());


### PR DESCRIPTION
```shell
[ERROR] TypeError: Hyperf\SuperGlobals\Proxy\Server::__construct(): Argument #1 ($default) must be of type array, Hyperf\SuperGlobals\Proxy\Server given, called in /Users/user/gitroot/demo/vendor/hyperf/di/src/Resolver/ObjectResolver.php on line 84 and defined in /Users/user/gitroot/demo/vendor/hyperf/super-globals/src/Proxy/Server.php:21
```