### PR TITLE
optimize code: useless after version 2.0

### DIFF
--- a/src/redis/src/RedisProxy.php
+++ b/src/redis/src/RedisProxy.php
@@ -24,15 +24,4 @@ class RedisProxy extends Redis
 
         $this->poolName = $pool;
     }
-
-    /**
-     * WARN: Can't remove this function, because AOP need it.
-     * @see https://github.com/hyperf/hyperf/issues/1239
-     * @param string $name
-     * @param array $arguments
-     */
-    public function __call($name, $arguments)
-    {
-        return parent::__call($name, $arguments);
-    }
 }

--- a/src/redis/src/RedisProxy.php
+++ b/src/redis/src/RedisProxy.php
@@ -24,4 +24,14 @@ class RedisProxy extends Redis
 
         $this->poolName = $pool;
     }
+
+    /**
+     * @deprecated since version 3.1
+     * @param string $name
+     * @param array $arguments
+     */
+    public function __call($name, $arguments)
+    {
+        return parent::__call($name, $arguments);
+    }
 }


### PR DESCRIPTION
2.0 之后可以移除, AOP 通过classmap 可以作用于子类