### PR TITLE
Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage` to avoid message block.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,11 @@
 
 ## Added
 
-[#5721](https://github.com/hyperf/hyperf/pull/5721) Added `exception` property to Request Lifecycle Events.
+- [#5721](https://github.com/hyperf/hyperf/pull/5721) Added `exception` property to Request Lifecycle Events.
+
+## Optimized
+
+- [#5720](https://github.com/hyperf/hyperf/pull/5720) Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage`;
 
 # v3.0.20 - 2023-05-12
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,7 +6,7 @@
 
 ## Optimized
 
-- [#5720](https://github.com/hyperf/hyperf/pull/5720) Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage`.
+- [#5720](https://github.com/hyperf/hyperf/pull/5720) Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage` to avoid message block.
 
 # v3.0.20 - 2023-05-12
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,7 +6,7 @@
 
 ## Optimized
 
-- [#5720](https://github.com/hyperf/hyperf/pull/5720) Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage`;
+- [#5720](https://github.com/hyperf/hyperf/pull/5720) Optimized the code of `Hyperf\Metric\Listener\OnPipeMessage`.
 
 # v3.0.20 - 2023-05-12
 

--- a/src/metric/src/Listener/OnPipeMessage.php
+++ b/src/metric/src/Listener/OnPipeMessage.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Metric\Listener;
 
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Metric\Adapter\RemoteProxy\Counter;
 use Hyperf\Metric\Adapter\RemoteProxy\Gauge;
@@ -41,30 +42,32 @@ class OnPipeMessage implements ListenerInterface
      */
     public function process(object $event): void
     {
-        $factory = make(MetricFactoryInterface::class);
-        if (property_exists($event, 'data') && $event instanceof PipeMessage) {
-            $inner = $event->data;
-            switch (true) {
-                case $inner instanceof Counter:
-                    $counter = $factory->makeCounter($inner->name, $inner->labelNames);
-                    $counter->with(...$inner->labelValues)->add($inner->delta);
-                    break;
-                case $inner instanceof Gauge:
-                    $gauge = $factory->makeGauge($inner->name, $inner->labelNames);
-                    if (isset($inner->value)) {
-                        $gauge->with(...$inner->labelValues)->set($inner->value);
-                    } else {
-                        $gauge->with(...$inner->labelValues)->add($inner->delta);
-                    }
-                    break;
-                case $inner instanceof Histogram:
-                    $histogram = $factory->makeHistogram($inner->name, $inner->labelNames);
-                    $histogram->with(...$inner->labelValues)->put($inner->sample);
-                    break;
-                default:
-                    // Nothing to do
-                    break;
+        Coroutine::create(function () use ($event) {
+            $factory = make(MetricFactoryInterface::class);
+            if (property_exists($event, 'data') && $event instanceof PipeMessage) {
+                $inner = $event->data;
+                switch (true) {
+                    case $inner instanceof Counter:
+                        $counter = $factory->makeCounter($inner->name, $inner->labelNames);
+                        $counter->with(...$inner->labelValues)->add($inner->delta);
+                        break;
+                    case $inner instanceof Gauge:
+                        $gauge = $factory->makeGauge($inner->name, $inner->labelNames);
+                        if (isset($inner->value)) {
+                            $gauge->with(...$inner->labelValues)->set($inner->value);
+                        } else {
+                            $gauge->with(...$inner->labelValues)->add($inner->delta);
+                        }
+                        break;
+                    case $inner instanceof Histogram:
+                        $histogram = $factory->makeHistogram($inner->name, $inner->labelNames);
+                        $histogram->with(...$inner->labelValues)->put($inner->sample);
+                        break;
+                    default:
+                        // Nothing to do
+                        break;
+                }
             }
-        }
+        });
     }
 }

--- a/src/metric/src/Listener/OnPipeMessage.php
+++ b/src/metric/src/Listener/OnPipeMessage.php
@@ -44,7 +44,7 @@ class OnPipeMessage implements ListenerInterface
     {
         Coroutine::create(function () use ($event) {
             $factory = make(MetricFactoryInterface::class);
-            if (property_exists($event, 'data') && $event instanceof PipeMessage) {
+            if ($event instanceof PipeMessage) {
                 $inner = $event->data;
                 switch (true) {
                     case $inner instanceof Counter:


### PR DESCRIPTION
`\Hyperf\Process\AbstractProcess::listen` 方法中，是一个协程容器；[src/process/src/AbstractProcess.php#L160](https://github.com/hyperf/hyperf/blob/master/src/process/src/AbstractProcess.php#L160) 的 `$sock->recv` 是一个协程客户端，也可以理解为其子协程容器

[src/process/src/AbstractProcess.php#L170](https://github.com/hyperf/hyperf/blob/master/src/process/src/AbstractProcess.php#L170)即 src/metric/src/Listener/OnPipeMessage.php 运行处是在父协程容器中，如果有 IO，并不会 yield 给 `$sock->recv`

#### 复现办法

```php
<?php

declare(strict_types=1);

namespace Hyperf\Metric\Listener;

use Hyperf\Coroutine\Coroutine;
use Hyperf\Event\Contract\ListenerInterface;
use Hyperf\Process\Event\PipeMessage;

class OnPipeMessage implements ListenerInterface
{
    public function listen(): array
    {
        return [
            PipeMessage::class,
        ];
    }

    public function process(object $event): void
    {
        // sleep(5); 如果解除注释，则会一直阻塞住，即 `src/process/src/AbstractProcess.php#L160` 的 `$sock->recv` 无法持续接受到消息

        Coroutine::create(function () use ($event) {
            sleep(5);
            echo date('Y-m-d H:i:s').PHP_EOL;
        });
    }
}
```

#### 解决思路

1、在 AbstractProcess 中使用 `Channel`

由于 Process 使用较多，此方式可能会有未知问题，否决

2、直接在 metric 的 OnPipeMessage 中使用 Coroutine

影响面最小，即此 PR 的方式


感谢