### PR TITLE
Add deprecated comments to `MySQLConnection`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.22 - TBD
 
+## Optimized
+
+- [#5741](https://github.com/hyperf/hyperf/pull/5741) Added deprecated comments to `Hyperf\DB\MySQLConnection`.
+
 # v3.0.21 - 2023-05-18
 
 ## Added

--- a/src/database/src/Connectors/ConnectionFactory.php
+++ b/src/database/src/Connectors/ConnectionFactory.php
@@ -63,12 +63,10 @@ class ConnectionFactory
             return $this->container->get($key);
         }
 
-        switch ($config['driver']) {
-            case 'mysql':
-                return new MySqlConnector();
-        }
-
-        throw new InvalidArgumentException("Unsupported driver [{$config['driver']}]");
+        return match ($config['driver']) {
+            'mysql' => new MySqlConnector(),
+            default => throw new InvalidArgumentException("Unsupported driver [{$config['driver']}]"),
+        };
     }
 
     /**

--- a/src/db/src/MySQLConnection.php
+++ b/src/db/src/MySQLConnection.php
@@ -19,7 +19,7 @@ use Swoole\Coroutine\MySQL;
 use Swoole\Coroutine\MySQL\Statement;
 
 /**
- * @deprecated since 3.1, use \Hyperf\DB\PDOConnection instead.
+ * @deprecated since 3.1, will be removed in 4.0.
  */
 class MySQLConnection extends AbstractConnection
 {

--- a/src/db/src/MySQLConnection.php
+++ b/src/db/src/MySQLConnection.php
@@ -18,6 +18,9 @@ use Psr\Container\ContainerInterface;
 use Swoole\Coroutine\MySQL;
 use Swoole\Coroutine\MySQL\Statement;
 
+/**
+ * @deprecated since 3.1, use \Hyperf\DB\PDOConnection instead.
+ */
 class MySQLConnection extends AbstractConnection
 {
     protected ?MySQL $connection = null;

--- a/src/db/src/Pool/PoolFactory.php
+++ b/src/db/src/Pool/PoolFactory.php
@@ -40,29 +40,22 @@ class PoolFactory
         $config = $this->container->get(ConfigInterface::class);
         $driver = $config->get(sprintf('db.%s.driver', $name), 'pdo');
         $class = $this->getPoolName($driver);
-
         $pool = make($class, [$this->container, $name]);
+
         if (! $pool instanceof Pool) {
             throw new InvalidDriverException(sprintf('Driver %s is not invalid.', $driver));
         }
+
         return $this->pools[$name] = $pool;
     }
 
     protected function getPoolName(string $driver): string
     {
-        switch (strtolower($driver)) {
-            case 'mysql':
-                return MySQLPool::class;
-            case 'pdo':
-                return PDOPool::class;
-            case 'pgsql':
-                return PgSQLPool::class;
-        }
-
-        if (class_exists($driver)) {
-            return $driver;
-        }
-
-        throw new DriverNotFoundException(sprintf('Driver %s is not found.', $driver));
+        return match (strtolower($driver)) {
+            'mysql' => MySQLPool::class,
+            'pdo' => PDOPool::class,
+            'pgsql' => PgSQLPool::class,
+            default => class_exists($driver) ? $driver : throw new DriverNotFoundException(sprintf('Driver %s is not found.', $driver)),
+        };
     }
 }


### PR DESCRIPTION
使用 `\Hyperf\DB\DB::connection('default')->query($sql)` 查询数据库时，有可能会发生以下错误：

```
TypeError: Hyperf\\DB\\MySQLConnection::query(): Return value must be of type array, bool returned
```

本次增加了对 `Statement::fetchAll()` 方法返回值的检查。