### PR TITLE
Improve `Hyperf\Command\Annotation\Command`

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.23 - TBD
 
+## Optimized
+
+- [#5768](https://github.com/hyperf/hyperf/pull/5768) Improved `Hyperf\Command\Annotation\Command`, support set properties for command.
+
 # v3.0.22 - 2023-05-27
 
 ## Added

--- a/src/command/src/Annotation/Command.php
+++ b/src/command/src/Annotation/Command.php
@@ -17,4 +17,13 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
 #[Attribute(Attribute::TARGET_CLASS)]
 class Command extends AbstractAnnotation
 {
+    public function __construct(
+        public string $name = '',
+        public array $arguments = [],
+        public array $options = [],
+        public string $description = '',
+        public array $aliases = [],
+        public ?string $signature = null,
+    ) {
+    }
 }

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -82,11 +82,15 @@ class ApplicationFactory
         }
 
         if ($annotation->arguments) {
-            $command->getDefinition()->setArguments($annotation->arguments);
+            $command->getDefinition()->setArguments(
+                array_merge($command->getDefinition()->getArguments(), $annotation->arguments)
+            );
         }
 
         if ($annotation->options) {
-            $command->getDefinition()->setOptions($annotation->options);
+            $command->getDefinition()->setOptions(
+                array_merge($command->getDefinition()->getOptions(), $annotation->options)
+            );
         }
 
         if ($annotation->description) {

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -16,10 +16,13 @@ use Hyperf\Command\Parser;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Framework\Event\BootApplication;
+use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
+use Symfony\Component\Console\Exception\LogicException;
 
 class ApplicationFactory
 {
@@ -55,6 +58,11 @@ class ApplicationFactory
         return $application;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     * @throws SymfonyInvalidArgumentException
+     * @throws LogicException
+     */
     protected function pendingCommand(SymfonyCommand $command): SymfonyCommand
     {
         /** @var null|Command $annotation */
@@ -82,15 +90,11 @@ class ApplicationFactory
         }
 
         if ($annotation->arguments) {
-            $command->getDefinition()->setArguments(
-                array_merge($command->getDefinition()->getArguments(), $annotation->arguments)
-            );
+            $command->getDefinition()->addArguments($annotation->arguments);
         }
 
         if ($annotation->options) {
-            $command->getDefinition()->setOptions(
-                array_merge($command->getDefinition()->getOptions(), $annotation->options)
-            );
+            $command->getDefinition()->addOptions($annotation->options);
         }
 
         if ($annotation->description) {

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -19,6 +19,7 @@ use Hyperf\Framework\Event\BootApplication;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 class ApplicationFactory
 {
@@ -54,9 +55,9 @@ class ApplicationFactory
         return $application;
     }
 
-    protected function setCommandProperties(object $command)
+    protected function setCommandProperties(SymfonyCommand $command): SymfonyCommand
     {
-        $annotation = AnnotationCollector::get($command::class)['_c'][Command::class] ?? null;
+        $annotation = AnnotationCollector::getClassAnnotation($command::class, Command::class) ?? null;
 
         if (! $annotation) {
             return $command;

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -57,7 +57,7 @@ class ApplicationFactory
 
     protected function pendingCommand(SymfonyCommand $command): SymfonyCommand
     {
-        /** @var Command $annotation */
+        /** @var null|Command $annotation */
         $annotation = AnnotationCollector::getClassAnnotation($command::class, Command::class) ?? null;
 
         if (! $annotation) {

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -48,14 +48,14 @@ class ApplicationFactory
 
         foreach ($commands as $command) {
             $application->add(
-                $this->setCommandProperties($container->get($command))
+                $this->pendingCommand($container->get($command))
             );
         }
 
         return $application;
     }
 
-    protected function setCommandProperties(SymfonyCommand $command): SymfonyCommand
+    protected function pendingCommand(SymfonyCommand $command): SymfonyCommand
     {
         $annotation = AnnotationCollector::getClassAnnotation($command::class, Command::class) ?? null;
 

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class ApplicationFactory
 {
@@ -90,11 +92,27 @@ class ApplicationFactory
         }
 
         if ($annotation->arguments) {
-            $command->getDefinition()->addArguments($annotation->arguments);
+            array_map(static function ($argument) use ($command) {
+                if ($argument instanceof InputArgument) {
+                    $command->getDefinition()->addArgument($argument);
+                } elseif (is_array($argument)) {
+                    $command->addArgument(...$argument);
+                } else {
+                    throw new LogicException(sprintf('Invalid argument type: %s.', gettype($argument)));
+                }
+            }, $annotation->arguments);
         }
 
         if ($annotation->options) {
-            $command->getDefinition()->addOptions($annotation->options);
+            array_map(static function ($option) use ($command) {
+                if ($option instanceof InputOption) {
+                    $command->getDefinition()->addOption($option);
+                } elseif (is_array($option)) {
+                    $command->addOption(...$option);
+                } else {
+                    throw new LogicException(sprintf('Invalid option type: %s.', gettype($option)));
+                }
+            }, $annotation->options);
         }
 
         if ($annotation->description) {

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -80,10 +80,10 @@ class ApplicationFactory
                 $annotation->name = $name;
             }
             if ($arguments) {
-                $annotation->arguments = $arguments;
+                $annotation->arguments = array_merge($annotation->arguments, $arguments);
             }
             if ($options) {
-                $annotation->options = $options;
+                $annotation->options = array_merge($annotation->options, $options);
             }
         }
 
@@ -92,27 +92,35 @@ class ApplicationFactory
         }
 
         if ($annotation->arguments) {
-            array_map(static function ($argument) use ($command) {
+            $annotation->arguments = array_map(static function ($argument): InputArgument {
                 if ($argument instanceof InputArgument) {
-                    $command->getDefinition()->addArgument($argument);
-                } elseif (is_array($argument)) {
-                    $command->addArgument(...$argument);
-                } else {
-                    throw new LogicException(sprintf('Invalid argument type: %s.', gettype($argument)));
+                    return $argument;
                 }
+
+                if (is_array($argument)) {
+                    return new InputArgument(...$argument);
+                }
+
+                throw new LogicException(sprintf('Invalid argument type: %s.', gettype($argument)));
             }, $annotation->arguments);
+
+            $command->getDefinition()->addArguments($annotation->arguments);
         }
 
         if ($annotation->options) {
-            array_map(static function ($option) use ($command) {
+            $annotation->options = array_map(static function ($option): InputOption {
                 if ($option instanceof InputOption) {
-                    $command->getDefinition()->addOption($option);
-                } elseif (is_array($option)) {
-                    $command->addOption(...$option);
-                } else {
-                    throw new LogicException(sprintf('Invalid option type: %s.', gettype($option)));
+                    return $option;
                 }
+
+                if (is_array($option)) {
+                    return new InputOption(...$option);
+                }
+
+                throw new LogicException(sprintf('Invalid option type: %s.', gettype($option)));
             }, $annotation->options);
+
+            $command->getDefinition()->addOptions($annotation->options);
         }
 
         if ($annotation->description) {

--- a/src/framework/src/ApplicationFactory.php
+++ b/src/framework/src/ApplicationFactory.php
@@ -57,6 +57,7 @@ class ApplicationFactory
 
     protected function pendingCommand(SymfonyCommand $command): SymfonyCommand
     {
+        /** @var Command $annotation */
         $annotation = AnnotationCollector::getClassAnnotation($command::class, Command::class) ?? null;
 
         if (! $annotation) {


### PR DESCRIPTION
Usage:

```php
<?php
namespace App\Command;

use Hyperf\Command\Annotation\Command;

#[Command(name: 'foo:bar', description: 'This is a foo command.')]
class FooCommand extends \Hyperf\Command\Command
{
    protected function handle()
    {
        var_dump($this->input->getOptions());
    }
}

```

Support Symfony Command

```php
<?php
namespace App\Command;

use Hyperf\Command\Annotation\Command;

#[Command(name: 'foo:bar', description: 'This is a foo command.')]
class FooCommand extends \Symfony\Component\Console\Command\Command
{
    protected function execute(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): int
    {
        var_dump($input->getOptions());
        return 0;
    }
}

```

Merge options or args

```php
namespace App\Command;

use Hyperf\Command\Annotation\Command;
use Symfony\Component\Console\Input\InputOption;

#[Command(signature: 'foo:bar {--id= : ID} {--sex=boy}', description: 'This is a foo command.')]
class FooCommand extends \Hyperf\Command\Command
{
    public function handle()
    {
        var_dump($this->input->getOptions());
    }

    protected function configure()
    {
        $this->addOption('name', 'N', InputOption::VALUE_OPTIONAL, 'The option description', 'Deeka');
        parent::configure();
    }
}

```

Output

```shell
array(10) {
  ["name"]=>
  string(5) "Deeka"
  ["disable-event-dispatcher"]=>
  bool(false)
  ["id"]=>
  NULL
  ["sex"]=>
  string(3) "boy"
  ["help"]=>
  bool(false)
  ["quiet"]=>
  bool(false)
  ["verbose"]=>
  bool(false)
  ["version"]=>
  bool(false)
  ["ansi"]=>
  NULL
  ["no-interaction"]=>
  bool(false)
}
```