### PR TITLE
Convert carrier key to string in `Zipkin\Propagation\Map`

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,10 @@
 - [#5757](https://github.com/hyperf/hyperf/pull/5757) Support nacos naming signature.
 - [#5765](https://github.com/hyperf/hyperf/pull/5765) Support Full-Text Search for `database`.
 
+## Fixed
+
+- [#5780](https://github.com/hyperf/hyperf/pull/5780) Convert carrier key to string.
+
 ## Optimized
 
 - [#5768](https://github.com/hyperf/hyperf/pull/5768) Improved `Hyperf\Command\Annotation\Command`, support set properties for command.

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,7 +8,7 @@
 ## Optimized
 
 - [#5768](https://github.com/hyperf/hyperf/pull/5768) Improved `Hyperf\Command\Annotation\Command`, support set properties for command.
-- [#5780](https://github.com/hyperf/hyperf/pull/5780) Convert carrier key to string.
+- [#5780](https://github.com/hyperf/hyperf/pull/5780) Convert carrier key to string in `Zipkin\Propagation\Map`.
 
 # v3.0.22 - 2023-05-27
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,13 +5,10 @@
 - [#5757](https://github.com/hyperf/hyperf/pull/5757) Support nacos naming signature.
 - [#5765](https://github.com/hyperf/hyperf/pull/5765) Support Full-Text Search for `database`.
 
-## Fixed
-
-- [#5780](https://github.com/hyperf/hyperf/pull/5780) Convert carrier key to string.
-
 ## Optimized
 
 - [#5768](https://github.com/hyperf/hyperf/pull/5768) Improved `Hyperf\Command\Annotation\Command`, support set properties for command.
+- [#5780](https://github.com/hyperf/hyperf/pull/5780) Convert carrier key to string.
 
 # v3.0.22 - 2023-05-27
 

--- a/src/tracer/class_map/Map.php
+++ b/src/tracer/class_map/Map.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Zipkin\Propagation;
+
+use ArrayAccess;
+use Zipkin\Propagation\Exceptions\InvalidPropagationCarrier;
+use Zipkin\Propagation\Exceptions\InvalidPropagationKey;
+
+use function is_array;
+
+class Map implements Getter, Setter
+{
+    /**
+     * {@inheritdoc}
+     *
+     * If the carrier is an array, the lookup is case insensitive, this is
+     * mainly because Map getter is commonly used for those cases where the
+     * HTTP framework does not follow the PSR request/response objects (e.g.
+     * Symfony) and thus the header bag should be treated as a map. ArrayAccess
+     * can't be case insensitive because we can not know the keys on beforehand.
+     *
+     * @param array|ArrayAccess $carrier
+     */
+    public function get($carrier, string $key): ?string
+    {
+        $lKey = \strtolower($key);
+
+        if ($carrier instanceof ArrayAccess) {
+            return $carrier->offsetExists($lKey) ? $carrier->offsetGet($lKey) : null;
+        }
+
+        if (is_array($carrier)) {
+            if (empty($carrier)) {
+                return null;
+            }
+
+            foreach ($carrier as $k => $value) {
+                if (strtolower((string) $k) === $lKey) {
+                    return $value;
+                }
+            }
+
+            return null;
+        }
+
+        throw InvalidPropagationCarrier::forCarrier($carrier);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @param array|ArrayAccess $carrier
+     */
+    public function put(&$carrier, string $key, string $value): void
+    {
+        if ($key === '') {
+            throw InvalidPropagationKey::forEmptyKey();
+        }
+
+        // Lowercasing the key was a first attempt to be compatible with the
+        // getter when using the Map getter for HTTP headers.
+        $lKey = \strtolower($key);
+
+        if ($carrier instanceof ArrayAccess || is_array($carrier)) {
+            $carrier[$lKey] = $value;
+            return;
+        }
+
+        throw InvalidPropagationCarrier::forCarrier($carrier);
+    }
+}

--- a/src/tracer/src/ConfigProvider.php
+++ b/src/tracer/src/ConfigProvider.php
@@ -18,6 +18,7 @@ use Hyperf\Tracer\Aspect\TraceAnnotationAspect;
 use Hyperf\Tracer\Listener\DbQueryExecutedListener;
 use Jaeger\ThriftUdpTransport;
 use OpenTracing\Tracer;
+use Zipkin\Propagation\Map;
 
 class ConfigProvider
 {
@@ -36,6 +37,7 @@ class ConfigProvider
             'annotations' => [
                 'scan' => [
                     'class_map' => [
+                        Map::class => __DIR__ . '/../class_map/Map.php',
                         ThriftUdpTransport::class => __DIR__ . '/../class_map/ThriftUdpTransport.php',
                     ],
                 ],


### PR DESCRIPTION
Fix the bug `strtolower(): Argument #1 ($string) must be of type string`

https://github.com/openzipkin/zipkin-php/pull/226