### PR TITLE
remove deprecated doc of isTransaction method

### DIFF
--- a/src/db-connection/src/Connection.php
+++ b/src/db-connection/src/Connection.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\DbConnection;
 
 use Hyperf\Contract\ConnectionInterface;

--- a/src/db-connection/src/Connection.php
+++ b/src/db-connection/src/Connection.php
@@ -55,7 +55,7 @@ class Connection extends BaseConnection implements ConnectionInterface, DbConnec
             return $this;
         }
 
-        if (!$this->reconnect()) {
+        if (! $this->reconnect()) {
             throw new ConnectionException('Connection reconnect failed.');
         }
 
@@ -98,7 +98,6 @@ class Connection extends BaseConnection implements ConnectionInterface, DbConnec
 
         return true;
     }
-
 
     public function isTransaction(): bool
     {

--- a/src/db-connection/src/Connection.php
+++ b/src/db-connection/src/Connection.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\DbConnection;
 
 use Hyperf\Contract\ConnectionInterface;
@@ -54,7 +55,7 @@ class Connection extends BaseConnection implements ConnectionInterface, DbConnec
             return $this;
         }
 
-        if (! $this->reconnect()) {
+        if (!$this->reconnect()) {
             throw new ConnectionException('Connection reconnect failed.');
         }
 
@@ -98,9 +99,7 @@ class Connection extends BaseConnection implements ConnectionInterface, DbConnec
         return true;
     }
 
-    /**
-     * @deprecated This method will be removed in v3.1, please use `$this->transactionLevel() > 0`.
-     */
+
     public function isTransaction(): bool
     {
         return $this->transactionLevel() > 0;


### PR DESCRIPTION
I recommend that keep the isTransaction method because it is easy to understand, see the link below
[discuss](https://github.com/hyperf/hyperf/commit/4d0884b1d56212ee89edc64421dacfa248cd1a22#commitcomment-115991921)