### PR TITLE
Remove redundant `setAccessible` methods

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -26,5 +26,6 @@
 ## Removed
 
 - [x] Remove unused codes in `hyperf/utils`.
+- [x] Remove redundant `setAccessible` methods.
 
 ## Deprecated

--- a/src/amqp/tests/ConsumerTest.php
+++ b/src/amqp/tests/ConsumerTest.php
@@ -32,6 +32,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ConsumerTest extends TestCase
 {
     public function testConsumerConcurrentLimit()
@@ -40,7 +44,6 @@ class ConsumerTest extends TestCase
         $consumer = new Consumer($container, Mockery::mock(ConnectionFactory::class), Mockery::mock(LoggerInterface::class));
         $ref = new ReflectionClass($consumer);
         $method = $ref->getMethod('getConcurrent');
-        $method->setAccessible(true);
         /** @var Concurrent $concurrent */
         $concurrent = $method->invokeArgs($consumer, ['default']);
         $this->assertSame(10, $concurrent->getLimit());

--- a/src/config/src/Listener/RegisterPropertyHandlerListener.php
+++ b/src/config/src/Listener/RegisterPropertyHandlerListener.php
@@ -40,7 +40,6 @@ class RegisterPropertyHandlerListener implements ListenerInterface
         PropertyHandlerManager::register(Value::class, function ($object, $currentClassName, $targetClassName, $property, $annotation) {
             if ($annotation instanceof Value && ApplicationContext::hasContainer()) {
                 $reflectionProperty = ReflectionManager::reflectProperty($currentClassName, $property);
-                $reflectionProperty->setAccessible(true);
                 $key = $annotation->key;
                 $config = ApplicationContext::getContainer()->get(ConfigInterface::class);
                 $reflectionProperty->setValue($object, $config->get($key, null));

--- a/src/consul/tests/ClientTest.php
+++ b/src/consul/tests/ClientTest.php
@@ -22,6 +22,10 @@ use ReflectionMethod;
  * @coversNothing
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Consul\Client::class)]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ClientTest extends TestCase
 {
     /**
@@ -41,7 +45,6 @@ class ClientTest extends TestCase
         });
         $reflectionClass = new ReflectionClass(Client::class);
         $method = $reflectionClass->getMethod('resolveOptions');
-        $method->setAccessible(true);
         $this->method = $method;
     }
 

--- a/src/crontab/tests/ParserCronNumberTest.php
+++ b/src/crontab/tests/ParserCronNumberTest.php
@@ -21,6 +21,10 @@ use ReflectionMethod;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ParserCronNumberTest extends TestCase
 {
     protected $timezone;
@@ -40,7 +44,6 @@ class ParserCronNumberTest extends TestCase
     {
         $parser = new Parser();
         $reflectionMethod = new ReflectionMethod(Parser::class, 'parseSegment');
-        $reflectionMethod->setAccessible(true);
 
         $result = $reflectionMethod->invoke($parser, '*', 0, 59);
         $expected = [];
@@ -72,7 +75,6 @@ class ParserCronNumberTest extends TestCase
     {
         $parser = new Parser();
         $reflectionMethod = new ReflectionMethod(Parser::class, 'parseSegment');
-        $reflectionMethod->setAccessible(true);
 
         $result = $reflectionMethod->invoke($parser, '*', 0, 59, 12);
         $expected = [];

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -1160,8 +1160,6 @@ class Builder
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasGlobalMacro($method->name)) {
-                $method->setAccessible(true);
-
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/src/database/tests/DatabaseConnectionTest.php
+++ b/src/database/tests/DatabaseConnectionTest.php
@@ -40,6 +40,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class DatabaseConnectionTest extends TestCase
 {
     protected function tearDown(): void
@@ -373,7 +377,6 @@ class DatabaseConnectionTest extends TestCase
     public function testRunMethodRetriesOnFailure()
     {
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
-        $method->setAccessible(true);
 
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
@@ -392,7 +395,6 @@ class DatabaseConnectionTest extends TestCase
         $this->expectExceptionMessage('(SQL: ) (SQL: )');
 
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
-        $method->setAccessible(true);
 
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction'])->getMock();
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);

--- a/src/database/tests/DatabaseModelCustomCastingTest.php
+++ b/src/database/tests/DatabaseModelCustomCastingTest.php
@@ -28,6 +28,10 @@ use stdClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class DatabaseModelCustomCastingTest extends TestCase
 {
     protected function tearDown(): void
@@ -207,7 +211,6 @@ class DatabaseModelCustomCastingTest extends TestCase
         $model = new TestModelWithCustomCast();
         $ref = new ReflectionClass($model);
         $method = $ref->getMethod('resolveCasterClass');
-        $method->setAccessible(true);
         CastUsing::$castsAttributes = UppercaseCaster::class;
         $this->assertNotSame($method->invokeArgs($model, ['cast_using']), $method->invokeArgs($model, ['cast_using']));
 

--- a/src/database/tests/ModelTest.php
+++ b/src/database/tests/ModelTest.php
@@ -861,7 +861,6 @@ class ModelTest extends TestCase
 
         $class = new ReflectionClass($model);
         $method = $class->getMethod('getArrayableRelations');
-        $method->setAccessible(true);
 
         $model->setRelation('foo', ['bar']);
         $model->setRelation('bam', ['boom']);

--- a/src/db/tests/Cases/DBTest.php
+++ b/src/db/tests/Cases/DBTest.php
@@ -20,6 +20,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class DBTest extends AbstractTestCase
 {
     public function testDBConnection()
@@ -33,7 +37,6 @@ class DBTest extends AbstractTestCase
 
         $ref = new ReflectionClass($db);
         $property = $ref->getProperty('poolName');
-        $property->setAccessible(true);
         $this->assertSame('default', $property->getValue($db));
         $this->assertSame('pdo', $property->getValue($db2));
     }

--- a/src/devtool/tests/Describe/RoutesCommandTest.php
+++ b/src/devtool/tests/Describe/RoutesCommandTest.php
@@ -26,6 +26,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RoutesCommandTest extends TestCase
 {
     protected function tearDown(): void
@@ -40,7 +44,6 @@ class RoutesCommandTest extends TestCase
 
         $ref = new ReflectionClass($command);
         $method = $ref->getMethod('analyzeHandler');
-        $method->setAccessible(true);
 
         $data = [];
         $method->invokeArgs($command, [&$data, 'http', 'GET', null, new Handler(IndexController::class . '::index', '/')]);

--- a/src/di/src/Aop/RegisterInjectPropertyHandler.php
+++ b/src/di/src/Aop/RegisterInjectPropertyHandler.php
@@ -35,7 +35,6 @@ class RegisterInjectPropertyHandler
             if ($annotation instanceof Inject) {
                 try {
                     $reflectionProperty = ReflectionManager::reflectProperty($currentClassName, $property);
-                    $reflectionProperty->setAccessible(true);
                     $container = ApplicationContext::getContainer();
                     if ($container->has($annotation->value)) {
                         $reflectionProperty->setValue($object, $container->get($annotation->value));

--- a/src/di/tests/Annotation/ScannerTest.php
+++ b/src/di/tests/Annotation/ScannerTest.php
@@ -35,6 +35,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ScannerTest extends TestCase
 {
     protected function tearDown(): void
@@ -61,7 +65,6 @@ class ScannerTest extends TestCase
         $scanner = new Scanner(new ScanConfig(false, '/'), new NullScanHandler());
         $ref = new ReflectionClass($scanner);
         $property = $ref->getProperty('filesystem');
-        $property->setAccessible(true);
         $property->setValue($scanner, $filesystem = Mockery::mock(Filesystem::class . '[lastModified]'));
         $times = [
             Debug1Aspect::class => 5,
@@ -73,7 +76,6 @@ class ScannerTest extends TestCase
         });
 
         $method = $ref->getMethod('getChangedAspects');
-        $method->setAccessible(true);
 
         $reader = new AnnotationReader();
         $scanner->collect($reader, ReflectionManager::reflectClass(Debug2Aspect::class));

--- a/src/di/tests/AnnotationTest.php
+++ b/src/di/tests/AnnotationTest.php
@@ -25,6 +25,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class AnnotationTest extends TestCase
 {
     protected function tearDown(): void
@@ -37,7 +41,6 @@ class AnnotationTest extends TestCase
         $scanner = new Scanner(new ScanConfig(false, '/'), new NullScanHandler());
         $ref = new ReflectionClass($scanner);
         $method = $ref->getMethod('normalizeDir');
-        $method->setAccessible(true);
 
         $this->expectException(DirectoryNotExistException::class);
         $method->invokeArgs($scanner, [['/not_exists']]);
@@ -48,7 +51,6 @@ class AnnotationTest extends TestCase
         $scanner = new Scanner(new ScanConfig(false, '/'), new NullScanHandler());
         $ref = new ReflectionClass($scanner);
         $method = $ref->getMethod('normalizeDir');
-        $method->setAccessible(true);
 
         $this->assertSame([], $method->invokeArgs($scanner, [[]]));
     }

--- a/src/di/tests/Aop/ProxyCallVisitorTest.php
+++ b/src/di/tests/Aop/ProxyCallVisitorTest.php
@@ -26,6 +26,10 @@ use ReflectionMethod;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ProxyCallVisitorTest extends TestCase
 {
     protected function tearDown(): void
@@ -58,7 +62,6 @@ CODETEMPLATE;
         $proxyCallVisitor = new ProxyCallVisitor(new VisitorMetadata('SomeClass'));
 
         $reflectionMethod = new ReflectionMethod($proxyCallVisitor, 'shouldRewrite');
-        $reflectionMethod->setAccessible(true);
         $this->assertFalse($reflectionMethod->invoke($proxyCallVisitor, $stmts->stmts[0]));
         $this->assertTrue($reflectionMethod->invoke($proxyCallVisitor, $stmts->stmts[1]));
     }
@@ -74,7 +77,6 @@ CODETEMPLATE;
         $proxyCallVisitor = new ProxyCallVisitor($visitorMetadata);
 
         $reflectionMethod = new ReflectionMethod($proxyCallVisitor, 'shouldRewrite');
-        $reflectionMethod->setAccessible(true);
         $this->assertTrue($reflectionMethod->invoke($proxyCallVisitor, new ClassMethod('foo')));
 
         $visitorMetadata->classLike = Node\Stmt\Interface_::class;

--- a/src/di/tests/ClassLoaderTest.php
+++ b/src/di/tests/ClassLoaderTest.php
@@ -23,6 +23,10 @@ use function Hyperf\Support\env;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ClassLoaderTest extends TestCase
 {
     public function testDotEnv()
@@ -35,7 +39,6 @@ class ClassLoaderTest extends TestCase
 
         $ref = new ReflectionClass($class);
         $method = $ref->getMethod('loadDotenv');
-        $method->setAccessible(true);
         $method->invoke($class);
 
         $this->assertNotEquals('0.0.0', env('SW_VERSION'));

--- a/src/event/tests/EventDispatcherTest.php
+++ b/src/event/tests/EventDispatcherTest.php
@@ -36,6 +36,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Event\EventDispatcher::class)]
+/**
+ * @internal
+ * @coversNothing
+ */
 class EventDispatcherTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
@@ -53,7 +57,6 @@ class EventDispatcherTest extends TestCase
         $this->assertInstanceOf(EventDispatcherInterface::class, $instance = new EventDispatcher($listeners, $logger));
         $reflectionClass = new ReflectionClass($instance);
         $loggerProperty = $reflectionClass->getProperty('logger');
-        $loggerProperty->setAccessible(true);
         $this->assertInstanceOf(StdoutLoggerInterface::class, $loggerProperty->getValue($instance));
     }
 
@@ -67,7 +70,6 @@ class EventDispatcherTest extends TestCase
         $this->assertInstanceOf(EventDispatcherInterface::class, $instance = (new EventDispatcherFactory())($container));
         $reflectionClass = new ReflectionClass($instance);
         $loggerProperty = $reflectionClass->getProperty('logger');
-        $loggerProperty->setAccessible(true);
         $this->assertInstanceOf(StdoutLoggerInterface::class, $loggerProperty->getValue($instance));
     }
 

--- a/src/guzzle/tests/Cases/HandlerStackFactoryTest.php
+++ b/src/guzzle/tests/Cases/HandlerStackFactoryTest.php
@@ -35,6 +35,10 @@ use Throwable;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class HandlerStackFactoryTest extends TestCase
 {
     public function testCreateCoroutineHandler()
@@ -50,11 +54,9 @@ class HandlerStackFactoryTest extends TestCase
         $ref = new ReflectionClass($stack);
 
         $handler = $ref->getProperty('handler');
-        $handler->setAccessible(true);
         $this->assertInstanceOf(CoroutineHandler::class, $handler->getValue($stack));
 
         $property = $ref->getProperty('stack');
-        $property->setAccessible(true);
         foreach ($property->getValue($stack) as $stack) {
             $this->assertTrue(in_array($stack[1], ['http_errors', 'allow_redirects', 'cookies', 'prepare_body', 'retry']));
         }
@@ -74,11 +76,9 @@ class HandlerStackFactoryTest extends TestCase
         $ref = new ReflectionClass($stack);
 
         $handler = $ref->getProperty('handler');
-        $handler->setAccessible(true);
         $this->assertInstanceOf(CoroutineHandler::class, $handler->getValue($stack));
 
         $property = $ref->getProperty('stack');
-        $property->setAccessible(true);
         foreach ($property->getValue($stack) as $stack) {
             $this->assertTrue(in_array($stack[1], ['http_errors', 'allow_redirects', 'cookies', 'prepare_body', 'retry']));
         }
@@ -96,11 +96,9 @@ class HandlerStackFactoryTest extends TestCase
         $ref = new ReflectionClass($stack);
 
         $handler = $ref->getProperty('handler');
-        $handler->setAccessible(true);
         $this->assertInstanceOf(PoolHandler::class, $handler->getValue($stack));
 
         $property = $ref->getProperty('stack');
-        $property->setAccessible(true);
         $items = array_column($property->getValue($stack), 1);
 
         $this->assertEquals(['http_errors', 'allow_redirects', 'cookies', 'prepare_body', 'retry'], $items);
@@ -115,12 +113,10 @@ class HandlerStackFactoryTest extends TestCase
 
         $ref = new ReflectionClass($stack);
         $handler = $ref->getProperty('handler');
-        $handler->setAccessible(true);
         $handler = $handler->getValue($stack);
 
         $ref = new ReflectionClass($handler);
         $option = $ref->getProperty('option');
-        $option->setAccessible(true);
 
         $this->assertSame(50, $option->getValue($handler)['max_connections']);
     }
@@ -134,7 +130,6 @@ class HandlerStackFactoryTest extends TestCase
 
         $ref = new ReflectionClass($stack);
         $property = $ref->getProperty('stack');
-        $property->setAccessible(true);
         $items = array_column($property->getValue($stack), 1);
         $this->assertEquals(['http_errors', 'allow_redirects', 'cookies', 'prepare_body', 'retry', 'retry_again'], $items);
     }

--- a/src/http-message/tests/ServerRequestTest.php
+++ b/src/http-message/tests/ServerRequestTest.php
@@ -36,6 +36,10 @@ use Swoole\Http\Request as SwooleRequest;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ServerRequestTest extends TestCase
 {
     protected function tearDown(): void
@@ -166,7 +170,6 @@ class ServerRequestTest extends TestCase
         $hostStrIPv6 = '[fe80::a464:1aff:fe88:7b5a]:9502';
         $objReflectClass = new ReflectionClass('Hyperf\HttpMessage\Server\Request');
         $method = $objReflectClass->getMethod('parseHost');
-        $method->setAccessible(true);
 
         $resIPv4 = $method->invokeArgs(null, [$hostStrIPv4]);
         $this->assertSame('192.168.119.100', $resIPv4[0]);

--- a/src/http-server/tests/CoreMiddlewareTest.php
+++ b/src/http-server/tests/CoreMiddlewareTest.php
@@ -49,6 +49,10 @@ use ReflectionMethod;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class CoreMiddlewareTest extends TestCase
 {
     public function testParseParameters()
@@ -65,7 +69,6 @@ class CoreMiddlewareTest extends TestCase
     {
         $middleware = new CoreMiddlewareStub($container = $this->getContainer(), 'http');
         $reflectionMethod = new ReflectionMethod(CoreMiddleware::class, 'transferToResponse');
-        $reflectionMethod->setAccessible(true);
         $request = Mockery::mock(ServerRequestInterface::class);
         /** @var ResponseInterface $response */
 
@@ -197,7 +200,6 @@ class CoreMiddlewareTest extends TestCase
         $middleware = new CoreMiddleware($container, 'http');
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('handleFound');
-        $method->setAccessible(true);
 
         $handler = new Handler([DemoController::class, 'demo'], '/');
         $dispatched = new Dispatched([Dispatcher::FOUND, $handler, []]);
@@ -212,7 +214,6 @@ class CoreMiddlewareTest extends TestCase
         $middleware = new CoreMiddleware($container, 'http');
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('handleFound');
-        $method->setAccessible(true);
 
         $handler = new Handler(DemoController::class, '/');
         $dispatched = new Dispatched([Dispatcher::FOUND, $handler, []]);
@@ -227,7 +228,6 @@ class CoreMiddlewareTest extends TestCase
         $middleware = new CoreMiddleware($container, 'http');
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('handleFound');
-        $method->setAccessible(true);
 
         $this->expectException(ServerErrorHttpException::class);
         $this->expectExceptionMessage('Method of class does not exist.');

--- a/src/http-server/tests/ResponseTest.php
+++ b/src/http-server/tests/ResponseTest.php
@@ -35,6 +35,10 @@ use Swoole\Http\Response as SwooleResponse;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ResponseTest extends TestCase
 {
     protected function tearDown(): void
@@ -88,7 +92,6 @@ class ResponseTest extends TestCase
         $response = new Response();
         $reflectionClass = new ReflectionClass(Response::class);
         $reflectionMethod = $reflectionClass->getMethod('toXml');
-        $reflectionMethod->setAccessible(true);
 
         $expected = '<?xml version="1.0" encoding="utf-8"?>
 <root><kstring>string</kstring><kint1>1</kint1><kint0>0</kint0><kfloat>0.12345</kfloat><kfalse/><ktrue>1</ktrue><karray><kstring>string</kstring><kint1>1</kint1><kint0>0</kint0><kfloat>0.12345</kfloat><kfalse/><ktrue>1</ktrue></karray></root>';

--- a/src/http2-client/tests/ClientTest.php
+++ b/src/http2-client/tests/ClientTest.php
@@ -115,7 +115,6 @@ class ClientTest extends TestCase
         $client = new Client($baseUri);
         $ref = new ReflectionClass($client);
         $identifier = $ref->getProperty('identifier');
-        $identifier->setAccessible(true);
         $identifier->setValue($client, 'HTTP2ClientUnit');
         return $client;
     }

--- a/src/json-rpc/tests/TcpServerTest.php
+++ b/src/json-rpc/tests/TcpServerTest.php
@@ -50,6 +50,10 @@ use stdClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class TcpServerTest extends TestCase
 {
     public function testGetDefaultExceptionHandler()
@@ -65,7 +69,6 @@ class TcpServerTest extends TestCase
 
         $ref = new ReflectionClass($server);
         $method = $ref->getMethod('getDefaultExceptionHandler');
-        $method->setAccessible(true);
         $res = $method->invoke($server);
 
         $this->assertSame([TcpExceptionHandler::class], $res);
@@ -90,7 +93,6 @@ class TcpServerTest extends TestCase
 
         $ref = new ReflectionClass($server);
         $method = $ref->getMethod('buildRequest');
-        $method->setAccessible(true);
         /** @var Request $request */
         $request = $method->invoke($server, 1, 1, Json::encode([
             'jsonrpc' => '2.0',

--- a/src/logger/tests/LoggerFactoryTest.php
+++ b/src/logger/tests/LoggerFactoryTest.php
@@ -32,6 +32,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Logger\LoggerFactory::class)]
+/**
+ * @internal
+ * @coversNothing
+ */
 class LoggerFactoryTest extends TestCase
 {
     protected function tearDown(): void
@@ -64,7 +68,6 @@ class LoggerFactoryTest extends TestCase
         $this->assertInstanceOf(\Hyperf\Logger\Logger::class, $logger);
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('handlers');
-        $handlersProperty->setAccessible(true);
         $handlers = $handlersProperty->getValue($logger);
         $this->assertCount(1, $handlers);
         $this->assertInstanceOf(StreamHandler::class, current($handlers));
@@ -78,7 +81,6 @@ class LoggerFactoryTest extends TestCase
         $this->assertInstanceOf(\Hyperf\Logger\Logger::class, $logger);
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('handlers');
-        $handlersProperty->setAccessible(true);
         $handlers = $handlersProperty->getValue($logger);
         $this->assertCount(2, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
@@ -93,7 +95,6 @@ class LoggerFactoryTest extends TestCase
         $this->assertInstanceOf(\Hyperf\Logger\Logger::class, $logger);
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('handlers');
-        $handlersProperty->setAccessible(true);
         $handlers = $handlersProperty->getValue($logger);
         $this->assertCount(1, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
@@ -102,7 +103,6 @@ class LoggerFactoryTest extends TestCase
         $this->assertInstanceOf(\Hyperf\Logger\Logger::class, $logger);
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('handlers');
-        $handlersProperty->setAccessible(true);
         $handlers = $handlersProperty->getValue($logger);
         $this->assertCount(2, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
@@ -116,7 +116,6 @@ class LoggerFactoryTest extends TestCase
         $logger = $factory->get('hyperf');
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('processors');
-        $handlersProperty->setAccessible(true);
         $processors = $handlersProperty->getValue($logger);
         $this->assertSame([], $processors);
     }
@@ -128,7 +127,6 @@ class LoggerFactoryTest extends TestCase
         $logger = $factory->get('hyperf', 'processor-test');
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('processors');
-        $handlersProperty->setAccessible(true);
         $processors = $handlersProperty->getValue($logger);
         $this->assertSame(3, count($processors));
         $this->assertInstanceOf(FooProcessor::class, $processors[0]);
@@ -150,7 +148,6 @@ class LoggerFactoryTest extends TestCase
         $logger = $factory->get('hyperf', 'default-processor');
         $reflectionClass = new ReflectionClass($logger);
         $handlersProperty = $reflectionClass->getProperty('processors');
-        $handlersProperty->setAccessible(true);
         $processors = $handlersProperty->getValue($logger);
         $this->assertSame(1, count($processors));
         $this->assertInstanceOf(FooProcessor::class, $processors[0]);

--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -109,7 +109,6 @@ trait Macroable
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasMacro($method->name)) {
-                $method->setAccessible(true);
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/src/metric/tests/Adapter/Prometheus/RedisStorageFactoryTest.php
+++ b/src/metric/tests/Adapter/Prometheus/RedisStorageFactoryTest.php
@@ -28,6 +28,10 @@ use ReflectionProperty;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RedisStorageFactoryTest extends TestCase
 {
     protected string $prePrefix;
@@ -39,10 +43,8 @@ class RedisStorageFactoryTest extends TestCase
         parent::setUp();
 
         $prefixProperty = new ReflectionProperty(Redis::class, 'prefix');
-        $prefixProperty->setAccessible(true);
 
         $metricGatherKeySuffix = new ReflectionProperty(Redis::class, 'metricGatherKeySuffix');
-        $metricGatherKeySuffix->setAccessible(true);
 
         $this->prePrefix = $prefixProperty->getDefaultValue();
         $this->preMetricGatherKeySuffix = $metricGatherKeySuffix->getDefaultValue();
@@ -71,10 +73,8 @@ class RedisStorageFactoryTest extends TestCase
         $redis = $factory($container);
 
         $prefixProperty = new ReflectionProperty(Redis::class, 'prefix');
-        $prefixProperty->setAccessible(true);
 
         $metricGatherKeySuffixProperty = new ReflectionProperty(Redis::class, 'metricGatherKeySuffix');
-        $metricGatherKeySuffixProperty->setAccessible(true);
 
         self::assertInstanceOf(Redis::class, $redis);
         self::assertEquals('skeleton', $prefixProperty->getValue($redis));
@@ -104,10 +104,8 @@ class RedisStorageFactoryTest extends TestCase
         $redis = $factory($container);
 
         $prefixProperty = new ReflectionProperty(Redis::class, 'prefix');
-        $prefixProperty->setAccessible(true);
 
         $metricGatherKeySuffixProperty = new ReflectionProperty(Redis::class, 'metricGatherKeySuffix');
-        $metricGatherKeySuffixProperty->setAccessible(true);
 
         self::assertInstanceOf(Redis::class, $redis);
         self::assertEquals('prometheus:', $prefixProperty->getValue($redis));

--- a/src/metric/tests/Adapter/Prometheus/RedisTest.php
+++ b/src/metric/tests/Adapter/Prometheus/RedisTest.php
@@ -25,6 +25,10 @@ use ReflectionProperty;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RedisTest extends TestCase
 {
     protected string $prePrefix;
@@ -36,10 +40,8 @@ class RedisTest extends TestCase
         parent::setUp();
 
         $prefixProperty = new ReflectionProperty(Redis::class, 'prefix');
-        $prefixProperty->setAccessible(true);
 
         $metricGatherKeySuffix = new ReflectionProperty(Redis::class, 'metricGatherKeySuffix');
-        $metricGatherKeySuffix->setAccessible(true);
 
         $this->prePrefix = $prefixProperty->getDefaultValue();
         $this->preMetricGatherKeySuffix = $metricGatherKeySuffix->getDefaultValue();
@@ -64,20 +66,17 @@ class RedisTest extends TestCase
 
         Redis::setPrefix('prometheus:');
         $method = new ReflectionMethod(Redis::class, 'toMetricKey');
-        $method->setAccessible(true);
         self::assertEquals('prometheus:counter:hyperf_metric{counter}', $method->invoke(new Redis(new \Redis()), $data));
 
         // 兼容 < v3.1
         Redis::setPrefix('PROMETHEUS_');
         $method = new ReflectionMethod(Redis::class, 'toMetricKey');
-        $method->setAccessible(true);
         self::assertEquals('PROMETHEUS_:counter:hyperf_metric{counter}', $method->invoke(new Redis(new \Redis()), $data));
     }
 
     public function testGetMetricGatherKey()
     {
         $method = new ReflectionMethod(Redis::class, 'getMetricGatherKey');
-        $method->setAccessible(true);
 
         self::assertEquals('PROMETHEUS_counter_METRIC_KEYS{counter}', $method->invoke(new Redis(new \Redis()), Counter::TYPE));
     }
@@ -107,7 +106,6 @@ class RedisTest extends TestCase
         );
 
         $method = new ReflectionMethod(Redis::class, 'collectSamples');
-        $method->setAccessible(true);
         $result = $method->invoke(new Redis($redis), Counter::TYPE);
 
         self::assertEquals([
@@ -160,7 +158,6 @@ class RedisTest extends TestCase
         );
 
         $method = new ReflectionMethod(Redis::class, 'collectSamples');
-        $method->setAccessible(true);
         $result = $method->invoke(new Redis($redis), Counter::TYPE);
 
         self::assertEquals([
@@ -204,7 +201,6 @@ class RedisTest extends TestCase
         );
 
         $method = new ReflectionMethod(Redis::class, 'collectHistograms');
-        $method->setAccessible(true);
         $result = $method->invoke(new Redis($redis), Histogram::TYPE);
 
         self::assertEquals([
@@ -309,7 +305,6 @@ class RedisTest extends TestCase
         );
 
         $method = new ReflectionMethod(Redis::class, 'collectHistograms');
-        $method->setAccessible(true);
         $result = $method->invoke(new Redis($redis), Histogram::TYPE);
 
         self::assertEquals([

--- a/src/metric/tests/Cases/MetricFactoryTest.php
+++ b/src/metric/tests/Cases/MetricFactoryTest.php
@@ -29,6 +29,10 @@ use ReflectionMethod;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class MetricFactoryTest extends TestCase
 {
     protected function tearDown(): void
@@ -57,7 +61,6 @@ class MetricFactoryTest extends TestCase
         $p = new PrometheusFactory($config, $r, $c, $l, new ServerFactory($l));
         $ref = new ReflectionClass($p);
         $method = $ref->getMethod('getUri');
-        $method->setAccessible(true);
         $this->assertStringContainsString('http://127.0.0.1/metrics/job/metric/ip/', $method->invokeArgs($p, ['127.0.0.1', 'metric']));
         $this->assertStringContainsString('https://127.0.0.1/metrics/job/metric/ip/', $method->invokeArgs($p, ['https://127.0.0.1', 'metric']));
         $this->assertStringContainsString('http://127.0.0.1:8080/metrics/job/metric/ip/', $method->invokeArgs($p, ['127.0.0.1:8080', 'metric']));
@@ -83,7 +86,6 @@ class MetricFactoryTest extends TestCase
         $l = Mockery::mock(StdoutLoggerInterface::class);
         $p = new PrometheusFactory($config, $r, $c, $l, new ServerFactory($l));
         $method = new ReflectionMethod(PrometheusFactory::class, 'getNamespace');
-        $method->setAccessible(true);
         $this->assertEquals('hello__world_', $method->invoke($p));
     }
 }

--- a/src/process/tests/BootProcessListenerTest.php
+++ b/src/process/tests/BootProcessListenerTest.php
@@ -27,6 +27,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class BootProcessListenerTest extends TestCase
 {
     protected function tearDown(): void
@@ -42,7 +46,6 @@ class BootProcessListenerTest extends TestCase
         $listener = new BootProcessListener(Mockery::mock(ContainerInterface::class), Mockery::mock(ConfigInterface::class));
         $ref = new ReflectionClass($listener);
         $method = $ref->getMethod('getAnnotationProcesses');
-        $method->setAccessible(true);
         $res = $method->invoke($listener);
         foreach ($res as $class => $annotation) {
             $this->assertSame(FooProcess::class, $class);

--- a/src/process/tests/ProcessTest.php
+++ b/src/process/tests/ProcessTest.php
@@ -27,6 +27,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class ProcessTest extends TestCase
 {
     public static $dispatched = [];
@@ -71,7 +75,6 @@ class ProcessTest extends TestCase
         $server->shouldReceive('addProcess')->withAnyArgs()->andReturnUsing(function ($process) {
             $ref = new ReflectionClass($process);
             $property = $ref->getProperty('callback');
-            $property->setAccessible(true);
             $callback = $property->getValue($process);
             $callback($process);
             return 1;

--- a/src/redis/tests/RedisTest.php
+++ b/src/redis/tests/RedisTest.php
@@ -45,6 +45,10 @@ use function Hyperf\Coroutine\parallel;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RedisTest extends TestCase
 {
     protected function tearDown(): void
@@ -95,7 +99,6 @@ class RedisTest extends TestCase
         $redis = $this->getRedis();
         $ref = new ReflectionClass($redis);
         $method = $ref->getMethod('getConnection');
-        $method->setAccessible(true);
 
         go(function () use ($chan, $redis, $method) {
             $id = null;
@@ -128,7 +131,6 @@ class RedisTest extends TestCase
 
         $chan->pop();
         $factory = $ref->getProperty('factory');
-        $factory->setAccessible(true);
         $factory = $factory->getValue($redis);
         $pool = $factory->getPool('default');
         $pool->flushAll();

--- a/src/retry/tests/RetryBudgetTest.php
+++ b/src/retry/tests/RetryBudgetTest.php
@@ -24,6 +24,10 @@ use Swoole\Timer;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RetryBudgetTest extends TestCase
 {
     protected function tearDown(): void
@@ -81,7 +85,6 @@ class RetryBudgetTest extends TestCase
         $budget->init();
         $ref = new ReflectionClass(RetryBudget::class);
         $prop = $ref->getProperty('budget');
-        $prop->setAccessible(true);
         System::sleep(1.2);
         $this->assertLessThanOrEqual(1, $prop->getValue($budget)->count());
         System::sleep(1.2);

--- a/src/rpc-multiplex/tests/Cases/AbstractTestCase.php
+++ b/src/rpc-multiplex/tests/Cases/AbstractTestCase.php
@@ -29,7 +29,6 @@ abstract class AbstractTestCase extends TestCase
     {
         $ref = new ReflectionClass($class);
         $method = $ref->getMethod($method);
-        $method->setAccessible(true);
         return $method->invoke($method);
     }
 }

--- a/src/rpc-server/tests/RouterDispatcherFactoryTest.php
+++ b/src/rpc-server/tests/RouterDispatcherFactoryTest.php
@@ -32,6 +32,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class RouterDispatcherFactoryTest extends TestCase
 {
     protected function tearDown(): void
@@ -59,7 +63,6 @@ class RouterDispatcherFactoryTest extends TestCase
         );
         $ref = new ReflectionClass($factory);
         $m = $ref->getMethod('handleRpcService');
-        $m->setAccessible(true);
         $m->invokeArgs($factory, [IdGeneratorStub::class, new RpcService('IdGenerator'), [], []]);
     }
 
@@ -76,7 +79,6 @@ class RouterDispatcherFactoryTest extends TestCase
         );
         $ref = new ReflectionClass($factory);
         $m = $ref->getMethod('handleRpcService');
-        $m->setAccessible(true);
         $m->invokeArgs($factory, [MiddlewareStub::class, new RpcService('Middleware'), [
             'generate' => [
                 Middleware::class => new Middleware('Bar'),

--- a/src/serializer/src/ExceptionNormalizer.php
+++ b/src/serializer/src/ExceptionNormalizer.php
@@ -43,7 +43,6 @@ class ExceptionNormalizer implements NormalizerInterface, DenormalizerInterface,
                 foreach (['code', 'message', 'file', 'line'] as $attribute) {
                     if (isset($data[$attribute])) {
                         $property = ReflectionManager::reflectProperty($type, $attribute);
-                        $property->setAccessible(true);
                         $property->setValue($exception, $data[$attribute]);
                     }
                 }

--- a/src/session/tests/SessionManagerTest.php
+++ b/src/session/tests/SessionManagerTest.php
@@ -27,6 +27,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Session\SessionManager::class)]
+/**
+ * @internal
+ * @coversNothing
+ */
 class SessionManagerTest extends TestCase
 {
     public function testSetterAndGetter()
@@ -46,7 +50,6 @@ class SessionManagerTest extends TestCase
         $sessionManager = new SessionManager(Mockery::mock(ContainerInterface::class), MockStub::makeConfig());
         $reflectionClass = new ReflectionClass(SessionManager::class);
         $parseSessionIdMethod = $reflectionClass->getMethod('parseSessionId');
-        $parseSessionIdMethod->setAccessible(true);
         $id = Str::random(40);
         $this->assertSame($id, $parseSessionIdMethod->invoke($sessionManager, $request->withCookieParams([
             'HYPERF_SESSION_ID' => $id,

--- a/src/session/tests/SessionMiddlewareTest.php
+++ b/src/session/tests/SessionMiddlewareTest.php
@@ -41,6 +41,10 @@ use SessionHandlerInterface;
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Session\Middleware\SessionMiddleware::class)]
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyperf\Session\SessionManager::class)]
+/**
+ * @internal
+ * @coversNothing
+ */
 class SessionMiddlewareTest extends TestCase
 {
     public function testHandle()
@@ -147,7 +151,6 @@ class SessionMiddlewareTest extends TestCase
         $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('addCookieToResponse');
-        $method->setAccessible(true);
 
         $request = new Request('GET', new Uri('http://hyperf.io'));
         $session = new Session('test', Mockery::mock(SessionHandlerInterface::class));
@@ -173,7 +176,6 @@ class SessionMiddlewareTest extends TestCase
         $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('addCookieToResponse');
-        $method->setAccessible(true);
 
         $request = new Request('GET', new Uri('http://hyperf.io'));
         $session = new Session('test', Mockery::mock(SessionHandlerInterface::class));
@@ -199,7 +201,6 @@ class SessionMiddlewareTest extends TestCase
         $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('addCookieToResponse');
-        $method->setAccessible(true);
 
         $request = new Request('GET', new Uri('http://hyperf.io'));
         $session = new Session('test', Mockery::mock(SessionHandlerInterface::class));
@@ -222,7 +223,6 @@ class SessionMiddlewareTest extends TestCase
         $middleware = new SessionMiddleware($sessionManager, $config);
         $reflectionClass = new ReflectionClass(SessionMiddleware::class);
         $reflectionMethod = $reflectionClass->getMethod('fullUrl');
-        $reflectionMethod->setAccessible(true);
         $result = $reflectionMethod->invokeArgs($middleware, [new Request('get', new Uri($path = '/foo/bar'))]);
         $this->assertSame($path, $result);
         $result = $reflectionMethod->invokeArgs($middleware, [new Request('get', new Uri($path = '/foo/bar?baz=1'))]);
@@ -246,7 +246,6 @@ class SessionMiddlewareTest extends TestCase
         $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);
         $ref = new ReflectionClass($middleware);
         $method = $ref->getMethod('addCookieToResponse');
-        $method->setAccessible(true);
         $request = new Request('GET', new Uri('http://hyperf.io'));
         $session = new Session('test', Mockery::mock(SessionHandlerInterface::class), $id = Str::random(40));
         $response = new Response();

--- a/src/socketio-server/tests/Cases/IONamespaceTest.php
+++ b/src/socketio-server/tests/Cases/IONamespaceTest.php
@@ -32,6 +32,10 @@ use Swoole\Atomic;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class IONamespaceTest extends AbstractTestCase
 {
     protected function setUp(): void
@@ -135,7 +139,6 @@ class IONamespaceTest extends AbstractTestCase
 
         $ref = new ReflectionClass($io);
         $m = $ref->getMethod('renewInAllNamespaces');
-        $m->setAccessible(true);
         $this->assertFalse(EphemeralAdapter::$isRenew);
         $m->invokeArgs($io, [1]);
         $this->assertTrue(EphemeralAdapter::$isRenew);

--- a/src/socketio-server/tests/Cases/SocketTest.php
+++ b/src/socketio-server/tests/Cases/SocketTest.php
@@ -30,6 +30,10 @@ use function Hyperf\Support\make;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class SocketTest extends AbstractTestCase
 {
     protected function setUp(): void
@@ -115,7 +119,6 @@ class SocketTest extends AbstractTestCase
         ]);
         $reflection = new ReflectionClass(Socket::class);
         $prop = $reflection->getProperty('broadcast');
-        $prop->setAccessible(true);
         $this->assertFalse($prop->getValue($socket1));
         $this->assertTrue($prop->getValue($socket1->broadcast));
     }

--- a/src/support/src/Reflection/ClassInvoker.php
+++ b/src/support/src/Reflection/ClassInvoker.php
@@ -26,16 +26,12 @@ class ClassInvoker
     {
         $property = $this->reflection->getProperty($name);
 
-        $property->setAccessible(true);
-
         return $property->getValue($this->instance);
     }
 
     public function __call($name, $arguments)
     {
         $method = $this->reflection->getMethod($name);
-
-        $method->setAccessible(true);
 
         return $method->invokeArgs($this->instance, $arguments);
     }

--- a/src/translation/tests/FileLoaderTest.php
+++ b/src/translation/tests/FileLoaderTest.php
@@ -28,6 +28,10 @@ use ReflectionClass;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class FileLoaderTest extends TestCase
 {
     protected function tearDown(): void
@@ -46,7 +50,6 @@ class FileLoaderTest extends TestCase
         $loader = $factory($container);
         $ref = new ReflectionClass($loader);
         $path = $ref->getProperty('path');
-        $path->setAccessible(true);
         $this->assertSame(BASE_PATH . '/storage/languages', $path->getValue($loader));
     }
 

--- a/src/translation/tests/TranslatorTest.php
+++ b/src/translation/tests/TranslatorTest.php
@@ -33,6 +33,10 @@ use function Hyperf\Coroutine\parallel;
  * @coversNothing
  */
 #[CoversNothing]
+/**
+ * @internal
+ * @coversNothing
+ */
 class TranslatorTest extends TestCase
 {
     protected function tearDown(): void
@@ -51,7 +55,6 @@ class TranslatorTest extends TestCase
         $loader = $factory($container);
         $ref = new ReflectionClass($loader);
         $locale = $ref->getProperty('locale');
-        $locale->setAccessible(true);
         $this->assertSame('zh_CN', $locale->getValue($loader));
     }
 


### PR DESCRIPTION
The `setAccessible()` method has had no effect (i.e. is redundant) as of PHP 8.1

Hyperf 3.1 has a minimum requirement of PHP 8.1, therefore officially dropping the requirement to retain these methods.

This PR simply removes all instances of `->setAccessible(true)` from all `ReflectionProperty` and `ReflectionMethod` objects throughout the `src/` and `tests/` directories.

Sources:

`ReflectionMethod::setAccessible()`: https://www.php.net/manual/en/reflectionmethod.setaccessible.php

> Note: As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

`ReflectionProperty::setAccessible()`: https://www.php.net/manual/en/reflectionproperty.setaccessible.php

> Note: As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default.

