### PR TITLE
Bumps php-cs-fixer to `3.17.0`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -85,6 +85,16 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'standardize_not_equals' => true,
         'multiline_comment_opening_closing' => true,
+        'php_unit_test_class_requires_covers' => false,
+        'php_unit_internal_class' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'none'
+        ],
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'none'
+        ],
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "elasticsearch/elasticsearch": "^7.0",
         "fig/http-message-util": "^1.1.2",
         "filp/whoops": "^2.7",
-        "friendsofphp/php-cs-fixer": "^3.16.0",
+        "friendsofphp/php-cs-fixer": "~3.17.0",
         "google/common-protos": "^3.2",
         "google/protobuf": "^3.6.1",
         "grpc/grpc": "^1.15",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "elasticsearch/elasticsearch": "^7.0",
         "fig/http-message-util": "^1.1.2",
         "filp/whoops": "^2.7",
-        "friendsofphp/php-cs-fixer": "~3.16.0",
+        "friendsofphp/php-cs-fixer": "^3.16.0",
         "google/common-protos": "^3.2",
         "google/protobuf": "^3.6.1",
         "grpc/grpc": "^1.15",


### PR DESCRIPTION
3.1 正式版发布后跟进