### PR TITLE
Fixed bug that the method `Hyperf\Database\Model\Builder::value()` cannot work when using column like `table.column`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- [#5829](https://github.com/hyperf/hyperf/pull/5829) Fixed bug that the method `Hyperf\Database\Model\Builder::value()` cannot work when using column like `table.column`.
 - [#5831](https://github.com/hyperf/hyperf/pull/5831) Fixed an endless loop when socket.io parses namespace.
 
 # v3.0.24 - 2023-06-10

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -581,7 +581,7 @@ class Builder
     public function value($column)
     {
         if ($result = $this->first([$column])) {
-            return $result->{$column};
+            return $result->{Str::afterLast($column, '.')};
         }
     }
 

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -596,6 +596,21 @@ class ModelRealBuilderTest extends TestCase
         }
     }
 
+    public function testModelBuilderValue()
+    {
+        $this->getContainer();
+
+        $res = User::query()->join('book', 'user.id', '=', 'book.user_id')->value('book.title');
+
+        $this->assertNotEmpty($res);
+
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame($event->sql, 'select `book`.`title` from `user` inner join `book` on `user`.`id` = `book`.`user_id` limit 1');
+            }
+        }
+    }
+
     public function testWhereFullText()
     {
         $container = $this->getContainer();

--- a/src/database/tests/Stubs/Model/User.php
+++ b/src/database/tests/Stubs/Model/User.php
@@ -17,8 +17,8 @@ namespace HyperfTest\Database\Stubs\Model;
  * @property int $gender
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
- * @property \App\Model\Book $book
- * @property \App\Model\Book[]|\Hyperf\Database\Model\Collection $books
+ * @property Book $book
+ * @property Book[]|\Hyperf\Database\Model\Collection $books
  */
 class User extends Model
 {


### PR DESCRIPTION
Hi, This PR fixed get integrity value with table aliases.

Sometimes, we need take explicitly table name to get the value, such as with `join` clauses to get roles name: `User::join('roles', 'users.id', '=', 'roles.user_id')->value('roles.name')`.

Ps: this bug also fixed in [laravel](https://github.com/laravel/framework/commit/609104806b8b639710268c75c22f43034c2b72db)
