### PR TITLE
Fixed socket.io check namespace

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,7 @@
 # v3.0.25 - TBD
 
+- [#5831](https://github.com/hyperf/hyperf/pull/5831) Fixed an endless loop when socket.io parses namespace
+
 # v3.0.24 - 2023-06-10
 
 ## Fixed

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,7 @@
 # v3.0.25 - TBD
 
+## Fixed
+
 - [#5831](https://github.com/hyperf/hyperf/pull/5831) Fixed an endless loop when socket.io parses namespace.
 
 # v3.0.24 - 2023-06-10

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,6 +1,6 @@
 # v3.0.25 - TBD
 
-- [#5831](https://github.com/hyperf/hyperf/pull/5831) Fixed an endless loop when socket.io parses namespace
+- [#5831](https://github.com/hyperf/hyperf/pull/5831) Fixed an endless loop when socket.io parses namespace.
 
 # v3.0.24 - 2023-06-10
 

--- a/src/socketio-server/src/SocketIO.php
+++ b/src/socketio-server/src/SocketIO.php
@@ -141,7 +141,7 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
         }
         // Check that the namespace is correct
         if (! str_contains($frame->data, ',') && ! str_contains($frame->data, '?')) {
-            $this->stdoutLogger->error("The data format is incorrect:{$frame->data}");
+            $this->stdoutLogger->error("The data format is incorrect: {$frame->data}");
             return;
         }
         $packet = $this->decoder->decode(substr($frame->data, 1));

--- a/src/socketio-server/src/SocketIO.php
+++ b/src/socketio-server/src/SocketIO.php
@@ -139,6 +139,11 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
             $this->stdoutLogger->error("EngineIO event type {$frame->data[0]} not supported");
             return;
         }
+        //  Check that the namespace is correct
+        if (! str_contains($frame->data, ',') && ! str_contains($frame->data, '?')) {
+            $this->stdoutLogger->error("The data format is incorrect:{$frame->data}");
+            return;
+        }
         $packet = $this->decoder->decode(substr($frame->data, 1));
         switch ($packet->type) {
             case Packet::OPEN: // client open

--- a/src/socketio-server/src/SocketIO.php
+++ b/src/socketio-server/src/SocketIO.php
@@ -139,7 +139,7 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
             $this->stdoutLogger->error("EngineIO event type {$frame->data[0]} not supported");
             return;
         }
-        //  Check that the namespace is correct
+        // Check that the namespace is correct
         if (! str_contains($frame->data, ',') && ! str_contains($frame->data, '?')) {
             $this->stdoutLogger->error("The data format is incorrect:{$frame->data}");
             return;


### PR DESCRIPTION
## 修复 socket.io 组件命名空间传参不太对时，会导致死循环的问题

复现步骤

1、安装好 socket.io server
2、用 ws://127.0.0.1:9502/socket.io/?EIO=2&transport=websocket 连接 websocket
3、message 发送 `42/x` , 则会出现死循环

错误信息如下：

```
PHP Warning:  Uninitialized string offset 511 in /opt/www/vendor/hyperf/socketio-server/src/Parser/Decoder.php on line 31
......
```