### PR TITLE
Throw exception when column id is not existed

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.26 - TBD
 
+## Fixed
+
+- [#5858](https://github.com/hyperf/hyperf/pull/5858) Throw exception when using `chunkById` but the column is not existed.
+
 # v3.0.25 - 2023-06-19
 
 ## Fixed

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -26,6 +26,7 @@ use Hyperf\Support\Traits\ForwardsCalls;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionMethod;
+use RuntimeException;
 
 use function Hyperf\Collection\collect;
 use function Hyperf\Tappable\tap;
@@ -718,6 +719,10 @@ class Builder
             }
 
             $lastId = $results->last()->{$alias};
+
+            if ($lastId === null) {
+                throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
+            }
 
             unset($results);
         } while ($countResults == $count);


### PR DESCRIPTION
与 `Query/Builder.php:2035` 中的逻辑保持一致