### PR TITLE
Adds `define()` method to `ModelFactory`

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -24,7 +24,7 @@
 - [#5815](https://github.com/hyperf/hyperf/pull/5815) Added alias as `mysql` for `pdo` in `hyperf/db`.
 - [#5849](https://github.com/hyperf/hyperf/pull/5849) Support for insert update and select using enums.
 - [#5855](https://github.com/hyperf/hyperf/pull/5855) Added `hyperf/closure-command` component.
-- [#5894](https://github.com/hyperf/hyperf/pull/5894) Added `model-factory` support for `hyperf/testing`.
+- [#5894](https://github.com/hyperf/hyperf/pull/5894) [#5897](https://github.com/hyperf/hyperf/pull/5897) Added `model-factory` support for `hyperf/testing`.
 
 ## Optimized
 

--- a/src/testing/src/Concerns/InteractsWithModelFactory.php
+++ b/src/testing/src/Concerns/InteractsWithModelFactory.php
@@ -18,7 +18,10 @@ trait InteractsWithModelFactory
 {
     protected ?ModelFactory $modelFactory = null;
 
-    protected string|array $factoryPath = BASE_PATH . '/database/factories';
+    /**
+     * @var string|string[]
+     */
+    protected $factoryPath = BASE_PATH . '/database/factories';
 
     protected function setUpInteractsWithModelFactory()
     {

--- a/src/testing/src/ModelFactory.php
+++ b/src/testing/src/ModelFactory.php
@@ -28,22 +28,27 @@ class ModelFactory
         return new static(new Factory($faker));
     }
 
+    public function define(string $class, callable $attributes, string $name = 'default'): void
+    {
+        $this->factory->define(...func_get_args());
+    }
+
     /**
-     * @param class-string<T> $model
+     * @param class-string<T> $class
      * @return T
      */
-    public function factory(string $model, ...$arguments)
+    public function factory(string $class)
     {
-        $factory = $this->factory;
+        $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
-            return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
+            return $this->factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
         }
         if (isset($arguments[1])) {
-            return $factory->of($arguments[0])->times($arguments[1]);
+            return $this->factory->of($arguments[0])->times($arguments[1]);
         }
 
-        return $factory->of($arguments[0]);
+        return $this->factory->of($arguments[0]);
     }
 
     public function load(string $path): void


### PR DESCRIPTION
```php
$this->modelFactory->define(User::class, function (Faker $faker) {
    return [
        'name' => $faker->name,
        'email' => $faker->unique()->safeEmail,
        'password' => md5('password123'),
    ];
});

$user = $this->modelFactory->factory(User::class)->create();
```