### PR TITLE
Optimized code for identifer established by the rpc client that must contain a string,number or null if included.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -34,6 +34,7 @@
 - [#5866](https://github.com/hyperf/hyperf/pull/5866) Use `StrCache` instead of `Str` in special cases.
 - [#5872](https://github.com/hyperf/hyperf/pull/5872) Avoid to execute the refresh callback more than once when calling `refresh()` multi times.
 - [#5879](https://github.com/hyperf/hyperf/pull/5879) [#5878](https://github.com/hyperf/hyperf/pull/5878) Improve `Command`.
+- [#5901](https://github.com/hyperf/hyperf/pull/5901) Optimized code for identifer established by the rpc client that must contain a string,number or null if included.
 
 ## Removed
 

--- a/src/rpc-client/src/AbstractServiceClient.php
+++ b/src/rpc-client/src/AbstractServiceClient.php
@@ -102,7 +102,7 @@ abstract class AbstractServiceClient
         return $this->pathGenerator->generate($this->serviceName, $methodName);
     }
 
-    protected function __generateData(string $methodName, array $params, ?string $id)
+    protected function __generateData(string $methodName, array $params, null|int|string $id)
     {
         return $this->dataFormatter->formatRequest(new Request($this->__generateRpcPath($methodName), $params, $id));
     }

--- a/src/rpc/src/ErrorResponse.php
+++ b/src/rpc/src/ErrorResponse.php
@@ -13,11 +13,11 @@ namespace Hyperf\Rpc;
 
 class ErrorResponse
 {
-    public function __construct(protected ?string $id, protected int $code, protected string $message, protected mixed $exception)
+    public function __construct(protected null|int|string $id, protected int $code, protected string $message, protected mixed $exception)
     {
     }
 
-    public function getId(): ?string
+    public function getId(): null|int|string
     {
         return $this->id;
     }

--- a/src/rpc/src/Request.php
+++ b/src/rpc/src/Request.php
@@ -13,7 +13,7 @@ namespace Hyperf\Rpc;
 
 class Request
 {
-    public function __construct(protected string $path, protected array $params, protected ?string $id = null)
+    public function __construct(protected string $path, protected array $params, protected null|int|string $id = null)
     {
     }
 
@@ -33,7 +33,7 @@ class Request
         return $this->params;
     }
 
-    public function getId(): ?string
+    public function getId(): null|int|string
     {
         return $this->id;
     }

--- a/src/rpc/src/Response.php
+++ b/src/rpc/src/Response.php
@@ -13,11 +13,11 @@ namespace Hyperf\Rpc;
 
 class Response
 {
-    public function __construct(protected ?string $id, protected mixed $result)
+    public function __construct(protected null|int|string $id, protected mixed $result)
     {
     }
 
-    public function getId(): ?string
+    public function getId(): null|int|string
     {
         return $this->id;
     }


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/5277