### PR TITLE
Fixed bug that `Str::startsWith` and `Str::endsWith` will cause the error result when the `$needles` is `[null]`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,8 @@
 
 ## Fixed
 
-- [#5969](https://github.com/hyperf/hyperf/pull/5969) Fixed bug that `Str::contains` with `null` will case the error result.
+- [#5969](https://github.com/hyperf/hyperf/pull/5969) Fixed bug that `Str::contains` with `null` will cause the error result.
+- [#5970](https://github.com/hyperf/hyperf/pull/5970) Fixed bug that `Str::startsWith` and `Str::endsWith` with `null` will cause the error result.
 
 # v3.0.30 - 2023-07-21
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,8 +2,8 @@
 
 ## Fixed
 
-- [#5969](https://github.com/hyperf/hyperf/pull/5969) Fixed bug that `Str::contains` with `null` will cause the error result.
-- [#5970](https://github.com/hyperf/hyperf/pull/5970) Fixed bug that `Str::startsWith` and `Str::endsWith` with `null` will cause the error result.
+- [#5969](https://github.com/hyperf/hyperf/pull/5969) Fixed bug that `Str::contains` will cause the error result when the `$needles` is `[null]`.
+- [#5970](https://github.com/hyperf/hyperf/pull/5970) Fixed bug that `Str::startsWith` and `Str::endsWith` will cause the error result when the `$needles` is `[null]`.
 
 # v3.0.30 - 2023-07-21
 

--- a/src/stringable/src/Str.php
+++ b/src/stringable/src/Str.php
@@ -247,6 +247,7 @@ class Str
     public static function endsWith(string $haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
+            $needle = (string) $needle;
             if ($needle !== '' && str_ends_with($haystack, (string) $needle)) {
                 return true;
             }
@@ -704,6 +705,7 @@ class Str
     public static function startsWith(string $haystack, $needles): bool
     {
         foreach ((array) $needles as $needle) {
+            $needle = (string) $needle;
             if ($needle !== '' && str_starts_with($haystack, (string) $needle)) {
                 return true;
             }

--- a/src/stringable/src/Str.php
+++ b/src/stringable/src/Str.php
@@ -248,7 +248,7 @@ class Str
     {
         foreach ((array) $needles as $needle) {
             $needle = (string) $needle;
-            if ($needle !== '' && str_ends_with($haystack, (string) $needle)) {
+            if ($needle !== '' && str_ends_with($haystack, $needle)) {
                 return true;
             }
         }
@@ -706,7 +706,7 @@ class Str
     {
         foreach ((array) $needles as $needle) {
             $needle = (string) $needle;
-            if ($needle !== '' && str_starts_with($haystack, (string) $needle)) {
+            if ($needle !== '' && str_starts_with($haystack, $needle)) {
                 return true;
             }
         }

--- a/src/stringable/tests/StrTest.php
+++ b/src/stringable/tests/StrTest.php
@@ -169,6 +169,9 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('hyperf.wiki', ['http://', 'https://']));
         $this->assertTrue(Str::startsWith('http://www.hyperf.io', 'http://'));
         $this->assertTrue(Str::startsWith('https://www.hyperf.io', ['http://', 'https://']));
+        $this->assertFalse(Str::startsWith('Hperfy', ['']));
+        $this->assertFalse(Str::startsWith('Hperfy', [null]));
+        $this->assertFalse(Str::startsWith('Hperfy', null));
     }
 
     public function testStripTags()
@@ -252,5 +255,13 @@ class StrTest extends TestCase
         $this->assertFalse(Str::contains('Hperfy', ['']));
         $this->assertFalse(Str::contains('Hperfy', [null]));
         $this->assertFalse(Str::contains('Hperfy', null));
+    }
+
+    public function testEndsWith()
+    {
+        $this->assertTrue(Str::endsWith('Hperfy', ['y']));
+        $this->assertFalse(Str::endsWith('Hperfy', ['']));
+        $this->assertFalse(Str::endsWith('Hperfy', [null]));
+        $this->assertFalse(Str::endsWith('Hperfy', null));
     }
 }

--- a/src/stringable/tests/StrTest.php
+++ b/src/stringable/tests/StrTest.php
@@ -171,7 +171,7 @@ class StrTest extends TestCase
         $this->assertTrue(Str::startsWith('https://www.hyperf.io', ['http://', 'https://']));
         $this->assertFalse(Str::startsWith('Hyperf', ['']));
         $this->assertFalse(Str::startsWith('Hyperf', [null]));
-        $this->assertFalse(Str::startsWith('Hyperf', null)); 
+        $this->assertFalse(Str::startsWith('Hyperf', null));
     }
 
     public function testStripTags()

--- a/src/stringable/tests/StrTest.php
+++ b/src/stringable/tests/StrTest.php
@@ -169,9 +169,9 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('hyperf.wiki', ['http://', 'https://']));
         $this->assertTrue(Str::startsWith('http://www.hyperf.io', 'http://'));
         $this->assertTrue(Str::startsWith('https://www.hyperf.io', ['http://', 'https://']));
-        $this->assertFalse(Str::startsWith('Hperfy', ['']));
-        $this->assertFalse(Str::startsWith('Hperfy', [null]));
-        $this->assertFalse(Str::startsWith('Hperfy', null));
+        $this->assertFalse(Str::startsWith('Hyperf', ['']));
+        $this->assertFalse(Str::startsWith('Hyperf', [null]));
+        $this->assertFalse(Str::startsWith('Hyperf', null)); 
     }
 
     public function testStripTags()
@@ -251,17 +251,17 @@ class StrTest extends TestCase
 
     public function testContains()
     {
-        $this->assertTrue(Str::contains('Hperfy', ['H']));
-        $this->assertFalse(Str::contains('Hperfy', ['']));
-        $this->assertFalse(Str::contains('Hperfy', [null]));
-        $this->assertFalse(Str::contains('Hperfy', null));
+        $this->assertTrue(Str::contains('Hyperf', ['H']));
+        $this->assertFalse(Str::contains('Hyperf', ['']));
+        $this->assertFalse(Str::contains('Hyperf', [null]));
+        $this->assertFalse(Str::contains('Hyperf', null));
     }
 
     public function testEndsWith()
     {
-        $this->assertTrue(Str::endsWith('Hperfy', ['y']));
-        $this->assertFalse(Str::endsWith('Hperfy', ['']));
-        $this->assertFalse(Str::endsWith('Hperfy', [null]));
-        $this->assertFalse(Str::endsWith('Hperfy', null));
+        $this->assertTrue(Str::endsWith('Hyperf', ['f']));
+        $this->assertFalse(Str::endsWith('Hyperf', ['']));
+        $this->assertFalse(Str::endsWith('Hyperf', [null]));
+        $this->assertFalse(Str::endsWith('Hyperf', null));
     }
 }


### PR DESCRIPTION
…l case the wrong result.