### PR TITLE
conf:在JSON RPC Server配置中设置服务地址，从而可以配置外网地址，直接将服务暴露到外网

### DIFF
--- a/docs/zh-cn/json-rpc.md
+++ b/docs/zh-cn/json-rpc.md
@@ -78,6 +78,8 @@ return [
             'name' => 'jsonrpc-http',
             'type' => Server::SERVER_HTTP,
             'host' => '0.0.0.0',
+            //服务地址，可以配外网地址,设置了之后服务就不会自动绑定内网地址
+            'address' => getenv('CONSUL_SERVICE_HOST'),
             'port' => 9504,
             'sock_type' => SWOOLE_SOCK_TCP,
             'callbacks' => [

--- a/src/service-governance/src/Listener/RegisterServiceListener.php
+++ b/src/service-governance/src/Listener/RegisterServiceListener.php
@@ -99,7 +99,7 @@ class RegisterServiceListener implements ListenerInterface
             if (! $server['name']) {
                 throw new InvalidArgumentException('Invalid server name');
             }
-            $host = $server['host'];
+            $host = isset($server['address']) ? $server['address'] : $server['host'];
             if (in_array($host, ['0.0.0.0', 'localhost'])) {
                 $host = $this->ipReader->read();
             }


### PR DESCRIPTION
有时候需要发布一些公开的接口服务，自动绑定内网地址就会导致不是同一个内网就访问不了