### PR TITLE
fix:依赖版本错误

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "league/flysystem-aws-s3-v3": "^1.0|^2.0|^3.0",
         "league/flysystem-memory": "^1.0|^2.0|^3.0",
         "league/plates": "^3.3",
-        "longlang/phpkafka": "^1.2.3",
+        "longlang/phpkafka": "^1.2.2",
         "markrogoyski/math-php": "^2.0",
         "mix/redis-subscriber": "^3.0.4",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires longlang/phpkafka ^1.2.3, found longlang/phpkafka[dev-master, v1.0.0, ..., v1.2.2] but it does not match the constraint.