### PR TITLE
Allow using the tracer instance from context, append `Trace-Id` to Response Header

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,7 +7,7 @@
 
 ## Optimized
 
-- [#6023](https://github.com/hyperf/hyperf/pull/6023) Append `Trace-Id` to Response Header.
+- [#6023](https://github.com/hyperf/hyperf/pull/6023) Allow using the tracer instance from context, append `Trace-Id` to Response Header.
 
 # v3.0.32 - 2023-08-09
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,10 @@
 - [#6011](https://github.com/hyperf/hyperf/pull/6011) Fixed the issue where validation for invocable controller route requests was not working.
 - [#6013](https://github.com/hyperf/hyperf/pull/6013) Fixed the bug that `no_aspect` is overridden.
 
+## Optimized
+
+- [#6023](https://github.com/hyperf/hyperf/pull/6023) Append `Trace-Id` to Response Header.
+
 # v3.0.32 - 2023-08-09
 
 ## Added

--- a/src/tracer/src/Middleware/TraceMiddleware.php
+++ b/src/tracer/src/Middleware/TraceMiddleware.php
@@ -23,8 +23,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
-use Zipkin\Propagation\TraceContext;
-use ZipkinOpenTracing\SpanContext;
 
 use function Hyperf\Coroutine\defer;
 

--- a/src/tracer/src/Middleware/TraceMiddleware.php
+++ b/src/tracer/src/Middleware/TraceMiddleware.php
@@ -51,7 +51,7 @@ class TraceMiddleware implements MiddlewareInterface
             }
         });
         try {
-            $response = $handler->handle($request);
+            $response = $handler->handle($request)->withHeader('Trace-Id', $span->getContext()->getContext()->getTraceId());
             $span->setTag($this->spanTagManager->get('response', 'status_code'), $response->getStatusCode());
         } catch (Throwable $exception) {
             $this->switchManager->isEnable('exception') && $this->appendExceptionToSpan($span, $exception);

--- a/src/tracer/src/SpanStarter.php
+++ b/src/tracer/src/SpanStarter.php
@@ -15,6 +15,7 @@ use Hyperf\Context\ApplicationContext;
 use Hyperf\Context\Context;
 use Hyperf\Rpc;
 use OpenTracing\Span;
+use OpenTracing\Tracer;
 use Psr\Http\Message\ServerRequestInterface;
 
 use const OpenTracing\Formats\TEXT_MAP;
@@ -32,14 +33,16 @@ trait SpanStarter
         string $kind = SPAN_KIND_RPC_SERVER
     ): Span {
         $root = Context::get('tracer.root');
+        /** @var Tracer $tracer */
+        $tracer = Context::get('tracer.tracer') ?: $this->tracer;
         if (! $root instanceof Span) {
             $container = ApplicationContext::getContainer();
             /** @var ServerRequestInterface $request */
             $request = Context::get(ServerRequestInterface::class);
             if (! $request instanceof ServerRequestInterface) {
-                // If the request object is absent, we are probably in a commandline context.
+                // If the request object is absent, we are probably in a commandLine context.
                 // Throwing an exception is unnecessary.
-                $root = $this->tracer->startSpan($name, $option);
+                $root = $tracer->startSpan($name, $option);
                 $root->setTag(SPAN_KIND, $kind);
                 Context::set('tracer.root', $root);
                 return $root;
@@ -54,17 +57,17 @@ trait SpanStarter
                 }
             }
             // Extracts the context from the HTTP headers.
-            $spanContext = $this->tracer->extract(TEXT_MAP, $carrier);
+            $spanContext = $tracer->extract(TEXT_MAP, $carrier);
             if ($spanContext) {
                 $option['child_of'] = $spanContext;
             }
-            $root = $this->tracer->startSpan($name, $option);
+            $root = $tracer->startSpan($name, $option);
             $root->setTag(SPAN_KIND, $kind);
             Context::set('tracer.root', $root);
             return $root;
         }
         $option['child_of'] = $root->getContext();
-        $child = $this->tracer->startSpan($name, $option);
+        $child = $tracer->startSpan($name, $option);
         $child->setTag(SPAN_KIND, $kind);
         return $child;
     }

--- a/src/tracer/src/TracerContext.php
+++ b/src/tracer/src/TracerContext.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Tracer;
+
+use Hyperf\Context\Context;
+use OpenTracing\Span;
+use OpenTracing\Tracer;
+
+class TracerContext
+{
+    public const TRACER = 'tracer.tracer';
+
+    public const ROOT = 'tracer.root';
+
+    public static function setTracer(Tracer $tracer): Tracer
+    {
+        return Context::set(self::TRACER, $tracer);
+    }
+
+    public static function getTracer(): ?Tracer
+    {
+        return Context::get(self::TRACER) ?: null;
+    }
+
+    public static function setRoot(Span $root): Span
+    {
+        return Context::set(self::ROOT, $root);
+    }
+
+    public static function getRoot(): ?Span
+    {
+        return Context::get(self::ROOT) ?: null;
+    }
+}


### PR DESCRIPTION
子协程里需要创建新的 `tracer`，在协程结束的时候执行 `$tracer->flush()`，防止 `span` 丢失或者在 `finish` 之前就被上报了。

https://github.com/hyperf/hyperf/issues/5003

创建子协程的时候需要处理一下。

```php
<?php

declare(strict_types=1);

namespace App\Kernel\Context;

use App\Kernel\Log\AppendRequestIdProcessor;
use Hyperf\Context\Context;
use Hyperf\Contract\StdoutLoggerInterface;
use Hyperf\Engine\Coroutine as Co;
use OpenTracing\Span;
use OpenTracing\Tracer;
use Psr\Container\ContainerInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Log\LoggerInterface;
use Sentry\SentrySdk;
use Throwable;

use function Hyperf\Support\call;
use function Hyperf\Support\make;

class Coroutine
{
    protected LoggerInterface $logger;

    public function __construct(protected ContainerInterface $container)
    {
        $this->logger = $container->get(StdoutLoggerInterface::class);
    }

    /**
     * @return int Returns the coroutine ID of the coroutine just created.
     *             Returns -1 when coroutine create failed.
     */
    public function create(callable $callable): int
    {
        $id = Co::id();
        $root = Context::get('tracer.root');

        $coroutine = Co::create(function () use ($callable, $id, $root) {
            try {
                // Shouldn't copy all contexts to avoid socket already been bound to another coroutine.
                Context::copy($id, [
                    AppendRequestIdProcessor::REQUEST_ID,
                    ServerRequestInterface::class,
                    SentrySdk::class,
                ]);

                // Tracer
                if ($root instanceof Span) {
                    /** @var Tracer $tracer */
                    $tracer = make(Tracer::class);
                    Context::set('tracer.tracer', $tracer);
                    $child = $tracer->startSpan('coroutine', [
                        'child_of' => $root->getContext(),
                    ]);
                    $child->setTag('coroutine.id', Co::id());
                    Context::set('tracer.root', $child);
                    Co::defer(function () use ($child, $tracer) {
                        $child->finish();
                        $tracer->flush();
                    });
                }

                call($callable);
            } catch (Throwable $throwable) {
                if (isset($child)) {
                    $child->setTag('error', true);
                    $child->log(['message', $throwable->getMessage(), 'code' => $throwable->getCode(), 'stacktrace' => $throwable->getTraceAsString()]);
                }
                $this->logger->warning((string) $throwable);
            }
        });

        try {
            return $coroutine->getId();
        } catch (Throwable $throwable) {
            $this->logger->warning((string) $throwable);
            return -1;
        }
    }
}


```