### PR TITLE
[feat] Support buffer mechanism in standalone process of metric

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -53,6 +53,7 @@
 - [#5972](https://github.com/hyperf/hyperf/pull/5972) `Collection::except()` with null returns all.
 - [#5973](https://github.com/hyperf/hyperf/pull/5973) Simplified the handlers definition of logger.
 - [#6010](https://github.com/hyperf/hyperf/pull/6010) Throw exception when cast class is not existed.
+- [#6030](https://github.com/hyperf/hyperf/pull/6030) Support buffer mechanism in standalone process of metric.
 
 ## Removed
 

--- a/src/metric/publish/metric.php
+++ b/src/metric/publish/metric.php
@@ -19,6 +19,9 @@ return [
     'use_standalone_process' => env('METRIC_USE_STANDALONE_PROCESS', true),
     'enable_default_metric' => env('METRIC_ENABLE_DEFAULT_METRIC', true),
     'default_metric_interval' => env('DEFAULT_METRIC_INTERVAL', 5),
+    // only available when use_standalone_process is true
+    'buffer_interval' => env('METRIC_BUFFER_INTERVAL', 5),
+    'buffer_size' => env('METRIC_BUFFER_SIZE', 200),
     'metric' => [
         'prometheus' => [
             'driver' => Hyperf\Metric\Adapter\Prometheus\MetricFactory::class,

--- a/src/metric/src/Adapter/RemoteProxy/Counter.php
+++ b/src/metric/src/Adapter/RemoteProxy/Counter.php
@@ -11,13 +11,12 @@ declare(strict_types=1);
  */
 namespace Hyperf\Metric\Adapter\RemoteProxy;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Metric\Contract\CounterInterface;
-use Hyperf\Process\ProcessCollector;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
 
 class Counter implements CounterInterface
 {
-    protected const TARGET_PROCESS_NAME = 'metric';
-
     /**
      * @var string[]
      */
@@ -38,7 +37,9 @@ class Counter implements CounterInterface
     public function add(int $delta): void
     {
         $this->delta = $delta;
-        $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
-        $process->write(serialize($this));
+
+        ApplicationContext::getContainer()
+            ->get(MetricCollectorInterface::class)
+            ->add($this);
     }
 }

--- a/src/metric/src/Adapter/RemoteProxy/Gauge.php
+++ b/src/metric/src/Adapter/RemoteProxy/Gauge.php
@@ -41,8 +41,10 @@ class Gauge implements GaugeInterface
     {
         $this->value = $value;
         $this->delta = null;
-        $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
-        $process->write(serialize($this));
+
+        ApplicationContext::getContainer()
+            ->get(MetricCollectorInterface::class)
+            ->add($this);
     }
 
     public function add(float $delta): void

--- a/src/metric/src/Adapter/RemoteProxy/Gauge.php
+++ b/src/metric/src/Adapter/RemoteProxy/Gauge.php
@@ -14,7 +14,6 @@ namespace Hyperf\Metric\Adapter\RemoteProxy;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Metric\Contract\GaugeInterface;
 use Hyperf\Metric\Contract\MetricCollectorInterface;
-use Hyperf\Process\ProcessCollector;
 
 class Gauge implements GaugeInterface
 {

--- a/src/metric/src/Adapter/RemoteProxy/Gauge.php
+++ b/src/metric/src/Adapter/RemoteProxy/Gauge.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  */
 namespace Hyperf\Metric\Adapter\RemoteProxy;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Metric\Contract\GaugeInterface;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
 use Hyperf\Process\ProcessCollector;
 
 class Gauge implements GaugeInterface
 {
-    protected const TARGET_PROCESS_NAME = 'metric';
-
     /**
      * @var string[]
      */
@@ -49,7 +49,9 @@ class Gauge implements GaugeInterface
     {
         $this->delta = $delta;
         $this->value = null;
-        $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
-        $process->write(serialize($this));
+
+        ApplicationContext::getContainer()
+            ->get(MetricCollectorInterface::class)
+            ->add($this);
     }
 }

--- a/src/metric/src/Adapter/RemoteProxy/Histogram.php
+++ b/src/metric/src/Adapter/RemoteProxy/Histogram.php
@@ -11,13 +11,12 @@ declare(strict_types=1);
  */
 namespace Hyperf\Metric\Adapter\RemoteProxy;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Metric\Contract\HistogramInterface;
-use Hyperf\Process\ProcessCollector;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
 
 class Histogram implements HistogramInterface
 {
-    protected const TARGET_PROCESS_NAME = 'metric';
-
     /**
      * @var string[]
      */
@@ -38,7 +37,9 @@ class Histogram implements HistogramInterface
     public function put(float $sample): void
     {
         $this->sample = $sample;
-        $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
-        $process->write(serialize($this));
+
+        ApplicationContext::getContainer()
+            ->get(MetricCollectorInterface::class)
+            ->add($this);
     }
 }

--- a/src/metric/src/Adapter/RemoteProxy/MetricCollector.php
+++ b/src/metric/src/Adapter/RemoteProxy/MetricCollector.php
@@ -37,9 +37,9 @@ class MetricCollector implements MetricCollectorInterface
     public function flush(): void
     {
         $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
-        $process->write(serialize($this->buffer));
-
+        $buffer = $this->buffer;
         $this->buffer = [];
+        $process->write(serialize($buffer));
     }
 
     public function getBuffer(): array

--- a/src/metric/src/Adapter/RemoteProxy/MetricCollector.php
+++ b/src/metric/src/Adapter/RemoteProxy/MetricCollector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Metric\Adapter\RemoteProxy;
+
+use Hyperf\Metric\Contract\MetricCollectorInterface;
+use Hyperf\Process\ProcessCollector;
+
+class MetricCollector implements MetricCollectorInterface
+{
+    protected const TARGET_PROCESS_NAME = 'metric';
+
+    protected array $buffer = [];
+
+    public function __construct(
+        protected int $bufferSize = 200
+    ) {
+    }
+
+    public function add(object $data): void
+    {
+        $this->buffer[] = $data;
+
+        if (count($this->buffer) >= $this->bufferSize) {
+            $this->flush();
+        }
+    }
+
+    public function flush(): void
+    {
+        $process = ProcessCollector::get(static::TARGET_PROCESS_NAME)[0];
+        $process->write(serialize($this->buffer));
+
+        $this->buffer = [];
+    }
+
+    public function getBuffer(): array
+    {
+        return $this->buffer;
+    }
+}

--- a/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
+++ b/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
@@ -14,6 +14,8 @@ namespace Hyperf\Metric\Adapter\RemoteProxy;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Metric\Contract\MetricCollectorInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 class MetricCollectorFactory
 {

--- a/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
+++ b/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Metric\Adapter\RemoteProxy;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
+use Psr\Container\ContainerInterface;
+
+class MetricCollectorFactory
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): MetricCollectorInterface
+    {
+        $config = $container->get(ConfigInterface::class);
+
+        return new MetricCollector(
+            (int) $config->get('metric.buffer_size', 200)
+        );
+    }
+}

--- a/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
+++ b/src/metric/src/Adapter/RemoteProxy/MetricCollectorFactory.php
@@ -13,8 +13,8 @@ namespace Hyperf\Metric\Adapter\RemoteProxy;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Metric\Contract\MetricCollectorInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 class MetricCollectorFactory

--- a/src/metric/src/ConfigProvider.php
+++ b/src/metric/src/ConfigProvider.php
@@ -13,9 +13,12 @@ namespace Hyperf\Metric;
 
 use Domnikl\Statsd\Connection;
 use Domnikl\Statsd\Connection\UdpSocket;
+use Hyperf\Metric\Adapter\RemoteProxy\MetricCollectorFactory;
 use Hyperf\Metric\Aspect\CounterAnnotationAspect;
 use Hyperf\Metric\Aspect\HistogramAnnotationAspect;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
+use Hyperf\Metric\Listener\MetricBufferWatcher;
 use Hyperf\Metric\Listener\OnBeforeHandle;
 use Hyperf\Metric\Listener\OnCoroutineServerStart;
 use Hyperf\Metric\Listener\OnMetricFactoryReady;
@@ -37,6 +40,7 @@ class ConfigProvider
                 Adapter::class => InMemory::class,
                 Connection::class => UdpSocket::class,
                 DriverInterface::class => Guzzle::class,
+                MetricCollectorInterface::class => MetricCollectorFactory::class,
             ],
             'aspects' => [
                 CounterAnnotationAspect::class,
@@ -56,6 +60,7 @@ class ConfigProvider
                 OnBeforeHandle::class,
                 OnWorkerStart::class,
                 OnCoroutineServerStart::class,
+                MetricBufferWatcher::class,
             ],
             'processes' => [
                 MetricProcess::class,

--- a/src/metric/src/Contract/MetricCollectorInterface.php
+++ b/src/metric/src/Contract/MetricCollectorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Metric\Contract;
+
+interface MetricCollectorInterface
+{
+    public function add(object $data): void;
+
+    public function flush(): void;
+}

--- a/src/metric/src/Listener/MetricBufferWatcher.php
+++ b/src/metric/src/Listener/MetricBufferWatcher.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Metric\Listener;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Coordinator\Timer;
+use Hyperf\Coroutine\Coroutine;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\BeforeWorkerStart;
+use Hyperf\Metric\Adapter\RemoteProxy\MetricCollector;
+use Hyperf\Metric\Contract\MetricCollectorInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Collect and handle metrics before worker start.
+ * Only used for swoole process mode.
+ */
+class MetricBufferWatcher implements ListenerInterface
+{
+    protected MetricFactoryInterface $factory;
+
+    private ConfigInterface $config;
+
+    private MetricCollectorInterface $collector;
+
+    private Timer $timer;
+
+    public function __construct(protected ContainerInterface $container)
+    {
+        $this->config = $container->get(ConfigInterface::class);
+        $this->collector = $container->get(MetricCollector::class);
+        $this->timer = new Timer();
+    }
+
+    /**
+     * @return string[] returns the events that you want to listen
+     */
+    public function listen(): array
+    {
+        return [
+            BeforeWorkerStart::class,
+        ];
+    }
+
+    /**
+     * Handle the Event when the event is triggered, all listeners will
+     * complete before the event is returned to the EventDispatcher.
+     */
+    public function process(object $event): void
+    {
+        if ($event->workerId === null) {
+            return;
+        }
+
+        /*
+         * Only start buffer watcher in standalone process mode
+         */
+        if (! $this->config->get('metric.use_standalone_process', true)) {
+            return;
+        }
+
+        $timerInterval = $this->config->get('metric.buffer_interval', 5);
+        $timerId = $this->timer->tick($timerInterval, function () {
+            $this->collector->flush();
+        });
+        // Clean up timer on worker exit;
+        Coroutine::create(function () use ($timerId) {
+            CoordinatorManager::until(Constants::WORKER_EXIT)->yield();
+            $this->timer->clear($timerId);
+        });
+    }
+}

--- a/src/metric/src/Listener/MetricBufferWatcher.php
+++ b/src/metric/src/Listener/MetricBufferWatcher.php
@@ -18,7 +18,6 @@ use Hyperf\Coordinator\Timer;
 use Hyperf\Coroutine\Coroutine;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
-use Hyperf\Metric\Adapter\RemoteProxy\MetricCollector;
 use Hyperf\Metric\Contract\MetricCollectorInterface;
 use Psr\Container\ContainerInterface;
 
@@ -39,7 +38,7 @@ class MetricBufferWatcher implements ListenerInterface
     public function __construct(protected ContainerInterface $container)
     {
         $this->config = $container->get(ConfigInterface::class);
-        $this->collector = $container->get(MetricCollector::class);
+        $this->collector = $container->get(MetricCollectorInterface::class);
         $this->timer = new Timer();
     }
 

--- a/src/metric/src/Listener/MetricBufferWatcher.php
+++ b/src/metric/src/Listener/MetricBufferWatcher.php
@@ -27,8 +27,6 @@ use Psr\Container\ContainerInterface;
  */
 class MetricBufferWatcher implements ListenerInterface
 {
-    protected MetricFactoryInterface $factory;
-
     private ConfigInterface $config;
 
     private MetricCollectorInterface $collector;

--- a/src/metric/src/Listener/OnPipeMessage.php
+++ b/src/metric/src/Listener/OnPipeMessage.php
@@ -42,32 +42,42 @@ class OnPipeMessage implements ListenerInterface
      */
     public function process(object $event): void
     {
-        Coroutine::create(function () use ($event) {
-            if ($event instanceof PipeMessage) {
-                $factory = make(MetricFactoryInterface::class);
-                $inner = $event->data;
-                switch (true) {
-                    case $inner instanceof Counter:
-                        $counter = $factory->makeCounter($inner->name, $inner->labelNames);
-                        $counter->with(...$inner->labelValues)->add($inner->delta);
-                        break;
-                    case $inner instanceof Gauge:
-                        $gauge = $factory->makeGauge($inner->name, $inner->labelNames);
-                        if (isset($inner->value)) {
-                            $gauge->with(...$inner->labelValues)->set($inner->value);
-                        } else {
-                            $gauge->with(...$inner->labelValues)->add($inner->delta);
-                        }
-                        break;
-                    case $inner instanceof Histogram:
-                        $histogram = $factory->makeHistogram($inner->name, $inner->labelNames);
-                        $histogram->with(...$inner->labelValues)->put($inner->sample);
-                        break;
-                    default:
-                        // Nothing to do
-                        break;
+        if (! $event instanceof PipeMessage) {
+            return;
+        }
+
+        $inner = ! is_array($event->data) ? [$event->data] : $value;
+        foreach ($inner as $data) {
+            Coroutine::create(function () use ($data) {
+                $this->processData($data);
+            });
+        }
+    }
+
+    protected function processData(object $data): void
+    {
+        $factory = make(MetricFactoryInterface::class);
+
+        switch (true) {
+            case $data instanceof Counter:
+                $counter = $factory->makeCounter($data->name, $data->labelNames);
+                $counter->with(...$data->labelValues)->add($data->delta);
+                break;
+            case $data instanceof Gauge:
+                $gauge = $factory->makeGauge($data->name, $data->labelNames);
+                if (isset($data->value)) {
+                    $gauge->with(...$data->labelValues)->set($data->value);
+                } else {
+                    $gauge->with(...$data->labelValues)->add($data->delta);
                 }
-            }
-        });
+                break;
+            case $data instanceof Histogram:
+                $histogram = $factory->makeHistogram($data->name, $data->labelNames);
+                $histogram->with(...$data->labelValues)->put($data->sample);
+                break;
+            default:
+                // Nothing to do
+                break;
+        }
     }
 }

--- a/src/metric/src/Listener/OnPipeMessage.php
+++ b/src/metric/src/Listener/OnPipeMessage.php
@@ -18,15 +18,17 @@ use Hyperf\Metric\Adapter\RemoteProxy\Gauge;
 use Hyperf\Metric\Adapter\RemoteProxy\Histogram;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
 use Hyperf\Process\Event\PipeMessage;
+use Psr\Container\ContainerInterface;
 
 /**
  * Receives messages in metric process.
  */
 class OnPipeMessage implements ListenerInterface
 {
-    public function __construct(
-        protected MetricFactoryInterface $factory
-    ) {
+    protected MetricFactoryInterface $factory;
+
+    public function __construct(protected ContainerInterface $container)
+    {
     }
 
     /**
@@ -49,6 +51,7 @@ class OnPipeMessage implements ListenerInterface
             return;
         }
 
+        $this->factory = $this->container->get(MetricFactoryInterface::class);
         $inner = ! is_array($event->data) ? [$event->data] : $event->data;
         foreach ($inner as $data) {
             Coroutine::create(function () use ($data) {

--- a/src/metric/src/Listener/OnPipeMessage.php
+++ b/src/metric/src/Listener/OnPipeMessage.php
@@ -46,7 +46,7 @@ class OnPipeMessage implements ListenerInterface
             return;
         }
 
-        $inner = ! is_array($event->data) ? [$event->data] : $value;
+        $inner = ! is_array($event->data) ? [$event->data] : $event->data;
         foreach ($inner as $data) {
             Coroutine::create(function () use ($data) {
                 $this->processData($data);

--- a/src/metric/tests/Adapter/RemoteProxy/MetricCollectorTest.php
+++ b/src/metric/tests/Adapter/RemoteProxy/MetricCollectorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Metric\Adapter\RemoteProxy;
+
+use Hyperf\Metric\Adapter\RemoteProxy\MetricCollector;
+use Hyperf\Process\ProcessCollector;
+use Mockery;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Swoole\Process;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class MetricCollectorTest extends TestCase
+{
+    public function testAddData()
+    {
+        $collector = new MetricCollector(100);
+
+        $this->assertSame(0, count($collector->getBuffer()));
+
+        $collector->add($data = new stdClass());
+
+        $this->assertSame(1, count($collector->getBuffer()));
+    }
+
+    public function testFlush()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('write')
+            ->once();
+        ProcessCollector::add('metric', $process);
+
+        $collector = new MetricCollector(100);
+        $collector->add(new stdClass());
+        $collector->flush();
+
+        $this->assertSame(0, count($collector->getBuffer()));
+    }
+
+    public function testAddWithFlush()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('write')
+            ->once();
+        ProcessCollector::add('metric', $process);
+
+        $collector = new MetricCollector(1);
+        $collector->add(new stdClass());
+
+        $this->assertSame(0, count($collector->getBuffer()));
+    }
+}


### PR DESCRIPTION
* 問題：metric 預設使用 standalone_process 時會大幅降低 qps
> 參照：https://github.com/hyperf/hyperf/issues/5665
* 實作：新增一個 `MetricCollector` 來統一蒐集 metric，當 buffer 到達閥值（預設 200 個）或是定時器週期內自動批次送出 metric buffer，透過該機制減少原先每次傳送 metric 次數以節省 ipc 開銷
* 性能測試：
  * 未啟用 metric 組件
```
  Running 10s test @ http://127.0.0.1:9501
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.76ms   10.83ms 141.05ms   91.69%
    Req/Sec    28.31k     7.05k   53.06k    78.25%
  1130323 requests in 10.09s, 204.81MB read
Requests/sec: 112035.82
Transfer/sec:     20.30MB
``` 

  * 原始 metric 版本：
```
  Running 10s test @ http://127.0.0.1:9501
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.47ms    4.33ms  60.70ms   95.48%
    Req/Sec     6.23k     4.09k   22.94k    92.08%
  250408 requests in 10.10s, 45.37MB read
  Socket errors: connect 0, read 0, write 0, timeout 1
Requests/sec:  24786.26
Transfer/sec:      4.49MB
```

  * metric 的 buffer 版本：
```
  Running 10s test @ http://127.0.0.1:9501
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.88ms   24.07ms 245.46ms   87.77%
    Req/Sec    16.66k     5.66k   36.74k    72.43%
  663653 requests in 10.07s, 120.25MB read
Requests/sec:  65897.45
Transfer/sec:     11.94MB
```