### PR TITLE
[feat] support connection setting in database config

### DIFF
--- a/src/database/src/Migrations/Migration.php
+++ b/src/database/src/Migrations/Migration.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\Database\Migrations;
 
 use Hyperf\Context\ApplicationContext;
-use Hyperf\Contract\ConfigInterface;
+use Hyperf\Database\ConnectionResolverInterface;
 
 abstract class Migration
 {
@@ -36,7 +36,7 @@ abstract class Migration
         }
 
         return ApplicationContext::getContainer()
-            ->get(ConfigInterface::class)
-            ->get('databases.connection', 'default');
+            ->get(ConnectionResolverInterface::class)
+            ->getDefaultConnection();
     }
 }

--- a/src/database/src/Migrations/Migration.php
+++ b/src/database/src/Migrations/Migration.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
  */
 namespace Hyperf\Database\Migrations;
 
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\ConfigInterface;
+
 abstract class Migration
 {
     /**
@@ -21,13 +24,19 @@ abstract class Migration
     /**
      * The name of the database connection to use.
      */
-    protected string $connection = 'default';
+    protected ?string $connection = null;
 
     /**
      * Get the migration connection name.
      */
     public function getConnection(): string
     {
-        return $this->connection;
+        if ($connection = $this->connection) {
+            return $connection;
+        }
+
+        return ApplicationContext::getContainer()
+            ->get(ConfigInterface::class)
+            ->get('databases.connection', 'default');
     }
 }

--- a/src/database/src/Model/Factory.php
+++ b/src/database/src/Model/Factory.php
@@ -14,7 +14,7 @@ namespace Hyperf\Database\Model;
 use ArrayAccess;
 use Faker\Generator as Faker;
 use Hyperf\Context\ApplicationContext;
-use Hyperf\Contract\ConfigInterface;
+use Hyperf\Database\ConnectionResolverInterface;
 use Symfony\Component\Finder\Finder;
 
 class Factory implements ArrayAccess
@@ -324,7 +324,7 @@ class Factory implements ArrayAccess
     protected function getConnection(): string
     {
         return ApplicationContext::getContainer()
-            ->get(ConfigInterface::class)
-            ->get('databases.connection', 'default');
+            ->get(ConnectionResolverInterface::class)
+            ->getDefaultConnection();
     }
 }

--- a/src/database/src/Model/Model.php
+++ b/src/database/src/Model/Model.php
@@ -82,7 +82,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The connection name for the model.
      */
-    protected ?string $connection = 'default';
+    protected ?string $connection = null;
 
     /**
      * The table associated with the model.

--- a/src/db-connection/publish/databases.php
+++ b/src/db-connection/publish/databases.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 use function Hyperf\Support\env;
 
 return [
+    'connection' => env('DB_CONNECTION', 'default'),
+
     'default' => [
         'driver' => env('DB_DRIVER', 'mysql'),
         'host' => env('DB_HOST', 'localhost'),

--- a/src/db-connection/src/Listener/RegisterConnectionResolverListener.php
+++ b/src/db-connection/src/Listener/RegisterConnectionResolverListener.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\DbConnection\Listener;
 
+use Hyperf\Contract\ConfigInterface;
 use Hyperf\Database\ConnectionResolverInterface;
 use Hyperf\Database\Model\Register;
 use Hyperf\Event\Contract\ListenerInterface;
@@ -32,10 +33,16 @@ class RegisterConnectionResolverListener implements ListenerInterface
 
     public function process(object $event): void
     {
-        if ($this->container->has(ConnectionResolverInterface::class)) {
-            Register::setConnectionResolver(
-                $this->container->get(ConnectionResolverInterface::class)
-            );
+        if (! $this->container->has(ConnectionResolverInterface::class)) {
+            return;
         }
+
+        $connection = $this->container
+            ->get(ConfigInterface::class)
+            ->get('databases.connection', 'default');
+        $resolver = $this->container->get(ConnectionResolverInterface::class);
+        $resolver->setDefaultConnection($connection);
+
+        Register::setConnectionResolver($resolver);
     }
 }


### PR DESCRIPTION
* 說明：讓 db connection 不是固定寫死成 `default`，而是在 config 中能指定預設的 connection
* 實作：
    * config 中增加 `connection` 的 key，並預設成 `default`
    * 將 Migration, Factory, Model 中的 connection 使用設定的 connection