### PR TITLE
Use HttpClient CoroutineHandler in swoole environment

### DIFF
--- a/src/guzzle/src/ClientFactory.php
+++ b/src/guzzle/src/ClientFactory.php
@@ -23,14 +23,9 @@ class ClientFactory
 {
     protected bool $runInSwoole = false;
 
-    protected int $nativeCurlHook = 0;
-
     public function __construct(private ContainerInterface $container)
     {
         $this->runInSwoole = extension_loaded('swoole');
-        if (defined('SWOOLE_HOOK_NATIVE_CURL')) {
-            $this->nativeCurlHook = SWOOLE_HOOK_NATIVE_CURL;
-        }
     }
 
     public function create(array $options = []): Client

--- a/src/guzzle/src/ClientFactory.php
+++ b/src/guzzle/src/ClientFactory.php
@@ -40,7 +40,6 @@ class ClientFactory
         if (
             $this->runInSwoole
             && Coroutine::inCoroutine()
-            && (\Swoole\Runtime::getHookFlags() & $this->nativeCurlHook) == 0
         ) {
             $stack = HandlerStack::create(new CoroutineHandler());
         }

--- a/src/watcher/src/Watcher.php
+++ b/src/watcher/src/Watcher.php
@@ -55,7 +55,7 @@ class Watcher
 
     public function run()
     {
-        $this->dumpautoload();
+        $this->dumpAutoload();
         $this->restart(true);
 
         $channel = new Channel(999);
@@ -84,7 +84,7 @@ class Watcher
         }
     }
 
-    public function dumpautoload()
+    public function dumpAutoload()
     {
         $ret = exec('composer dump-autoload -o --no-scripts -d ' . BASE_PATH);
         $this->output->writeln($ret['output'] ?? '');


### PR DESCRIPTION
## 问题

使用链路追踪 `HttpClient ` 、并且高并发的情况下，走nativeCurlHook （CURL） 会出现gc不及时 ，触发内存上限 异常退出的情况。
使用 协程客户端 情况得到改善。

```php
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 69632 bytes) in Unknown on line 0
```

## 测试步骤

```php

class IndexController extends Controller
{
    public function index(): ResponseInterface
    {
        
        time() % 3 === 0 && print_r(memory_get_usage() / 1024 / 1024 . 'M' . PHP_EOL);
        
        $user = $this->request->input('user', 'Hyperf');
        $method = $this->request->getMethod();
        return $this->response->success([
            'user' => $user,
            'method' => $method,
            'message' => 'Hello Hyperf.',
            'server_name' => config('app_name'),
            'ms' => get_ms_config(),
        ]);
    }
}
```

```shell
 wrk -t10 -c300 -d60 http://127.0.0.1:9501
```

```
~# php --ri swoole

swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 5.0.2
Built => Mar 18 2023 00:06:28
coroutine => enabled with boost asm context
epoll => enabled
eventfd => enabled
signalfd => enabled
spinlock => enabled
rwlock => enabled
openssl => OpenSSL 1.1.1t  7 Feb 2023
dtls => enabled
http2 => enabled
json => enabled
curl-native => enabled
pcre => enabled
c-ares => 1.18.1
zlib => 1.2.12
brotli => E16777225/D16777225
mutex_timedlock => enabled
pthread_barrier => enabled
async_redis => enabled
coroutine_postgresql => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 8388608 => 8388608
```