### PR TITLE
Enhance server config to support key-value mode

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Optimized
 
 - [#6046](https://github.com/hyperf/hyperf/pull/6046) Using the tracer instance from coroutine context.
+- [#6061](https://github.com/hyperf/hyperf/pull/6061) Enhance server config to support key-value mode.
 
 # v3.0.33 - 2023-08-18
 

--- a/src/server/src/ServerConfig.php
+++ b/src/server/src/ServerConfig.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\Server;
 
 use Hyperf\Contract\Arrayable;
@@ -37,7 +38,10 @@ class ServerConfig implements Arrayable
         }
 
         $servers = [];
-        foreach ($config['servers'] as $item) {
+        foreach ($config['servers'] as $name => $item) {
+            if (! isset($item['name']) && ! is_numeric($name)) {
+                $item['name'] = $name;
+            }
             $servers[] = Port::build($item);
         }
 

--- a/src/server/src/ServerConfig.php
+++ b/src/server/src/ServerConfig.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
-
 namespace Hyperf\Server;
 
 use Hyperf\Contract\Arrayable;


### PR DESCRIPTION
Before:

```php
    'servers' => [
        [
            'name' => 'http',
            'type' => Server::SERVER_HTTP,
            'host' => '0.0.0.0',
            'port' => 9501,
            'sock_type' => SWOOLE_SOCK_TCP,
            'callbacks' => [
                Event::ON_REQUEST => [Hyperf\HttpServer\Server::class, 'onRequest'],
            ],
            'options' => [
                'enable_request_lifecycle' => true,
            ],
        ],
    ],
```

After:

```php
    'servers' => [
        'http' => [
            // 'name' => 'http', // 如果设置了此项，会优先使用
            'type' => Server::SERVER_HTTP,
            'host' => '0.0.0.0',
            'port' => 9501,
            'sock_type' => SWOOLE_SOCK_TCP,
            'callbacks' => [
                Event::ON_REQUEST => [Hyperf\HttpServer\Server::class, 'onRequest'],
            ],
            'options' => [
                'enable_request_lifecycle' => true,
            ],
        ],
    ],
```

调整理由：方便获取和修改某个 server 的参数。
建议：3.1 默认使用 key-value 的配置方式