### PR TITLE
Don't show deprecated notice when using `#[Constants]`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -18,6 +18,7 @@
 
 - [#6046](https://github.com/hyperf/hyperf/pull/6046) Using the tracer instance from coroutine context.
 - [#6061](https://github.com/hyperf/hyperf/pull/6061) Enhance server config to support key-value mode.
+- [#6077](https://github.com/hyperf/hyperf/pull/6077) Don't show deprecated notice when using `#[Hyperf\Constants\Annotation\Constants]`.
 
 # v3.0.33 - 2023-08-18
 

--- a/src/constants/src/Annotation/Constants.php
+++ b/src/constants/src/Annotation/Constants.php
@@ -23,7 +23,7 @@ class Constants extends AbstractAnnotation
     public function __construct()
     {
     }
-    
+
     public function collectClass(string $className): void
     {
         $reader = new AnnotationReader();

--- a/src/constants/src/Annotation/Constants.php
+++ b/src/constants/src/Annotation/Constants.php
@@ -20,6 +20,10 @@ use ReflectionClass;
 #[Attribute(Attribute::TARGET_CLASS)]
 class Constants extends AbstractAnnotation
 {
+    public function __construct()
+    {
+    }
+    
     public function collectClass(string $className): void
     {
         $reader = new AnnotationReader();


### PR DESCRIPTION
AbstractAnnotation 的构造函数加入了即将弃用注解，导致在直接引用 Constants 注解时，编译器会报弃用警告，再不修改AbstractAnnotation的情况下，在Constants 中加入覆写构造函数代码以消除警告