### PR TITLE
Adds contextual binding support

### DIFF
--- a/src/di/src/Aop/RegisterInjectPropertyHandler.php
+++ b/src/di/src/Aop/RegisterInjectPropertyHandler.php
@@ -36,7 +36,9 @@ class RegisterInjectPropertyHandler
                 try {
                     $reflectionProperty = ReflectionManager::reflectProperty($currentClassName, $property);
                     $container = ApplicationContext::getContainer();
-                    if ($container->has($annotation->value)) {
+                    if (! str_contains($annotation->value, '@') && $container->has($id = $annotation->value . '@' . $currentClassName)) {
+                        $reflectionProperty->setValue($object, $container->get($id));
+                    } elseif ($container->has($annotation->value)) {
                         $reflectionProperty->setValue($object, $container->get($annotation->value));
                     } elseif ($annotation->required) {
                         throw new NotFoundException("No entry or class found for '{$annotation->value}'");

--- a/src/di/src/Definition/DefinitionSource.php
+++ b/src/di/src/Definition/DefinitionSource.php
@@ -75,7 +75,7 @@ class DefinitionSource implements DefinitionSourceInterface
 
             $parameterType = $parameter->getType();
             if ($parameterType instanceof ReflectionNamedType && ! $parameterType->isBuiltin()) {
-                $parameters[$index] = new Reference($parameterType->getName());
+                $parameters[$index] = new Reference($parameterType->getName(), $constructor->class); /* @phpstan-ignore-line */
             }
         }
 

--- a/src/di/src/Definition/Reference.php
+++ b/src/di/src/Definition/Reference.php
@@ -25,7 +25,7 @@ class Reference implements DefinitionInterface, SelfResolvingDefinitionInterface
     /**
      * @param string $targetEntryName name of the target entry
      */
-    public function __construct(private string $targetEntryName)
+    public function __construct(private string $targetEntryName, private $sourceEntryName)
     {
     }
 
@@ -58,14 +58,22 @@ class Reference implements DefinitionInterface, SelfResolvingDefinitionInterface
         return $this->targetEntryName;
     }
 
+    public function getFullTargetEntryName(): string
+    {
+        return $this->targetEntryName . '@' . $this->sourceEntryName;
+    }
+
     public function resolve(ContainerInterface $container)
     {
+        if ($container->has($this->getFullTargetEntryName())) {
+            return $container->get($this->getFullTargetEntryName());
+        }
         return $container->get($this->getTargetEntryName());
     }
 
     public function isResolvable(ContainerInterface $container): bool
     {
-        return $container->has($this->getTargetEntryName());
+        return $container->has($this->getFullTargetEntryName()) || $container->has($this->getTargetEntryName());
     }
 
     /**


### PR DESCRIPTION
> 这是一个思路

```php
<?php
// config/autoload/dependencies.php
return [
    'App\Bar@App\Foo1' => App\BarAtFoo1Factory::class,
    'App\Bar@App\Foo2' => App\BarAtFoo2Factory::class,
];
```

```php
<?php
namespace App;

class Foo1
{
    public function __construct(public Bar $bar)
    {
    }
}

class Foo2
{
    public function __construct(public Bar $bar)
    {
    }
}
```

支持注解的方式

```php
<?php
namespace App;

use Hyperf\Di\Annotation\Inject;

class Foo1
{
    #[Inject]
    public Bar $bar;
}

class Foo2
{
    #[Inject]
    public Bar $bar;
}
```

Foo1 和 Foo2 都通过 DI 注入了 Foo，也都是从容器实例化出来的单例，但是区别不是同一个对象。

https://github.com/hyperf/hyperf/issues/4716