### PR TITLE
Fixed bug that configuration of other processes were not updated when using `nacos grpc client`

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - [#6097](https://github.com/hyperf/hyperf/pull/6097) Fixed error that using non-zipkin driver of tracer.
 - [#6099](https://github.com/hyperf/hyperf/pull/6099) Fixed bug that `ConstantFrequency` cannot work when using `redis`.
+- [#6110](https://github.com/hyperf/hyperf/pull/6110) Fixed bug that configuration of other processes were not updated when using `nacos grpc client`.
 
 ## Added
 

--- a/src/config-nacos/src/NacosDriver.php
+++ b/src/config-nacos/src/NacosDriver.php
@@ -50,9 +50,15 @@ class NacosDriver extends AbstractDriver
 
             $client = $application->grpc->get($tenant);
             $client->listenConfig($group, $dataId, new ConfigChangeNotifyRequestHandler(function (ConfigQueryResponse $response) use ($key, $type) {
-                $this->updateConfig([
-                    $key => $this->client->decode($response->getContent(), $type),
-                ]);
+                $config = $this->client->decode($response->getContent(), $type);
+                $prevConfig = $this->config->get($key, []);
+
+                if ($config !== $prevConfig) {
+                    $this->syncConfig(
+                        [$key => $config],
+                        [$key => $prevConfig],
+                    );
+                }
             }));
         }
 


### PR DESCRIPTION
Fixed #6076 