### PR TITLE
Fixed bug that grpc client cannot able to be reused.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.36 - TBD
 
+## Fixed
+
+- [#6117](https://github.com/hyperf/hyperf/pull/6117) Fixed bug that grpc client cannot able to be reused.
+
 # v3.0.35 - 2023-09-01
 
 ## Fixed

--- a/src/grpc-client/src/GrpcClient.php
+++ b/src/grpc-client/src/GrpcClient.php
@@ -305,6 +305,9 @@ class GrpcClient
                     $channel->push($response);
                     if (! $response->pipeline) {
                         unset($this->recvChannelMap[$streamId]);
+                        if(! $channel->isEmpty()) {
+                            $channel->pop();
+                        }
                         $this->channelPool->push($channel);
                     }
                     // If wait status is equal to WAIT_CLOSE, and no coroutine is waiting, then break the recv loop.

--- a/src/grpc-client/src/GrpcClient.php
+++ b/src/grpc-client/src/GrpcClient.php
@@ -305,7 +305,7 @@ class GrpcClient
                     $channel->push($response);
                     if (! $response->pipeline) {
                         unset($this->recvChannelMap[$streamId]);
-                        if(! $channel->isEmpty()) {
+                        if (! $channel->isEmpty()) {
                             $channel->pop();
                         }
                         $this->channelPool->push($channel);


### PR DESCRIPTION
这里改了两个地方
1）获取客户端时，判断下是否Running，因为服务侧响应RST_STREAM帧时关闭链接，下一次发起请求需要重新链接，并重新启动runReceiveCoroutine
2）流关闭时 回收Channel，需要判断是否非空，非空会影响下一次请求。使用客户端流时，问题会暴露，服务侧发了一个 空结束帧 没有被 pop 就被回收了