### PR TITLE
Optimized multi-level dir config

### DIFF
--- a/src/config/src/ConfigFactory.php
+++ b/src/config/src/ConfigFactory.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Config;
 
+use Hyperf\Collection\Arr;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -40,9 +41,13 @@ class ConfigFactory
         $finder = new Finder();
         $finder->files()->in($paths)->name('*.php');
         foreach ($finder as $file) {
-            $configs[] = [
-                $file->getBasename('.php') => require $file->getRealPath(),
-            ];
+            $config = [];
+            $key = implode('.', array_filter([
+                str_replace('/', '.', $file->getRelativePath()),
+                $file->getBasename('.php'),
+            ]));
+            Arr::set($config, $key, require $file->getRealPath());
+            $configs[] = $config;
         }
         return $configs;
     }


### PR DESCRIPTION
现有逻辑：

问题1
```
config
├── autoload
│   ├── businessA
│   │   ├── ai.php
│   ├── businessB
│   │   ├── ai.php
```

两个`ai.php`文件，假设都有一个`enable => true`配置项，会以文件名`ai`作为键值放在config中，故`config('ai.enable')`取出是一个`array(true, true)`

>  假设用户新建了一个同名配置文件 如 `server.php`，可能会影响原有配置的获取和程序执行，产生报错

问题2
与laravel配置文件管理不同，复制代码过来后还需要修改才能运行

-----

更改后逻辑：`以相对目录.文件名` 作为键值（与3.0现有逻辑BC）

