### PR TITLE
gen:model: fix ModelRewriteGetterSetterVisitor and GenerateModelIDEVi…

### DIFF
--- a/src/database/src/Commands/Ast/GenerateModelIDEVisitor.php
+++ b/src/database/src/Commands/Ast/GenerateModelIDEVisitor.php
@@ -160,7 +160,12 @@ class GenerateModelIDEVisitor extends AbstractVisitor
         $reflection = new ReflectionClass($this->data->getClass());
         sort($methods);
         foreach ($methods as $methodStmt) {
-            $method = $reflection->getMethod($methodStmt->name->name);
+            try {
+                $method = $reflection->getMethod($methodStmt->name->name);
+            } catch (\ReflectionException) {
+                continue;
+            }
+
             if (Str::startsWith($method->getName(), 'scope') && $method->getName() !== 'scopeQuery') {
                 $name = Str::camel(substr($method->getName(), 5));
                 if (! empty($name)) {


### PR DESCRIPTION
ModelRewriteGetterSetterVisitor问题：
     其中getter和setter是从当前model中代码中获取的，没有考虑父类和trait等，重写方法可能会导致错误，例如
    `PHP Fatal error:  Declaration of App\Model\User::setCreatedAt($created_at) must be compatible with Hyperf\Database\Model\Model::setCreatedAt($value): static in /project/hyperf-skeleton/app/Model/User.php on line 104`
GenerateModelIDEVisitor问题：
