### PR TITLE
Added `gen:class` to generate a common class.

### DIFF
--- a/src/devtool/publish/devtool.php
+++ b/src/devtool/publish/devtool.php
@@ -29,6 +29,9 @@ return [
         'aspect' => [
             'namespace' => 'App\\Aspect',
         ],
+        'class' => [
+            'namespace' => 'App',
+        ],
         'command' => [
             'namespace' => 'App\\Command',
         ],

--- a/src/devtool/src/Generator/ClassCommand.php
+++ b/src/devtool/src/Generator/ClassCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Devtool\Generator;
+
+use Hyperf\Command\Annotation\Command;
+
+#[Command]
+class ClassCommand extends GeneratorCommand
+{
+    public function __construct()
+    {
+        parent::__construct('gen:class');
+    }
+
+    public function configure()
+    {
+        $this->setDescription('Create a new class');
+
+        parent::configure();
+    }
+
+    protected function getStub(): string
+    {
+        return $this->getConfig()['stub'] ?? __DIR__ . '/stubs/class.stub';
+    }
+
+    protected function getDefaultNamespace(): string
+    {
+        return $this->getConfig()['namespace'] ?? 'App';
+    }
+}

--- a/src/devtool/src/Generator/stubs/class.stub
+++ b/src/devtool/src/Generator/stubs/class.stub
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace %NAMESPACE%;
+
+class %CLASS%
+{
+    
+}


### PR DESCRIPTION
Don't know about you, but sometimes I miss a `gen` command for simple classes, like:
```bash
php bin/hyperf.php gen:class FooService -N App\\Service
```
Or
```bash
php bin/hyperf.php gen:class FooEvent -N App\\Event
```

你们都想念通用类生成器吗?