### PR TITLE
Fixed bug that service governance still registers services even when `services.enable.register` is `false`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -11,7 +11,7 @@
 
 ## Fixed
 
-- [#6160](https://github.com/hyperf/hyperf/pull/6160) Fixed bug that service governance always register services although the `services.enable.register` is `false`.
+- [#6160](https://github.com/hyperf/hyperf/pull/6160) Fixed bug that service governance still registers services even when `services.enable.register` is `false`.
 
 # v3.0.36 - 2023-09-15
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -9,6 +9,10 @@
 - [#6154](https://github.com/hyperf/hyperf/pull/6154) Use PHP native `json_validate` to validate is json if function is available.
 - [#6157](https://github.com/hyperf/hyperf/pull/6157) Record the exception message only by opening the exception switch and closing the ignore switch when using `trace`.
 
+## Fixed
+
+- [#6160](https://github.com/hyperf/hyperf/pull/6160) Fixed bug that service governance always register services although the `services.enable.register` is `false`.
+
 # v3.0.36 - 2023-09-15
 
 ## Added

--- a/src/service-governance/src/Listener/RegisterServiceListener.php
+++ b/src/service-governance/src/Listener/RegisterServiceListener.php
@@ -123,6 +123,6 @@ class RegisterServiceListener implements ListenerInterface
 
     protected function getEnableRegister(): bool
     {
-        return $this->config->get('services.enable.register', true);
+        return (bool) $this->config->get('services.enable.register', true);
     }
 }

--- a/src/service-governance/src/Listener/RegisterServiceListener.php
+++ b/src/service-governance/src/Listener/RegisterServiceListener.php
@@ -58,34 +58,38 @@ class RegisterServiceListener implements ListenerInterface
      */
     public function process(object $event): void
     {
-        $attempts = 10;
-        while ($attempts > 0) {
-            try {
-                $services = $this->serviceManager->all();
-                $servers = $this->getServers();
-                foreach ($services as $serviceName => $serviceProtocols) {
-                    foreach ($serviceProtocols as $paths) {
-                        foreach ($paths as $service) {
-                            if (! isset($service['publishTo'], $service['server'])) {
-                                continue;
-                            }
-                            [$address, $port] = $servers[$service['server']];
-                            if ($governance = $this->governanceManager->get($service['publishTo'])) {
-                                if (! $governance->isRegistered($serviceName, $address, (int) $port, $service)) {
-                                    $governance->register($serviceName, $address, (int) $port, $service);
+        $register = $this->getEnableRegister();
+        if($register){
+            $attempts = 10;
+            while ($attempts > 0) {
+                try {
+                    $services = $this->serviceManager->all();
+                    $servers = $this->getServers();
+                    foreach ($services as $serviceName => $serviceProtocols) {
+                        foreach ($serviceProtocols as $paths) {
+                            foreach ($paths as $service) {
+                                if (! isset($service['publishTo'], $service['server'])) {
+                                    continue;
+                                }
+                                [$address, $port] = $servers[$service['server']];
+                                if ($governance = $this->governanceManager->get($service['publishTo'])) {
+                                    if (! $governance->isRegistered($serviceName, $address, (int) $port, $service)) {
+                                        $governance->register($serviceName, $address, (int) $port, $service);
+                                    }
                                 }
                             }
                         }
                     }
+                    break;
+                } catch (Exception $exception) {
+                    $this->logger->error('Cannot register service, connect service center failed, re-register after 1 seconds.');
+                    $this->logger->error((string) $exception);
+                    sleep(1);
+                    --$attempts;
                 }
-                break;
-            } catch (Exception $exception) {
-                $this->logger->error('Cannot register service, connect service center failed, re-register after 1 seconds.');
-                $this->logger->error((string) $exception);
-                sleep(1);
-                --$attempts;
             }
         }
+        
     }
 
     protected function getServers(): array
@@ -114,5 +118,11 @@ class RegisterServiceListener implements ListenerInterface
             $result[$server['name']] = [$host, $port];
         }
         return $result;
+    }
+
+    protected function getEnableRegister(): bool
+    {
+        $enable = $this->config->get('services.enable', []);
+        return $enable['register']??true;
     }
 }

--- a/src/service-governance/src/Listener/RegisterServiceListener.php
+++ b/src/service-governance/src/Listener/RegisterServiceListener.php
@@ -123,7 +123,6 @@ class RegisterServiceListener implements ListenerInterface
 
     protected function getEnableRegister(): bool
     {
-        $enable = $this->config->get('services.enable', []);
-        return $enable['register'] ?? true;
+        return $this->config->get('services.enable.register', true);
     }
 }


### PR DESCRIPTION
解决：多人开发，发布到测试服务中心，调不通rpc接口，没有开关关闭注册。