### PR TITLE
Fixed bug that `cleanUpExpiredOnce` failed when sids is empty when using `socketio-server`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.38 - TBD
 
+## Fixed
+
+- [#6185](https://github.com/hyperf/hyperf/pull/6185) Fixed bug that `cleanUpExpiredOnce` failed when sids is empty when using `socketio-server`.
+
 # v3.0.37 - 2023-09-22
 
 ## Added

--- a/src/socketio-server/src/Room/RedisAdapter.php
+++ b/src/socketio-server/src/Room/RedisAdapter.php
@@ -195,9 +195,9 @@ class RedisAdapter implements AdapterInterface, EphemeralInterface
             foreach ($sids as $sid) {
                 $this->del($sid);
             }
-        }
 
-        $this->redis->zRem($this->getExpireKey(), ...$sids);
+            $this->redis->zRem($this->getExpireKey(), ...$sids);
+        }
     }
 
     public function setTtl(int $ms): EphemeralInterface


### PR DESCRIPTION
fix https://github.com/hyperf/hyperf/issues/6179