### PR TITLE
nacos multi service source discovery

### DIFF
--- a/src/rpc-client/src/AbstractServiceClient.php
+++ b/src/rpc-client/src/AbstractServiceClient.php
@@ -171,7 +171,7 @@ abstract class AbstractServiceClient
         $consumer = $this->getConsumerConfig();
 
         $registryProtocol = $consumer['registry']['protocol'] ?? null;
-        $registryAddress = $consumer['registry']['address'] ?? null;
+        $registryAddress = $consumer['registry']['address'] ?? '';
         // Current $consumer is the config of the specified consumer.
         if (! empty($registryProtocol) && $this->container->has(DriverManager::class)) {
             $governance = $this->container->get(DriverManager::class)->get($registryProtocol);

--- a/src/service-governance-nacos/src/ClientFactory.php
+++ b/src/service-governance-nacos/src/ClientFactory.php
@@ -17,15 +17,20 @@ use Psr\Container\ContainerInterface;
 
 class ClientFactory
 {
-    public function __invoke(ContainerInterface $container): Client
+    public function __invoke(ContainerInterface $container,array $parameters = []): Client
     {
-        $config = $container->get(ConfigInterface::class)->get('services.drivers.nacos', []);
+
+        if(empty($parameters['config'])){
+            $config = $container->get(ConfigInterface::class)->get('services.drivers.nacos', []);
+
+        }else{
+            $config = $parameters['config'];
+        }
         if (! empty($config['uri'])) {
             $baseUri = $config['uri'];
         } else {
             $baseUri = sprintf('http://%s:%d', $config['host'] ?? '127.0.0.1', $config['port'] ?? 8848);
         }
-
         return new Client(new Config([
             'base_uri' => $baseUri,
             'username' => $config['username'] ?? null,

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -22,6 +22,8 @@ use Hyperf\ServiceGovernance\DriverInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
+use function Hyperf\Support\make;
+
 use Throwable;
 
 use function Hyperf\Support\retry;
@@ -48,10 +50,41 @@ class NacosDriver implements DriverInterface
         $this->logger = $container->get(StdoutLoggerInterface::class);
         $this->config = $container->get(ConfigInterface::class);
     }
-
+    protected function getConsumersClient(string $name): Client{
+        static  $client;
+        if(empty($client[$name])){
+            $consumerConfigs=$this->config->get("services.consumers");
+            foreach ($consumerConfigs as $consumerConfig){
+                if($consumerConfig['name']==$name){
+                    $config=$consumerConfig['registry']['config']??[];
+                    $address=$consumerConfig['registry']['address']??'';
+                    //If there is no dedicated configuration and address not empty
+                    if(empty($config)&&$address!=''){
+                        //merge and replace config from services.drivers.nacos
+                        $config=array_merge(
+                            $this->container->get(ConfigInterface::class)->get('services.drivers.nacos', []),
+                            [
+                                'uri'=>$address
+                            ]
+                        );
+                    }
+                    if(!empty($config)){
+                        $client[$name]=make(Client::class,[
+                            'config'=>$config
+                        ]);
+                    }
+                    break;
+                }
+            }
+            if(empty($client[$name])){
+                $client[$name]=$this->client;
+            }
+        }
+        return $client[$name];
+    }
     public function getNodes(string $uri, string $name, array $metadata): array
     {
-        $response = $this->client->instance->list($name, [
+        $response = $this->getConsumersClient($name)->instance->list($name, [
             'groupName' => $this->config->get('services.drivers.nacos.group_name'),
             'namespaceId' => $this->config->get('services.drivers.nacos.namespace_id'),
         ]);


### PR DESCRIPTION
###  增加了 对  services.consumers.*.registry.address 单独配置地址的支持
> 如单独配置address地址，默认复制：services.drivers.nacos 下的配置 然后覆盖掉会使用 address 覆盖掉 uri 参数。
### 增加了 某个服务单独配置服务源的支持  services.consumers.*.registry.config
> config 同 services.drivers.nacos 参数
> config 参数 优先级大于 address 参数
```
'consumers' => [
        [
            // name 需与服务提供者的 name 属性相同
            'name' => 'xxxx.grpc.xxxx.xxxx',
            'service' => \App\Grpc\OrderServiceInterface::class,
//            // 对应容器对象 ID，可选，默认值等于 service 配置的值，用来定义依赖注入的 key
//            'id' => \App\Grpc\OrderServiceInterface::class,
            'protocol' => 'grpc',
            'registry' => [
                'protocol' => 'nacos',
//                'address' => 'http://'.env("NACOS_HOST").':'.env("NACOS_PORT"),
//                'address' => 'http://'.env("NACOS_HOST").':'.env("NACOS_PORT"),
                'config'=>[
                    'host' => env("NACOS_HOST"),
                    'port' => env("NACOS_PORT"),
                    'username' => env("NACOS_USERNAME"),
                    'password' => env("NACOS_PASSWORD"),
                    'guzzle' => [
                        'config' => null,
                    ],
                    'group_name' => 'tms-order',
                    'namespace_id' => 'tms-order',
                    'heartbeat' => 5,
                    'ephemeral' => true,
                ],
            ],
        ]
```
