### PR TITLE
Check if the connection has been closed

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.41 - TBD
 
+## Added
+
+- [#6224](https://github.com/hyperf/hyperf/pull/6224) Adds charset param and html method for Response.
+
 ## Optimized
 
 - [#6226](https://github.com/hyperf/hyperf/pull/6226) Don't send response when the connection of grpc server has been closed.
@@ -9,7 +13,6 @@
 ## Added
 
 - [#6220](https://github.com/hyperf/hyperf/pull/6220) Added `Hyperf\Stringable\Str::replaceMatches()`.
-- [#6224](https://github.com/hyperf/hyperf/pull/6224) Adds charset param and html method for Response.
 
 ## Fixed
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.41 - TBD
 
+## Optimized
+
+- [#6226](https://github.com/hyperf/hyperf/pull/6226) Don't send response when the connection of grpc server has been closed.
+
 # v3.0.40 - 2023-10-20
 
 ## Added

--- a/src/grpc-server/src/ResponseEmitter.php
+++ b/src/grpc-server/src/ResponseEmitter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\GrpcServer;
+
+use Hyperf\HttpMessage\Stream\FileInterface;
+use Psr\Http\Message\ResponseInterface;
+use Swoole\Http\Response;
+use Throwable;
+
+class ResponseEmitter extends \Hyperf\HttpServer\ResponseEmitter
+{
+    /**
+     * @param Response $connection
+     */
+    public function emit(ResponseInterface $response, mixed $connection, bool $withContent = true): void
+    {
+        try {
+            if (method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
+                return;
+            }
+            $this->buildSwooleResponse($connection, $response);
+            $content = $response->getBody();
+            if ($content instanceof FileInterface) {
+                $connection->sendfile($content->getFilename());
+                return;
+            }
+
+            if ($withContent) {
+                $connection->end((string) $content);
+            } else {
+                $connection->end();
+            }
+        } catch (Throwable $exception) {
+            $this->logger?->critical((string) $exception);
+        }
+    }
+}

--- a/src/grpc-server/src/ResponseEmitter.php
+++ b/src/grpc-server/src/ResponseEmitter.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  */
 namespace Hyperf\GrpcServer;
 
-use Hyperf\HttpMessage\Stream\FileInterface;
 use Psr\Http\Message\ResponseInterface;
 use Swoole\Http\Response;
 use Throwable;
@@ -27,18 +26,7 @@ class ResponseEmitter extends \Hyperf\HttpServer\ResponseEmitter
             if (method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
                 return;
             }
-            $this->buildSwooleResponse($connection, $response);
-            $content = $response->getBody();
-            if ($content instanceof FileInterface) {
-                $connection->sendfile($content->getFilename());
-                return;
-            }
-
-            if ($withContent) {
-                $connection->end((string) $content);
-            } else {
-                $connection->end();
-            }
+            parent::emit($response, $connection, $withContent);
         } catch (Throwable $exception) {
             $this->logger?->critical((string) $exception);
         }

--- a/src/grpc-server/src/Server.php
+++ b/src/grpc-server/src/Server.php
@@ -12,22 +12,23 @@ declare(strict_types=1);
 namespace Hyperf\GrpcServer;
 
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Coordinator\Constants;
-use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Dispatcher\HttpDispatcher;
+use Hyperf\ExceptionHandler\ExceptionHandlerDispatcher;
 use Hyperf\GrpcServer\Exception\Handler\GrpcExceptionHandler;
-use Hyperf\HttpMessage\Server\Response as Psr7Response;
-use Hyperf\HttpServer\Event\RequestHandled;
-use Hyperf\HttpServer\Event\RequestReceived;
-use Hyperf\HttpServer\Event\RequestTerminated;
-use Hyperf\HttpServer\MiddlewareManager;
-use Hyperf\HttpServer\Router\Dispatched;
 use Hyperf\HttpServer\Server as HttpServer;
-use Hyperf\Support\SafeCaller;
-use Psr\Http\Message\ResponseInterface;
-use Throwable;
+use Psr\Container\ContainerInterface;
 
 class Server extends HttpServer
 {
+    public function __construct(
+        ContainerInterface $container,
+        HttpDispatcher $dispatcher,
+        ExceptionHandlerDispatcher $exceptionHandlerDispatcher,
+        ResponseEmitter $responseEmitter
+    ) {
+        parent::__construct($container, $dispatcher, $exceptionHandlerDispatcher, $responseEmitter);
+    }
+
     public function initCoreMiddleware(string $serverName): void
     {
         $this->serverName = $serverName;
@@ -38,74 +39,5 @@ class Server extends HttpServer
         $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, [
             GrpcExceptionHandler::class,
         ]);
-    }
-
-    public function onRequest($request, $response): void
-    {
-        try {
-            CoordinatorManager::until(Constants::WORKER_START)->yield();
-
-            [$psr7Request, $psr7Response] = $this->initRequestAndResponse($request, $response);
-
-            $this->option?->isEnableRequestLifecycle() && $this->event?->dispatch(new RequestReceived(
-                request: $psr7Request,
-                response: $psr7Response,
-                server: $this->serverName
-            ));
-
-            $psr7Request = $this->coreMiddleware->dispatch($psr7Request);
-            /** @var Dispatched $dispatched */
-            $dispatched = $psr7Request->getAttribute(Dispatched::class);
-            $middlewares = $this->middlewares;
-
-            $registeredMiddlewares = [];
-            if ($dispatched->isFound()) {
-                $registeredMiddlewares = MiddlewareManager::get($this->serverName, $dispatched->handler->route, $psr7Request->getMethod());
-                $middlewares = array_merge($middlewares, $registeredMiddlewares);
-            }
-
-            if ($this->option?->isMustSortMiddlewares() || $registeredMiddlewares) {
-                $middlewares = MiddlewareManager::sortMiddlewares($middlewares);
-            }
-
-            $psr7Response = $this->dispatcher->dispatch($psr7Request, $middlewares, $this->coreMiddleware);
-        } catch (Throwable $throwable) {
-            // Delegate the exception to exception handler.
-            $psr7Response = $this->container->get(SafeCaller::class)->call(function () use ($throwable) {
-                return $this->exceptionHandlerDispatcher->dispatch($throwable, $this->exceptionHandlers);
-            }, static function () {
-                return (new Psr7Response())->withStatus(400);
-            });
-        } finally {
-            if (isset($psr7Request) && $this->option?->isEnableRequestLifecycle()) {
-                defer(fn () => $this->event?->dispatch(new RequestTerminated(
-                    request: $psr7Request,
-                    response: $psr7Response ?? null,
-                    exception: $throwable ?? null,
-                    server: $this->serverName
-                )));
-
-                $this->event?->dispatch(new RequestHandled(
-                    request: $psr7Request,
-                    response: $psr7Response ?? null,
-                    exception: $throwable ?? null,
-                    server: $this->serverName
-                ));
-            }
-
-            // Send the Response to client.
-            if (! isset($psr7Response) || ! $psr7Response instanceof ResponseInterface) {
-                return;
-            }
-            // If the response is not writable, then ignore it.
-            if (method_exists($response, 'isWritable') && ! $response->isWritable()) {
-                return;
-            }
-            if (isset($psr7Request) && $psr7Request->getMethod() === 'HEAD') {
-                $this->responseEmitter->emit($psr7Response, $response, false);
-            } else {
-                $this->responseEmitter->emit($psr7Response, $response);
-            }
-        }
     }
 }

--- a/src/grpc-server/src/Server.php
+++ b/src/grpc-server/src/Server.php
@@ -12,8 +12,19 @@ declare(strict_types=1);
 namespace Hyperf\GrpcServer;
 
 use Hyperf\Contract\ConfigInterface;
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\GrpcServer\Exception\Handler\GrpcExceptionHandler;
+use Hyperf\HttpMessage\Server\Response as Psr7Response;
+use Hyperf\HttpServer\Event\RequestHandled;
+use Hyperf\HttpServer\Event\RequestReceived;
+use Hyperf\HttpServer\Event\RequestTerminated;
+use Hyperf\HttpServer\MiddlewareManager;
+use Hyperf\HttpServer\Router\Dispatched;
 use Hyperf\HttpServer\Server as HttpServer;
+use Hyperf\Support\SafeCaller;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 class Server extends HttpServer
 {
@@ -27,5 +38,74 @@ class Server extends HttpServer
         $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, [
             GrpcExceptionHandler::class,
         ]);
+    }
+
+    public function onRequest($request, $response): void
+    {
+        try {
+            CoordinatorManager::until(Constants::WORKER_START)->yield();
+
+            [$psr7Request, $psr7Response] = $this->initRequestAndResponse($request, $response);
+
+            $this->option?->isEnableRequestLifecycle() && $this->event?->dispatch(new RequestReceived(
+                request: $psr7Request,
+                response: $psr7Response,
+                server: $this->serverName
+            ));
+
+            $psr7Request = $this->coreMiddleware->dispatch($psr7Request);
+            /** @var Dispatched $dispatched */
+            $dispatched = $psr7Request->getAttribute(Dispatched::class);
+            $middlewares = $this->middlewares;
+
+            $registeredMiddlewares = [];
+            if ($dispatched->isFound()) {
+                $registeredMiddlewares = MiddlewareManager::get($this->serverName, $dispatched->handler->route, $psr7Request->getMethod());
+                $middlewares = array_merge($middlewares, $registeredMiddlewares);
+            }
+
+            if ($this->option?->isMustSortMiddlewares() || $registeredMiddlewares) {
+                $middlewares = MiddlewareManager::sortMiddlewares($middlewares);
+            }
+
+            $psr7Response = $this->dispatcher->dispatch($psr7Request, $middlewares, $this->coreMiddleware);
+        } catch (Throwable $throwable) {
+            // Delegate the exception to exception handler.
+            $psr7Response = $this->container->get(SafeCaller::class)->call(function () use ($throwable) {
+                return $this->exceptionHandlerDispatcher->dispatch($throwable, $this->exceptionHandlers);
+            }, static function () {
+                return (new Psr7Response())->withStatus(400);
+            });
+        } finally {
+            if (isset($psr7Request) && $this->option?->isEnableRequestLifecycle()) {
+                defer(fn () => $this->event?->dispatch(new RequestTerminated(
+                    request: $psr7Request,
+                    response: $psr7Response ?? null,
+                    exception: $throwable ?? null,
+                    server: $this->serverName
+                )));
+
+                $this->event?->dispatch(new RequestHandled(
+                    request: $psr7Request,
+                    response: $psr7Response ?? null,
+                    exception: $throwable ?? null,
+                    server: $this->serverName
+                ));
+            }
+
+            // Send the Response to client.
+            if (! isset($psr7Response) || ! $psr7Response instanceof ResponseInterface) {
+                return;
+            }
+            // If the response is not writable, then ignore it.
+            if (method_exists($response, 'isWritable') && ! $response->isWritable()) {
+                return;
+            }
+            if (isset($psr7Request) && $psr7Request->getMethod() === 'HEAD') {
+                $this->responseEmitter->emit($psr7Response, $response, false);
+            } else {
+                $this->responseEmitter->emit($psr7Response, $response);
+            }
+        }
     }
 }

--- a/src/http-server/src/ResponseEmitter.php
+++ b/src/http-server/src/ResponseEmitter.php
@@ -33,7 +33,7 @@ class ResponseEmitter implements ResponseEmitterInterface
             if (strtolower($connection->header['Upgrade'] ?? '') === 'websocket') {
                 return;
             }
-            if (strtolower($response->getHeaderLine('Content-Type') ?? '') === 'application/grpc' && method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
+            if (strtolower($response->getHeaderLine('Content-Type')) === 'application/grpc' && method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
                 return;
             }
             $this->buildSwooleResponse($connection, $response);

--- a/src/http-server/src/ResponseEmitter.php
+++ b/src/http-server/src/ResponseEmitter.php
@@ -33,9 +33,6 @@ class ResponseEmitter implements ResponseEmitterInterface
             if (strtolower($connection->header['Upgrade'] ?? '') === 'websocket') {
                 return;
             }
-            if (strtolower($response->getHeaderLine('Content-Type')) === 'application/grpc' && method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
-                return;
-            }
             $this->buildSwooleResponse($connection, $response);
             $content = $response->getBody();
             if ($content instanceof FileInterface) {

--- a/src/http-server/src/ResponseEmitter.php
+++ b/src/http-server/src/ResponseEmitter.php
@@ -33,6 +33,9 @@ class ResponseEmitter implements ResponseEmitterInterface
             if (strtolower($connection->header['Upgrade'] ?? '') === 'websocket') {
                 return;
             }
+            if (strtolower($response->getHeaderLine('Content-Type') ?? '') === 'application/grpc' && method_exists($connection, 'isWritable') && ! $connection->isWritable()) {
+                return;
+            }
             $this->buildSwooleResponse($connection, $response);
             $content = $response->getBody();
             if ($content instanceof FileInterface) {


### PR DESCRIPTION
grpc-server端伪代码
```
class HiController implements SearchInterface
{
    public function sayHello(HiUser $user): HiReply
    {
       //  延迟响应
        sleep(30);
        return new HiReply(
            [
                'message' => 'Hyperf ' . $user->getName(),
            ]
        );
    }
}
```
grpc-server端超时导致grpc-client主动关闭连接，grpc-server 响应数据导致CRITICAL异常
```
[CRITICAL] ErrorException: Swoole\Http\Response::header(): http response is unavailable (maybe it has been ended or detached) in /usr/local/var/www/guandeng/php/services/grpc/vendor/hyperf/http-server/src/ResponseEmitter.php:61