### PR TITLE
Improve amqp, use methods instead of `$delivery_info` and optimize `BeforeConsume` event

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.42 - TBD
 
+## Optimized
+
+- [#6239](https://github.com/hyperf/hyperf/pull/6239) Improve amqp, use methods instead of `$delivery_info` and optimize `BeforeConsume` event.
+
 # v3.0.41 - 2023-10-27
 
 ## Added

--- a/src/amqp/src/Consumer.php
+++ b/src/amqp/src/Consumer.php
@@ -165,10 +165,11 @@ class Consumer extends Builder
     protected function getCallback(ConsumerMessageInterface $consumerMessage, AMQPMessage $message): callable
     {
         return function () use ($consumerMessage, $message) {
+            $channel = $message->getChannel();
+            $deliveryTag = $message->getDeliveryTag();
+
             try {
                 $data = $consumerMessage->unserialize($message->getBody());
-                $channel = $message->getChannel();
-                $deliveryTag = $message->getDeliveryTag();
 
                 $this->eventDispatcher?->dispatch(new BeforeConsume($consumerMessage));
                 $result = $consumerMessage->consumeMessage($data, $message);

--- a/src/amqp/src/Event/FailToConsume.php
+++ b/src/amqp/src/Event/FailToConsume.php
@@ -27,7 +27,7 @@ class FailToConsume extends ConsumeEvent
         return $this->throwable;
     }
 
-    public function getAmqpMessage(): AMQPMessage
+    public function getAMQPMessage(): AMQPMessage
     {
         return $this->amqpMessage;
     }

--- a/src/amqp/src/Event/FailToConsume.php
+++ b/src/amqp/src/Event/FailToConsume.php
@@ -12,11 +12,12 @@ declare(strict_types=1);
 namespace Hyperf\Amqp\Event;
 
 use Hyperf\Amqp\Message\ConsumerMessageInterface;
+use PhpAmqpLib\Message\AMQPMessage;
 use Throwable;
 
 class FailToConsume extends ConsumeEvent
 {
-    public function __construct(ConsumerMessageInterface $message, protected Throwable $throwable)
+    public function __construct(ConsumerMessageInterface $message, protected Throwable $throwable, protected AMQPMessage $amqpMessage)
     {
         parent::__construct($message);
     }
@@ -24,5 +25,10 @@ class FailToConsume extends ConsumeEvent
     public function getThrowable(): Throwable
     {
         return $this->throwable;
+    }
+
+    public function getAmqpMessage(): AMQPMessage
+    {
+        return $this->amqpMessage;
     }
 }

--- a/src/amqp/src/Message/ConsumerMessage.php
+++ b/src/amqp/src/Message/ConsumerMessage.php
@@ -15,7 +15,6 @@ use Hyperf\Amqp\Builder\QueueBuilder;
 use Hyperf\Amqp\Packer\Packer;
 use Hyperf\Amqp\Result;
 use Hyperf\Context\ApplicationContext;
-use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Psr\Container\ContainerInterface;
 
@@ -151,8 +150,7 @@ abstract class ConsumerMessage extends Message implements ConsumerMessageInterfa
     {
         $packer = ApplicationContext::getContainer()->get(Packer::class);
 
-        /** @var AMQPChannel $channel */
-        $channel = $message->delivery_info['channel'];
+        $channel = $message->getChannel();
         $channel->basic_publish(
             new AMQPMessage($packer->pack($data), [
                 'correlation_id' => $message->get('correlation_id'),


### PR DESCRIPTION
- `AMQPMessage::$delivery_info` 在 [v2.12.0](https://github.com/php-amqplib/php-amqplib/pull/799) 版本已经标记为废弃了，`hyperf/amqp` 要求 `"php-amqplib/php-amqplib": "^3.5"`
- 今天遇到 `$data = $consumerMessage->unserialize($message->getBody());` 这里抛异常，导致了自定义进程退出