### PR TITLE
Added BeforeConsumeHandle for amqp

### DIFF
--- a/src/amqp/src/ConsumerManager.php
+++ b/src/amqp/src/ConsumerManager.php
@@ -17,6 +17,7 @@ use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Process\AbstractProcess;
 use Hyperf\Process\ProcessManager;
 use Psr\Container\ContainerInterface;
+use Hyperf\Amqp\Event\BeforeConsumeHandle;
 
 use function Hyperf\Support\make;
 
@@ -75,6 +76,7 @@ class ConsumerManager
 
             public function handle(): void
             {
+                $this->event?->dispatch(new BeforeConsumeHandle($this->consumerMessage));
                 $this->consumer->consume($this->consumerMessage);
             }
 

--- a/src/amqp/src/Event/BeforeConsumeHandle.php
+++ b/src/amqp/src/Event/BeforeConsumeHandle.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Amqp\Event;
+
+class BeforeConsumeHandle extends ConsumeEvent
+{
+}


### PR DESCRIPTION
消费者进程启动后，因为消费开始前需要初始化一些数据，所以要依赖BeforeConsumeHandle事件。