### PR TITLE
Optimized the code about `Arr::flatten`, which is faster than before.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -10,6 +10,10 @@
 - [#6284](https://github.com/hyperf/hyperf/pull/6284) Fixed bug that the crontab cannot be closed when throw exceptions.
 - [#6291](https://github.com/hyperf/hyperf/pull/6291) Fixed that the crontab timer cannot be stopped sometimes.
 
+## Optimized
+
+- [#6293](https://github.com/hyperf/hyperf/pull/6293) Optimized the code about `Arr::flatten`, which is faster than before.
+
 # v3.0.43 - 2023-11-10
 
 ## Added

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -166,10 +166,14 @@ class Arr
             $item = $item instanceof Collection ? $item->all() : $item;
             if (! is_array($item)) {
                 $result[] = $item;
-            } elseif ($depth === 1) {
-                $result = array_merge($result, array_values($item));
             } else {
-                $result = array_merge($result, static::flatten($item, $depth - 1));
+                $values = $depth === 1
+                    ? array_values($item)
+                    : static::flatten($item, $depth - 1);
+
+                foreach ($values as $value) {
+                    $result[] = $value;
+                }
             }
         }
         return $result;


### PR DESCRIPTION
## Benchmark
大概200倍的提升

```php
$source = [];
$exampleItem = ['a','b','c','d','e','f','g','h']; // 8
for ($i=0; $i<5000; $i++){
    $source[] = $exampleItem;
}
$start = microtime(true);
\Hyperf\Collection\collect($source)->flatten();
var_dump('cost: ' . microtime(true) - $start); // original: 0.21s, now: 0.001s
```