### PR TITLE
Fixed bug that the jaeger cannot show the http code when using `tracer`.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # v3.0.46 - TBD
 
+## Fixed
+
+- [#6321](https://github.com/hyperf/hyperf/pull/6321) Fixed bug that the jaeger cannot show the http code when using `tracer`.
+
 # v3.0.45 - 2023-11-24
 
 ## Added

--- a/src/tracer/src/Aspect/HttpClientAspect.php
+++ b/src/tracer/src/Aspect/HttpClientAspect.php
@@ -77,7 +77,7 @@ class HttpClientAspect extends AbstractAspect
         try {
             $result = $proceedingJoinPoint->process();
             if ($result instanceof ResponseInterface) {
-                $span->setTag($this->spanTagManager->get('http_client', 'http.status_code'), $result->getStatusCode());
+                $span->setTag($this->spanTagManager->get('http_client', 'http.status_code'), (string) $result->getStatusCode());
             }
         } catch (Throwable $e) {
             if ($this->switchManager->isEnable('exception') && ! $this->switchManager->isIgnoreException($e)) {

--- a/src/tracer/src/Listener/RequestTraceListener.php
+++ b/src/tracer/src/Listener/RequestTraceListener.php
@@ -75,7 +75,7 @@ class RequestTraceListener implements ListenerInterface
 
         $tracer = TracerContext::getTracer();
         $span = TracerContext::getRoot();
-        $span->setTag($this->spanTagManager->get('response', 'status_code'), $response->getStatusCode());
+        $span->setTag($this->spanTagManager->get('response', 'status_code'), (string) $response->getStatusCode());
 
         if ($event->exception && $this->switchManager->isEnable('exception') && ! $this->switchManager->isIgnoreException($event->exception)) {
             $this->appendExceptionToSpan($span, $exception = $event->exception);
@@ -93,7 +93,7 @@ class RequestTraceListener implements ListenerInterface
     {
         $span->setTag('error', true);
         $span->setTag($this->spanTagManager->get('exception', 'class'), get_class($exception));
-        $span->setTag($this->spanTagManager->get('exception', 'code'), $exception->getCode());
+        $span->setTag($this->spanTagManager->get('exception', 'code'), (string) $exception->getCode());
         $span->setTag($this->spanTagManager->get('exception', 'message'), $exception->getMessage());
         $span->setTag($this->spanTagManager->get('exception', 'stack_trace'), (string) $exception);
     }

--- a/src/tracer/src/Middleware/TraceMiddleware.php
+++ b/src/tracer/src/Middleware/TraceMiddleware.php
@@ -56,13 +56,13 @@ class TraceMiddleware implements MiddlewareInterface
             if ($traceId = TracerContext::getTraceId()) {
                 $response = $response->withHeader('Trace-Id', $traceId);
             }
-            $span->setTag($this->spanTagManager->get('response', 'status_code'), $response->getStatusCode());
+            $span->setTag($this->spanTagManager->get('response', 'status_code'), (string) $response->getStatusCode());
         } catch (Throwable $exception) {
             if ($this->switchManager->isEnable('exception') && ! $this->switchManager->isIgnoreException($exception)) {
                 $this->appendExceptionToSpan($span, $exception);
             }
             if ($exception instanceof HttpException) {
-                $span->setTag($this->spanTagManager->get('response', 'status_code'), $exception->getStatusCode());
+                $span->setTag($this->spanTagManager->get('response', 'status_code'), (string) $exception->getStatusCode());
             }
             throw $exception;
         } finally {
@@ -76,7 +76,7 @@ class TraceMiddleware implements MiddlewareInterface
     {
         $span->setTag('error', true);
         $span->setTag($this->spanTagManager->get('exception', 'class'), get_class($exception));
-        $span->setTag($this->spanTagManager->get('exception', 'code'), $exception->getCode());
+        $span->setTag($this->spanTagManager->get('exception', 'code'), (string) $exception->getCode());
         $span->setTag($this->spanTagManager->get('exception', 'message'), $exception->getMessage());
         $span->setTag($this->spanTagManager->get('exception', 'stack_trace'), (string) $exception);
     }


### PR DESCRIPTION
close #6323