### PR TITLE
Fixed bug that the recv channel cannot be found, because `GrpcClient::runReceiveCoroutine` will unset streamId before recv method.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,7 +4,7 @@
 
 - [#6347](https://github.com/hyperf/hyperf/pull/6347) Fixed bug that the view function may add redundant content-type to header.
 - [#6352](https://github.com/hyperf/hyperf/pull/6352) Fixed bug that nacos config center cannot work when using grpc protocol.
-- [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug when runReceiveCoroutine unset streamId before recv method.
+- [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug that the recv channel cannot be found, because `runReceiveCoroutine` will unset streamId before recv method.
 
 ## Added
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - [#6347](https://github.com/hyperf/hyperf/pull/6347) Fixed bug that the view function may add redundant content-type to header.
 - [#6352](https://github.com/hyperf/hyperf/pull/6352) Fixed bug that nacos config center cannot work when using grpc protocol.
+- [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug when runReceiveCoroutine unset streamId before recv method.
 
 ## Added
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,7 +4,7 @@
 
 - [#6347](https://github.com/hyperf/hyperf/pull/6347) Fixed bug that the view function may add redundant content-type to header.
 - [#6352](https://github.com/hyperf/hyperf/pull/6352) Fixed bug that nacos config center cannot work when using grpc protocol.
-- [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug that the recv channel cannot be found, because `runReceiveCoroutine` will unset streamId before recv method.
+- [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug that the recv channel cannot be found, because `GrpcClient::runReceiveCoroutine` will unset streamId before recv method.
 
 ## Added
 


### PR DESCRIPTION
模拟一个场景hyperf/grpc-client/src/BaseClient.php
```
$streamId = retry($this->options['retry_attempts'] ?? 3, function () use ($method, $argument, $options) {
            $streamId = $this->send($this->buildRequest($method, $argument, $options));
            if ($streamId <= 0) {
                $this->init();
                // The client should not be used after this exception
                throw new GrpcClientException('Failed to send the request to server', StatusCode::INTERNAL);
            }
            return $streamId;
        }, $this->options['retry_interval'] ?? 100);
        // 模拟 runReceiveCoroutine先于recv unset $streamId
        sleep(1);
        return Parser::parseResponse($this->recv($streamId), $deserialize);
    }
```