### PR TITLE
Fixed bug that Entry `Hyperf\SocketIOServer\Emitter\Future` cannot be resolved: Parameter $opcode of __construct() has no value defined or guessable.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -5,6 +5,7 @@
 - [#6347](https://github.com/hyperf/hyperf/pull/6347) Fixed bug that the view function may add redundant content-type to header.
 - [#6352](https://github.com/hyperf/hyperf/pull/6352) Fixed bug that nacos config center cannot work when using grpc protocol.
 - [#6350](https://github.com/hyperf/hyperf/pull/6350) Fixed bug that the recv channel cannot be found, because `GrpcClient::runReceiveCoroutine` will unset streamId before recv method.
+- [#6361](https://github.com/hyperf/hyperf/pull/6361) Fixed bug that `Hyperf\SocketIOServer\Emitter\Future` cannot be resolved.
 
 ## Added
 

--- a/src/socketio-server/src/Emitter/Future.php
+++ b/src/socketio-server/src/Emitter/Future.php
@@ -35,8 +35,6 @@ class Future
         private string $event,
         private array $data,
         callable $encode,
-        private int $opcode,
-        private int $flag,
         private ?FrameInterface $frame = null
     ) {
         $this->id = '';
@@ -72,10 +70,6 @@ class Future
         }
         $message = ($this->encode)($this->id, $this->event, $this->data);
         $this->sent = true;
-        if ($this->frame) {
-            $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
-        } else {
-            $this->sender->pushFrame($this->fd, new Frame(opcode: $this->opcode, payloadData: $message));
-        }
+        $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
     }
 }

--- a/src/socketio-server/src/Emitter/Future.php
+++ b/src/socketio-server/src/Emitter/Future.php
@@ -29,6 +29,9 @@ class Future
 
     private bool $sent;
 
+    /**
+     * @param int $flag deprecated it will be removed in v3.2 or v4.0
+     */
     public function __construct(
         private SocketIO $socketIO,
         private Sender $sender,

--- a/src/socketio-server/src/Emitter/Future.php
+++ b/src/socketio-server/src/Emitter/Future.php
@@ -14,6 +14,7 @@ namespace Hyperf\SocketIOServer\Emitter;
 use Hyperf\Engine\Channel;
 use Hyperf\Engine\Contract\WebSocket\FrameInterface;
 use Hyperf\Engine\WebSocket\Frame;
+use Hyperf\Engine\WebSocket\Opcode;
 use Hyperf\SocketIOServer\SocketIO;
 use Hyperf\WebSocketServer\Sender;
 
@@ -35,6 +36,8 @@ class Future
         private string $event,
         private array $data,
         callable $encode,
+        private int $opcode = Opcode::TEXT,
+        private int $flag = 0,
         private ?FrameInterface $frame = null
     ) {
         $this->id = '';
@@ -70,6 +73,10 @@ class Future
         }
         $message = ($this->encode)($this->id, $this->event, $this->data);
         $this->sent = true;
-        $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
+        if ($this->frame) {
+            $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
+        } else {
+            $this->sender->pushFrame($this->fd, new Frame(opcode: $this->opcode, payloadData: $message));
+        }
     }
 }


### PR DESCRIPTION
Fixed bug that Entry `Hyperf\SocketIOServer\Emitter\Future` cannot be resolved: Parameter $opcode of __construct() has no value defined or guessable.
<img width="1557" alt="image" src="https://github.com/hyperf/hyperf/assets/110524397/95582de0-bc9e-45f9-90a6-d710f8567914">
