### PR TITLE
Fixed bug that `Hyperf\RateLimit\Aspect\RateLimitAnnotationAspect::getWeightingAnnotation()` cannot work.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,7 +3,7 @@
 ## Fixed
 
 - [#6372](https://github.com/hyperf/hyperf/pull/6372) Fixed bug that AOP not working when using variadic parameters.
-- [#6374](https://github.com/hyperf/hyperf/pull/6374) Fixed bug that `Hyperf\RateLimit\Aspect\RateLimitAnnotationAspect::getWeightingAnnotation()` cannot work.
+- [#6374](https://github.com/hyperf/hyperf/pull/6374) Fixed bug that `RateLimitAnnotationAspect::getWeightingAnnotation()` cannot work when using config `rate_limit.storage`.
 
 ## Added
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#6372](https://github.com/hyperf/hyperf/pull/6372) Fixed bug that AOP not working when using variadic parameters.
+- [#6374](https://github.com/hyperf/hyperf/pull/6374) Fixed bug that `Hyperf\RateLimit\Aspect\RateLimitAnnotationAspect::getWeightingAnnotation()` cannot work.
 
 ## Added
 

--- a/src/rate-limit/src/Aspect/RateLimitAnnotationAspect.php
+++ b/src/rate-limit/src/Aspect/RateLimitAnnotationAspect.php
@@ -86,9 +86,13 @@ class RateLimitAnnotationAspect implements AroundInterface
      */
     public function getWeightingAnnotation(array $annotations): RateLimit
     {
-        $property = array_merge($this->annotationProperty, array_filter($this->config, function ($key) {
-            return in_array($key, array_keys($this->annotationProperty));
-        }, ARRAY_FILTER_USE_KEY));
+        $property = $this->annotationProperty;
+        foreach ($this->annotationProperty as $key => $value) {
+            if (! empty($this->config[$key])) {
+                $property[$key] = $this->config[$key];
+            }
+        }
+
         /** @var null|RateLimit $annotation */
         foreach ($annotations as $annotation) {
             if (! $annotation) {

--- a/src/rate-limit/src/Aspect/RateLimitAnnotationAspect.php
+++ b/src/rate-limit/src/Aspect/RateLimitAnnotationAspect.php
@@ -86,7 +86,9 @@ class RateLimitAnnotationAspect implements AroundInterface
      */
     public function getWeightingAnnotation(array $annotations): RateLimit
     {
-        $property = array_merge($this->annotationProperty, $this->config);
+        $property = array_merge($this->annotationProperty, array_filter($this->config, function ($key) {
+            return in_array($key, array_keys($this->annotationProperty));
+        }, ARRAY_FILTER_USE_KEY));
         /** @var null|RateLimit $annotation */
         foreach ($annotations as $annotation) {
             if (! $annotation) {


### PR DESCRIPTION
fix #6370 
配置信息：
<img width="720" alt="image" src="https://github.com/hyperf/hyperf/assets/110524397/f2c96f25-14e7-46fe-b9ca-ac62c33801df">

错误信息：
<img width="731" alt="image" src="https://github.com/hyperf/hyperf/assets/110524397/1fe664f3-8430-4d42-b939-46cfd3d663d3">

