### PR TITLE
fix(HasAttributes) no cast when use expressions

### DIFF
--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -26,6 +26,7 @@ use Hyperf\Database\Exception\InvalidCastException;
 use Hyperf\Database\Model\EnumCollector;
 use Hyperf\Database\Model\JsonEncodingException;
 use Hyperf\Database\Model\Relations\Relation;
+use Hyperf\Database\Query\Expression;
 use Hyperf\Stringable\Str;
 use Hyperf\Stringable\StrCache;
 use LogicException;
@@ -887,6 +888,10 @@ trait HasAttributes
      */
     protected function castAttribute(string $key, mixed $value): mixed
     {
+        if ($value instanceof Expression) {
+            return $value;
+        }
+
         $castType = $this->getCastType($key);
 
         if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {


### PR DESCRIPTION
When the "ct" attribute of the Foo model is set to cast.
```php
class Foo extends Model
{
    protected array $casts = ['id' => 'integer', 'ct' => 'integer'];
}
```
In the updateOrCreate method, an Expression expression is used.
```php
Foo::updateOrCreate(['id' => 1], ['ct' => Db::raw('ct + 1')]);
``` 
The following warning will be issued
```
 WARNING  Object of class Hyperf\Database\Query\Expression could not be converted to int in vendor/hyperf/database/src/Model/Concerns/HasAttributes.php on line 883
```