### PR TITLE
feat:add scene feature to Validator

### DIFF
--- a/src/contract/src/ValidatorInterface.php
+++ b/src/contract/src/ValidatorInterface.php
@@ -56,8 +56,7 @@ interface ValidatorInterface extends MessageProvider
     public function errors(): MessageBag;
 
     /**
-     * Set scene of the validation
-     * @param array $scene
+     * Set scene of the validation.
      * @return $this
      */
     public function scene(array $scene): static;

--- a/src/contract/src/ValidatorInterface.php
+++ b/src/contract/src/ValidatorInterface.php
@@ -54,4 +54,11 @@ interface ValidatorInterface extends MessageProvider
      * Get all of the validation error messages.
      */
     public function errors(): MessageBag;
+
+    /**
+     * Set scene of the validation
+     * @param array $scene
+     * @return $this
+     */
+    public function scene(array $scene): static;
 }

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -61,9 +61,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * get the scene config from the request config
-     * @param string|null $config
-     * @return array
+     * get the scene config from the request config.
      */
     public function getSceneConfig(string $config = null): array
     {

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -61,6 +61,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * get the scene config from the request config
+     * @return array
+     */
+    public function getSceneConfig(): array
+    {
+        return $this->scenes;
+    }
+
+    /**
      * Get the proper failed validation response for the request.
      */
     public function response(): ResponseInterface

--- a/src/validation/src/Request/FormRequest.php
+++ b/src/validation/src/Request/FormRequest.php
@@ -62,11 +62,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
     /**
      * get the scene config from the request config
+     * @param string|null $config
      * @return array
      */
-    public function getSceneConfig(): array
+    public function getSceneConfig(string $config = null): array
     {
-        return $this->scenes;
+        if (empty($config)) {
+            return $this->scenes;
+        }
+        return $this->scenes[$config];
     }
 
     /**

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -1038,7 +1038,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * getContextValidatorKey.
+     * Get a validatorKey for context.
      */
     protected function getContextValidatorKey(string $key): string
     {

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -725,6 +725,24 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Set scene array | The Current SceneConfig collected from FormRequest::getSceneConfig.
+     * @return $this
+     */
+    public function scene(array $scene): static
+    {
+        Context::set($this->getContextValidatorKey('scene'), $scene);
+        return $this;
+    }
+
+    /**
+     * Get scene array.
+     */
+    public function getScene(): ?array
+    {
+        return Context::get($this->getContextValidatorKey('scene'));
+    }
+
+    /**
      * Validate a given attribute against a rule.
      *
      * @param object|string $rule
@@ -1020,29 +1038,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Set scene array | The Current SceneConfig collected from FormRequest::getSceneConfig
-     * @param array $scene
-     * @return $this
-     */
-    public function scene(array $scene): static
-    {
-        Context::set($this->getContextValidatorKey('scene'), $scene);
-        return $this;
-    }
-
-    /**
-     * Get scene array
-     * @return array|null
-     */
-    public function getScene(): ?array
-    {
-        return Context::get($this->getContextValidatorKey('scene'));
-    }
-
-    /**
-     * getContextValidatorKey
-     * @param string $key
-     * @return string
+     * getContextValidatorKey.
      */
     protected function getContextValidatorKey(string $key): string
     {


### PR DESCRIPTION
在需要切换场景而且使用的是ValidateFactory时,获取request的scenes数据可以用getSceneConfig获取配置，
比如规则文件上伪代码写的
```
class SceneRequest extends FormRequest
 { 
       protected array $scenes = [
                     'foo' => ['username'],
                     'bar' => ['username', 'password'], 
        ];
```

这时候可以获取对应场景的字段数组,然后调用的时候进行validator->scene(SceneRequest::getSceneConfig('foo'))