### PR TITLE
Added: Test Interacts With Database

### DIFF
--- a/src/testing/src/Concerns/InteractsWithDatabase.php
+++ b/src/testing/src/Concerns/InteractsWithDatabase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Testing\Concerns;
+
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\ConnectionResolverInterface;
+use Hyperf\Testing\Constraint\HasInDatabase;
+use PHPUnit\Framework\Constraint\LogicalNot;
+
+trait InteractsWithDatabase
+{
+    private function assertDatabaseHas(string $table, array $data, ?string $connection = null): void
+    {
+        $this->assertThat($data, new HasInDatabase($this->getConnection($connection), $table));
+    }
+
+    private function assertDatabaseMissing(string $table, array $data, ?string $connection = null): void
+    {
+        $this->assertThat($data, new LogicalNot(new HasInDatabase($this->getConnection($connection), $table)));
+    }
+
+    private function getConnection(?string $name): ConnectionInterface
+    {
+        return ApplicationContext::getContainer()->get(ConnectionResolverInterface::class)->connection($name);
+    }
+}

--- a/src/testing/src/Constraint/HasInDatabase.php
+++ b/src/testing/src/Constraint/HasInDatabase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace Hyperf\Testing\Constraint;
+
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\Query\Builder;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class HasInDatabase extends Constraint
+{
+    protected ConnectionInterface $connection;
+
+    protected string $table;
+
+    public function __construct(ConnectionInterface $connection, string $table)
+    {
+        $this->table = $table;
+        $this->connection = $connection;
+    }
+
+    public function matches($data): bool
+    {
+        return $this->query($data)->count() > 0;
+    }
+
+    public function failureDescription($data): string
+    {
+        return sprintf(
+            'a row in the table [%s] matches the attributes %s',
+            $this->table,
+            json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+        );
+    }
+
+    public function toString(): string
+    {
+        return sprintf('There is a record of table %s with the specified data', $this->table);
+    }
+
+    private function query(array $data): Builder
+    {
+        /** @var Builder $query */
+        $query = $this->connection->table($this->table);
+
+        foreach ($data as $index => $value) {
+            if (is_array($value)) {
+                [$column, $operator, $expected] = $value;
+                $query->where($column, $operator, $expected);
+                continue;
+            }
+
+            $query->where($index, $value);
+        }
+
+        return $query;
+    }
+}

--- a/src/testing/src/TestCase.php
+++ b/src/testing/src/TestCase.php
@@ -27,6 +27,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     use Concerns\InteractsWithModelFactory;
     use Concerns\MakesHttpRequests;
     use Concerns\RunTestsInCoroutine;
+    use Concerns\InteractsWithDatabase;
 
     /**
      * The callbacks that should be run after the application is created.


### PR DESCRIPTION
Implements assertions to check data in the database (`assertDatabaseHas` and `assertDatabaseMissing`).

Examples:
```php
$this->assertDatabaseHas('users', ['id' => $userId, 'nickname' => 'John']);
$this->assertDatabaseMissing('users', ['id' => $userId, 'nickname' => 'John']);
```

You can also specify other comparison operators:
```php
// Selects a user's orders that have a defined score
$this->assertDatabaseHas('orders', ['user_id' => $user_id, ['score', '<>', null]]);
```