### PR TITLE
Added `template_suffix` configuration to `twig` engine.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,6 +7,7 @@
 ## Added
 
 - [#6398](https://github.com/hyperf/hyperf/pull/6398) Added `timezone` parameter to `hyperf/crontab` component.
+- [#6402](https://github.com/hyperf/hyperf/pull/6402) Add `template_suffix` configuration to `twig` engine.
 
 # v3.1.2 - 2023-12-15
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,7 +7,7 @@
 ## Added
 
 - [#6398](https://github.com/hyperf/hyperf/pull/6398) Added `timezone` parameter to `hyperf/crontab` component.
-- [#6402](https://github.com/hyperf/hyperf/pull/6402) Add `template_suffix` configuration to `twig` engine.
+- [#6402](https://github.com/hyperf/hyperf/pull/6402) Added `template_suffix` configuration to `twig` engine.
 
 # v3.1.2 - 2023-12-15
 

--- a/src/view/src/Engine/TwigEngine.php
+++ b/src/view/src/Engine/TwigEngine.php
@@ -21,6 +21,10 @@ class TwigEngine implements EngineInterface
         $loader = new FilesystemLoader($config['view_path']);
         $twig = new Environment($loader, ['cache' => $config['cache_path']]);
 
+        if($suffix = $config['template_suffix'] ?? '') {
+            $template .= $suffix;
+        }
+
         return $twig->render($template, $data);
     }
 }

--- a/src/view/src/Engine/TwigEngine.php
+++ b/src/view/src/Engine/TwigEngine.php
@@ -21,7 +21,7 @@ class TwigEngine implements EngineInterface
         $loader = new FilesystemLoader($config['view_path']);
         $twig = new Environment($loader, ['cache' => $config['cache_path']]);
 
-        if($suffix = $config['template_suffix'] ?? '') {
+        if ($suffix = $config['template_suffix'] ?? '') {
             $template .= $suffix;
         }
 

--- a/src/view/tests/TwigTest.php
+++ b/src/view/tests/TwigTest.php
@@ -43,4 +43,27 @@ Hello, Hyperf. You are using twig template now.
 </body>
 </html>', $res);
     }
+
+    public function testConfig()
+    {
+        $config = [
+            'view_path' => __DIR__ . '/tpl',
+            'cache_path' => __DIR__ . '/runtime',
+            'template_suffix' => '.twig',
+        ];
+
+        $engine = new TwigEngine();
+        $res = $engine->render('index', ['name' => 'Hyperf'], $config);
+
+        $this->assertEquals('<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hyperf</title>
+</head>
+<body>
+Hello, Hyperf. You are using twig template now.
+</body>
+</html>', $res);
+    }
 }


### PR DESCRIPTION
在view.php->config->添加template_suffix参数设置twig全局模板文件扩展名，以解决每次render的时候需要添加模板扩展名