### PR TITLE
Fixed bug that `Hyperf\Scout\Searchable` don't import namespace of function `config`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#6389](https://github.com/hyperf/hyperf/pull/6389) Fixed bug that es version cannot be found when the index is null.
+- [#6406](https://github.com/hyperf/hyperf/pull/6406) Fixed bug that `Hyperf\Scout\Searchable` don't import namespace of function `config`.
 
 ## Added
 

--- a/src/scout/src/Searchable.php
+++ b/src/scout/src/Searchable.php
@@ -21,6 +21,7 @@ use Hyperf\Database\Model\SoftDeletes;
 use Hyperf\ModelListener\Collector\ListenerCollector;
 use Hyperf\Scout\Engine\Engine;
 
+use function Hyperf\Config\config;
 use function Hyperf\Support\class_uses_recursive;
 use function Hyperf\Support\make;
 


### PR DESCRIPTION
The hyperf/scout-v3.1 doesn't import namespaces of the config function.