### PR TITLE
Fixed bug that `prepareHandler` cannot work sometimes for `circuit-breaker`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.4 - TBD
 
+## Fixed
+
+- [#6419](https://github.com/hyperf/hyperf/pull/6419) Fixed bug that `prepareHandler` cannot work sometimes for `circuit-breaker`.
+
 ## Optimized
 
 - [#6415](https://github.com/hyperf/hyperf/pull/6415) Throw `InvalidArgumentException` instead of `TypeError` for decoding an empty string when using `Base62::decode`.

--- a/src/circuit-breaker/src/Handler/AbstractHandler.php
+++ b/src/circuit-breaker/src/Handler/AbstractHandler.php
@@ -192,13 +192,13 @@ abstract class AbstractHandler implements HandlerInterface
     {
         if (is_string($fallback)) {
             $fallback = explode('::', $fallback);
-            if (! isset($fallback[1]) && is_callable([$proceedingJoinPoint->className, $fallback[0]])) {
+            if (! isset($fallback[1]) && method_exists($proceedingJoinPoint->className, $fallback[0])) {
                 return [$proceedingJoinPoint->className, $fallback[0]];
             }
             $fallback[1] ??= 'fallback';
         }
 
-        if (is_array($fallback) && is_callable($fallback)) {
+        if (is_array($fallback) && count($fallback) === 2) {
             return $fallback;
         }
 


### PR DESCRIPTION
![image](https://github.com/hyperf/hyperf/assets/17758819/b1081835-568f-4edd-913f-094746cc32a3)
