### PR TITLE
修复 http server query 解析不正确的问题

### DIFF
--- a/src/http-message/src/Server/Request.php
+++ b/src/http-message/src/Server/Request.php
@@ -58,6 +58,7 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
     public static function loadFromSwooleRequest(Swoole\Http\Request $swooleRequest)
     {
         $queryString = $swooleRequest->server['query_string'] ?? '';
+        $queryParams = [];
         parse_str(urldecode($queryString), $queryParams);
         $server = $swooleRequest->server;
         $method = $server['request_method'] ?? 'GET';

--- a/src/http-message/src/Server/Request.php
+++ b/src/http-message/src/Server/Request.php
@@ -57,6 +57,8 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
      */
     public static function loadFromSwooleRequest(Swoole\Http\Request $swooleRequest)
     {
+        $queryString = $swooleRequest->server['query_string'] ?? '';
+        parse_str(urldecode($queryString), $queryParams);
         $server = $swooleRequest->server;
         $method = $server['request_method'] ?? 'GET';
         $headers = $swooleRequest->header ?? [];
@@ -65,7 +67,7 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
         $protocol = isset($server['server_protocol']) ? str_replace('HTTP/', '', $server['server_protocol']) : '1.1';
         $request = new Request($method, $uri, $headers, $body, $protocol);
         $request->cookieParams = ($swooleRequest->cookie ?? []);
-        $request->queryParams = ($swooleRequest->get ?? []);
+        $request->queryParams = ($queryParams ?? []);
         $request->serverParams = ($server ?? []);
         $request->parsedBody = self::normalizeParsedBody($swooleRequest->post ?? [], $request);
         $request->uploadedFiles = self::normalizeFiles($swooleRequest->files ?? []);


### PR DESCRIPTION
bug 复现场景：

GET  http://127.0.0.1:9501/xxxx/xxx?modules%5B%5D%3Dxxxx%26modules%5B%5D%3D3Dxxxxxx

遇到上面这种请求则会无法正确解析 query 内的参数