### PR TITLE
Translate comments to English

### DIFF
--- a/docs/en/db/model.md
+++ b/docs/en/db/model.md
@@ -42,7 +42,7 @@ use Hyperf\Database\Commands\ModelOption;
 
 return [
     'default' => [
-        // 忽略其他配置
+        // Ignore other configurations.
         'commands' => [
             'gen:model' => [
                 'path' => 'app/Model',


### PR DESCRIPTION
The original comments in the code were in Chinese, and I noticed an opportunity to improve the code's accessibility by translating them into English. This change aims to make the code more understandable for developers who may not be familiar with the Chinese language.