### PR TITLE
Added cron support for closure-command

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - [#6483](https://github.com/hyperf/hyperf/pull/6483) [#6487] (https://github.com/hyperf/hyperf/pull/6487) Added new ways to register crontab.
 - [#6488](https://github.com/hyperf/hyperf/pull/6488) Added the default implement for `Psr\Log\LoggerInterface`.
+- [#6495](https://github.com/hyperf/hyperf/pull/6495) Added cron support for closure-command.
 
 ## Optimized
 

--- a/src/command/src/ClosureCommand.php
+++ b/src/command/src/ClosureCommand.php
@@ -16,11 +16,60 @@ use Hyperf\Crontab\Crontab;
 use Hyperf\Crontab\Schedule;
 use Psr\Container\ContainerInterface;
 
-use function Hyperf\Tappable\tap;
-
+/**
+ * @method Crontab cron(string $expression)
+ * @method Crontab everySecond()
+ * @method Crontab everyTwoSeconds()
+ * @method Crontab everyFiveSeconds()
+ * @method Crontab everyTenSeconds()
+ * @method Crontab everyFifteenSeconds()
+ * @method Crontab everyTwentySeconds()
+ * @method Crontab everyThirtySeconds()
+ * @method Crontab everyMinute()
+ * @method Crontab everyTwoMinutes()
+ * @method Crontab everyThreeMinutes()
+ * @method Crontab everyFourMinutes()
+ * @method Crontab everyFiveMinutes()
+ * @method Crontab everyTenMinutes()
+ * @method Crontab everyFifteenMinutes()
+ * @method Crontab everyThirtyMinutes()
+ * @method Crontab hourly()
+ * @method Crontab hourlyAt($offset)
+ * @method Crontab everyOddHour($offset = 0)
+ * @method Crontab everyTwoHours($offset = 0)
+ * @method Crontab everyThreeHours($offset = 0)
+ * @method Crontab everyFourHours($offset = 0)
+ * @method Crontab everySixHours($offset = 0)
+ * @method Crontab daily()
+ * @method Crontab at(string $time)
+ * @method Crontab dailyAt(string $time)
+ * @method Crontab twiceDaily(int $first = 1, int $second = 13)
+ * @method Crontab twiceDailyAt(int $first = 1, int $second = 13, int $offset = 0)
+ * @method Crontab weekdays()
+ * @method Crontab weekends()
+ * @method Crontab mondays()
+ * @method Crontab tuesdays()
+ * @method Crontab wednesdays()
+ * @method Crontab thursdays()
+ * @method Crontab fridays()
+ * @method Crontab saturdays()
+ * @method Crontab sundays()
+ * @method Crontab weekly()
+ * @method Crontab weeklyOn($dayOfWeek, string $time = '0:0')
+ * @method Crontab monthly()
+ * @method Crontab monthlyOn(int $dayOfMonth = 1, string $time = '0:0')
+ * @method Crontab twiceMonthly(int $first = 1, int $second = 16, string $time = '0:0')
+ * @method Crontab lastDayOfMonth(string $time = '0:0')
+ * @method Crontab quarterly()
+ * @method Crontab yearly()
+ * @method Crontab yearlyOn(int $month = 1, int|string $dayOfMonth = 1, string $time = '0:0')
+ * @method Crontab days($days)
+ */
 final class ClosureCommand extends Command
 {
     private ParameterParser $parameterParser;
+
+    private ?Crontab $crontab = null;
 
     public function __construct(
         private ContainerInterface $container,
@@ -31,6 +80,15 @@ final class ClosureCommand extends Command
         $this->parameterParser = $container->get(ParameterParser::class);
 
         parent::__construct();
+    }
+
+    public function __call($name, $arguments)
+    {
+        $this->crontab ??= Schedule::command($this->getName())
+            ->setName($this->getName())
+            ->setMemo($this->getDescription());
+
+        return $this->crontab->{$name}(...$arguments);
     }
 
     public function handle()
@@ -44,22 +102,6 @@ final class ClosureCommand extends Command
     public function describe(string $description): self
     {
         $this->setDescription($description);
-
-        return $this;
-    }
-
-    /**
-     * @param callable(Crontab $crontab):Crontab|null $callback
-     */
-    public function cron(string $rule, array $arguments = [], ?callable $callback = null): self
-    {
-        tap(
-            Schedule::command($this->getName(), $arguments)
-                ->setName($this->getName())
-                ->setRule($rule)
-                ->setMemo($this->getDescription()),
-            $callback
-        );
 
         return $this;
     }

--- a/src/command/src/ClosureCommand.php
+++ b/src/command/src/ClosureCommand.php
@@ -16,6 +16,8 @@ use Hyperf\Crontab\Crontab;
 use Hyperf\Crontab\Schedule;
 use Psr\Container\ContainerInterface;
 
+use function Hyperf\Tappable\tap;
+
 final class ClosureCommand extends Command
 {
     private ParameterParser $parameterParser;

--- a/src/command/src/ClosureCommand.php
+++ b/src/command/src/ClosureCommand.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Hyperf\Command;
 
 use Closure;
+use Hyperf\Crontab\Crontab;
+use Hyperf\Crontab\Schedule;
 use Psr\Container\ContainerInterface;
 
 final class ClosureCommand extends Command
@@ -40,6 +42,22 @@ final class ClosureCommand extends Command
     public function describe(string $description): self
     {
         $this->setDescription($description);
+
+        return $this;
+    }
+
+    /**
+     * @param callable(Crontab $crontab):Crontab|null $callback
+     */
+    public function cron(string $rule, ?callable $callback = null): self
+    {
+        tap(
+            Schedule::command($this->getName())
+                ->setName($this->getName())
+                ->setRule($rule)
+                ->setMemo($this->getDescription()),
+            $callback
+        );
 
         return $this;
     }

--- a/src/command/src/ClosureCommand.php
+++ b/src/command/src/ClosureCommand.php
@@ -16,60 +16,11 @@ use Hyperf\Crontab\Crontab;
 use Hyperf\Crontab\Schedule;
 use Psr\Container\ContainerInterface;
 
-/**
- * @method Crontab cron(string $expression)
- * @method Crontab everySecond()
- * @method Crontab everyTwoSeconds()
- * @method Crontab everyFiveSeconds()
- * @method Crontab everyTenSeconds()
- * @method Crontab everyFifteenSeconds()
- * @method Crontab everyTwentySeconds()
- * @method Crontab everyThirtySeconds()
- * @method Crontab everyMinute()
- * @method Crontab everyTwoMinutes()
- * @method Crontab everyThreeMinutes()
- * @method Crontab everyFourMinutes()
- * @method Crontab everyFiveMinutes()
- * @method Crontab everyTenMinutes()
- * @method Crontab everyFifteenMinutes()
- * @method Crontab everyThirtyMinutes()
- * @method Crontab hourly()
- * @method Crontab hourlyAt($offset)
- * @method Crontab everyOddHour($offset = 0)
- * @method Crontab everyTwoHours($offset = 0)
- * @method Crontab everyThreeHours($offset = 0)
- * @method Crontab everyFourHours($offset = 0)
- * @method Crontab everySixHours($offset = 0)
- * @method Crontab daily()
- * @method Crontab at(string $time)
- * @method Crontab dailyAt(string $time)
- * @method Crontab twiceDaily(int $first = 1, int $second = 13)
- * @method Crontab twiceDailyAt(int $first = 1, int $second = 13, int $offset = 0)
- * @method Crontab weekdays()
- * @method Crontab weekends()
- * @method Crontab mondays()
- * @method Crontab tuesdays()
- * @method Crontab wednesdays()
- * @method Crontab thursdays()
- * @method Crontab fridays()
- * @method Crontab saturdays()
- * @method Crontab sundays()
- * @method Crontab weekly()
- * @method Crontab weeklyOn($dayOfWeek, string $time = '0:0')
- * @method Crontab monthly()
- * @method Crontab monthlyOn(int $dayOfMonth = 1, string $time = '0:0')
- * @method Crontab twiceMonthly(int $first = 1, int $second = 16, string $time = '0:0')
- * @method Crontab lastDayOfMonth(string $time = '0:0')
- * @method Crontab quarterly()
- * @method Crontab yearly()
- * @method Crontab yearlyOn(int $month = 1, int|string $dayOfMonth = 1, string $time = '0:0')
- * @method Crontab days($days)
- */
+use function Hyperf\Tappable\tap;
+
 final class ClosureCommand extends Command
 {
     private ParameterParser $parameterParser;
-
-    private ?Crontab $crontab = null;
 
     public function __construct(
         private ContainerInterface $container,
@@ -80,15 +31,6 @@ final class ClosureCommand extends Command
         $this->parameterParser = $container->get(ParameterParser::class);
 
         parent::__construct();
-    }
-
-    public function __call($name, $arguments)
-    {
-        $this->crontab ??= Schedule::command($this->getName())
-            ->setName($this->getName())
-            ->setMemo($this->getDescription());
-
-        return $this->crontab->{$name}(...$arguments);
     }
 
     public function handle()
@@ -102,6 +44,22 @@ final class ClosureCommand extends Command
     public function describe(string $description): self
     {
         $this->setDescription($description);
+
+        return $this;
+    }
+
+    /**
+     * @param callable(Crontab $crontab):Crontab|null $callback
+     */
+    public function cron(string $rule, array $arguments = [], ?callable $callback = null): self
+    {
+        tap(
+            Schedule::command($this->getName(), $arguments)
+                ->setName($this->getName())
+                ->setRule($rule)
+                ->setMemo($this->getDescription()),
+            $callback
+        );
 
         return $this;
     }

--- a/src/command/src/ClosureCommand.php
+++ b/src/command/src/ClosureCommand.php
@@ -51,10 +51,10 @@ final class ClosureCommand extends Command
     /**
      * @param callable(Crontab $crontab):Crontab|null $callback
      */
-    public function cron(string $rule, ?callable $callback = null): self
+    public function cron(string $rule, array $arguments = [], ?callable $callback = null): self
     {
         tap(
-            Schedule::command($this->getName())
+            Schedule::command($this->getName(), $arguments)
                 ->setName($this->getName())
                 ->setRule($rule)
                 ->setMemo($this->getDescription()),


### PR DESCRIPTION
Example:

```php
// config/console.php

use Hyperf\Command\Console;

Console::command('foo:bar', function(){
    // do something
})->cron('* * * * *');

Console::command('foo:baz', function(){
    // do something
})->cron('* * * * *', callback: fn($cron) => $cron->setSingleton(true));

Console::command('foo:bax {--id=0}', function($id=0){
    var_dump($id);
})->cron('* * * * *', arguments: ['id' => 1]);
```