### PR TITLE
Fixed bug that inconsistent parsing response in `Rpc-Multiplex` client.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#6491](https://github.com/hyperf/hyperf/pull/6491) Fixed bug that swagger validation collector cannot collect query parameters.
+- [#6500](https://github.com/hyperf/hyperf/pull/6500) Fixed bug that inconsistent parsing response in Rpc-Multiplex client.
 
 ## Added
 

--- a/src/rpc-multiplex/src/DataFormatter.php
+++ b/src/rpc-multiplex/src/DataFormatter.php
@@ -72,10 +72,10 @@ class DataFormatter implements DataFormatterInterface, DataFetcherInterface
 
     public function fetch(array $data): mixed
     {
-        if (array_key_exists(Constant::DATA, $data)) {
+        if (array_key_exists(Constant::RESULT, $data)) {
             $this->context->setData($data[Constant::CONTEXT] ?? []);
 
-            return $data[Constant::DATA];
+            return $data[Constant::RESULT];
         }
 
         if (array_key_exists(Constant::ERROR, $data)) {


### PR DESCRIPTION
修复 多路复用client fetch方法 判断问题