### PR TITLE
Fixed error when callable type is array

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.8 - TBD
 
+## Fixed
+
+- [#6509](https://github.com/hyperf/hyperf/pull/6509) Fix the bug that cannot give array type.
+
 ## Added
 
 - [#6504](https://github.com/hyperf/hyperf/pull/6504) Added `HostReaderInterface` for `rpc-multiplex`.

--- a/src/crontab/src/Schedule.php
+++ b/src/crontab/src/Schedule.php
@@ -44,7 +44,7 @@ class Schedule
             ->setCallback($arguments);
     }
 
-    public static function call(Closure|callable $callable): Crontab
+    public static function call(mixed $callable): Crontab
     {
         $type = $callable instanceof Closure ? 'closure' : 'callback';
 


### PR DESCRIPTION
```php
(new Crontab())->setCallable([Foo::class, 'bar']); // ok
Schedule::call([Foo::class, 'bar']); // bad
```