### PR TITLE
Fixed the bug that `CoroutineServer` process exit when input variables exceeded

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.10 - TBD
 
+## Fixed
+
+- [#6525](https://github.com/hyperf/hyperf/pull/6525) Fixed the bug that `CoroutineServer` process exit when input variables exceeded.
+
 # v3.1.9 - 2024-02-18
 
 ## Fixed

--- a/src/amqp/tests/Message/ConsumerMessageTest.php
+++ b/src/amqp/tests/Message/ConsumerMessageTest.php
@@ -20,6 +20,7 @@ use HyperfTest\Amqp\Stub\QosConsumer;
 use Mockery;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,6 +35,7 @@ class ConsumerMessageTest extends TestCase
         Mockery::close();
     }
 
+    #[WithoutErrorHandler]
     public function testQosConfig()
     {
         $container = ContainerStub::getContainer();

--- a/src/amqp/tests/Message/ConsumerMessageTest.php
+++ b/src/amqp/tests/Message/ConsumerMessageTest.php
@@ -20,7 +20,6 @@ use HyperfTest\Amqp\Stub\QosConsumer;
 use Mockery;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,7 +34,6 @@ class ConsumerMessageTest extends TestCase
         Mockery::close();
     }
 
-    #[WithoutErrorHandler]
     public function testQosConfig()
     {
         $container = ContainerStub::getContainer();

--- a/src/exception-handler/src/Listener/ErrorExceptionHandler.php
+++ b/src/exception-handler/src/Listener/ErrorExceptionHandler.php
@@ -39,17 +39,16 @@ class ErrorExceptionHandler implements ListenerInterface
     {
         $logger = $this->logger;
         set_error_handler(static function ($level, $message, $file = '', $line = 0) use ($logger): bool {
-
-            if ($line === 0) {
-                if ($logger) {
-                    $logger->error(sprintf('Error: %s', $message));
-                } else {
-                    echo sprintf('Error: %s', $message);
-                }
-                return true;
-            }
-
             if (error_reporting() & $level) {
+                if ($line === 0) {
+                    if ($logger) {
+                        $logger->error($message);
+                    } else {
+                        echo $message . PHP_EOL;
+                    }
+                    return true;
+                }
+
                 throw new ErrorException($message, 0, $level, $file, $line);
             }
 

--- a/src/exception-handler/src/Listener/ErrorExceptionHandler.php
+++ b/src/exception-handler/src/Listener/ErrorExceptionHandler.php
@@ -39,7 +39,7 @@ class ErrorExceptionHandler implements ListenerInterface
         $logger = $this->logger;
         set_error_handler(static function ($level, $message, $file = '', $line = 0) use ($logger): bool {
 
-            if ($line === 0 ) {
+            if ($line === 0) {
                 if ($logger) {
                     $logger->error(sprintf('Error: %s', $message));
                 } else {

--- a/src/exception-handler/src/Listener/ErrorExceptionHandler.php
+++ b/src/exception-handler/src/Listener/ErrorExceptionHandler.php
@@ -27,6 +27,7 @@ class ErrorExceptionHandler implements ListenerInterface
             $this->logger = $container->get(StdoutLoggerInterface::class);
         }
     }
+
     public function listen(): array
     {
         return [

--- a/src/exception-handler/tests/ErrorExceptionHandlerTest.php
+++ b/src/exception-handler/tests/ErrorExceptionHandlerTest.php
@@ -13,6 +13,7 @@ namespace HyperfTest\ExceptionHandler;
 
 use ErrorException;
 use Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler;
+use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,9 @@ class ErrorExceptionHandlerTest extends TestCase
     #[WithoutErrorHandler]
     public function testHandleError()
     {
-        $listener = new ErrorExceptionHandler();
+        $container = Mockery::mock(\Psr\Container\ContainerInterface::class);
+        $container->shouldReceive('has')->with(\Hyperf\Contract\StdoutLoggerInterface::class)->andReturn(false);
+        $listener = new ErrorExceptionHandler($container);
         $listener->process((object) []);
 
         $this->expectException(ErrorException::class);

--- a/src/exception-handler/tests/ErrorExceptionHandlerTest.php
+++ b/src/exception-handler/tests/ErrorExceptionHandlerTest.php
@@ -15,7 +15,6 @@ use ErrorException;
 use Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +29,6 @@ class ErrorExceptionHandlerTest extends TestCase
         Mockery::close();
     }
 
-    #[WithoutErrorHandler]
     public function testHandleError()
     {
         $container = Mockery::mock(\Psr\Container\ContainerInterface::class);

--- a/src/exception-handler/tests/ErrorExceptionHandlerTest.php
+++ b/src/exception-handler/tests/ErrorExceptionHandlerTest.php
@@ -25,6 +25,11 @@ use PHPUnit\Framework\TestCase;
 #[CoversNothing]
 class ErrorExceptionHandlerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     #[WithoutErrorHandler]
     public function testHandleError()
     {

--- a/src/exception-handler/tests/ErrorExceptionHandlerTest.php
+++ b/src/exception-handler/tests/ErrorExceptionHandlerTest.php
@@ -15,6 +15,7 @@ use ErrorException;
 use Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,6 +30,7 @@ class ErrorExceptionHandlerTest extends TestCase
         Mockery::close();
     }
 
+    #[WithoutErrorHandler]
     public function testHandleError()
     {
         $container = Mockery::mock(\Psr\Container\ContainerInterface::class);


### PR DESCRIPTION
$line 为0 的都是内核虚拟机问题，而非代码异常