### PR TITLE
You can set an expression to model parameters, but it is not standardized.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,10 @@
 
 - [#6550](https://github.com/hyperf/hyperf/pull/6550) Added default config of noop driver for `hyperf/opentracing`.
 
+## Optimized
+
+- [#6556](https://github.com/hyperf/hyperf/pull/6556) You can set an expression to model parameters, but it is not standardized.
+
 # v3.1.10 - 2024-02-23
 
 ## Added

--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -626,7 +626,15 @@ trait HasAttributes
             return true;
         }
 
-        if (is_null($current) || $current instanceof Expression) {
+        if (is_null($current)) {
+            return false;
+        }
+
+        // The model parameters should not be set with an expression,
+        // Because after saving the expression, the parameters of the model will not receive the latest results,
+        // When the model be used again, It will cause some problems.
+        // So you must do something by yourself, the framework shouldn't be modified in any way.
+        if ($current instanceof Expression) {
             return false;
         }
 

--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -626,11 +626,7 @@ trait HasAttributes
             return true;
         }
 
-        if (is_null($current)) {
-            return false;
-        }
-
-        if ($current instanceof Expression) {
+        if (is_null($current) || $current instanceof Expression) {
             return false;
         }
 

--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -630,18 +630,16 @@ trait HasAttributes
             return false;
         }
 
+        if ($current instanceof Expression) {
+            return false;
+        }
+
         if ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===
                 $this->fromDateTime($original);
         }
 
         if ($this->hasCast($key, static::$primitiveCastTypes)) {
-            if ($current instanceof Expression) {
-                $current = $current->getValue();
-                if ($current != $this->castAttribute($key, $current)) {
-                    return false;
-                }
-            }
             return $this->castAttribute($key, $current) ===
                 $this->castAttribute($key, $original);
         }

--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -26,6 +26,7 @@ use Hyperf\Database\Exception\InvalidCastException;
 use Hyperf\Database\Model\EnumCollector;
 use Hyperf\Database\Model\JsonEncodingException;
 use Hyperf\Database\Model\Relations\Relation;
+use Hyperf\Database\Query\Expression;
 use Hyperf\Stringable\Str;
 use Hyperf\Stringable\StrCache;
 use LogicException;
@@ -635,6 +636,12 @@ trait HasAttributes
         }
 
         if ($this->hasCast($key, static::$primitiveCastTypes)) {
+            if ($current instanceof Expression) {
+                $current = $current->getValue();
+                if ($current != $this->castAttribute($key, $current)) {
+                    return false;
+                }
+            }
             return $this->castAttribute($key, $current) ===
                 $this->castAttribute($key, $original);
         }

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -637,7 +637,8 @@ class ModelRealBuilderTest extends TestCase
 
     public function testSaveExpression()
     {
-        $this->getContainer();
+        $container = $this->getContainer();
+        $container->shouldReceive('get')->with(Db::class)->andReturn(new Db($container));
 
         /** @var UserExt $ext */
         $ext = UserExt::query()->find(1);

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -655,14 +655,14 @@ class ModelRealBuilderTest extends TestCase
         $this->assertTrue($ext->save());
 
         $this->assertFalse($ext->isDirty());
-        $ext->str = Db::raw('concat(`str`, \'test\')');
+        $ext->str = Db::raw('concat(`str`, \'t\')');
         $this->assertTrue($ext->isDirty('str'));
         $this->assertTrue($ext->save());
 
         $this->assertFalse($ext->isDirty());
         $ext->count = Db::raw('`count` + 1');
         $ext->float_num = Db::raw('`float_num` + 0.1');
-        $ext->str = Db::raw('concat(`str`, \'test\')');
+        $ext->str = Db::raw('concat(`str`, \'e\')');
         $this->assertTrue($ext->isDirty());
         $this->assertTrue($ext->save());
 
@@ -670,8 +670,8 @@ class ModelRealBuilderTest extends TestCase
             'select * from `user_ext` where `user_ext`.`id` = ? limit 1',
             'update `user_ext` set `count` = `count` + 1 where `id` = ?',
             'update `user_ext` set `float_num` = `float_num` + 0.1 where `id` = ?',
-            'update `user_ext` set `str` = concat(`str`, \'test\') where `id` = ?',
-            'update `user_ext` set `count` = `count` + 1, `float_num` = `float_num` + 0.1, `str` = concat(`str`, \'test\') where `id` = ?',
+            'update `user_ext` set `str` = concat(`str`, \'t\') where `id` = ?',
+            'update `user_ext` set `count` = `count` + 1, `float_num` = `float_num` + 0.1, `str` = concat(`str`, \'e\') where `id` = ?',
         ];
         while ($event = $this->channel->pop(0.001)) {
             if ($event instanceof QueryExecuted) {

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -635,6 +635,50 @@ class ModelRealBuilderTest extends TestCase
         $this->assertTrue($model->save());
     }
 
+    public function testSaveExpression()
+    {
+        $this->getContainer();
+
+        /** @var UserExt $ext */
+        $ext = UserExt::query()->find(1);
+        $ext->timestamps = false;
+
+        $this->assertFalse($ext->isDirty());
+        $ext->count = Db::raw('`count` + 1');
+        $this->assertTrue($ext->isDirty('count'));
+        $this->assertTrue($ext->save());
+
+        $this->assertFalse($ext->isDirty());
+        $ext->float_num = Db::raw('`float_num` + 0.1');
+        $this->assertTrue($ext->isDirty('float_num'));
+        $this->assertTrue($ext->save());
+
+        $this->assertFalse($ext->isDirty());
+        $ext->str = Db::raw('concat(`str`, \'test\')');
+        $this->assertTrue($ext->isDirty('str'));
+        $this->assertTrue($ext->save());
+
+        $this->assertFalse($ext->isDirty());
+        $ext->count = Db::raw('`count` + 1');
+        $ext->float_num = Db::raw('`float_num` + 0.1');
+        $ext->str = Db::raw('concat(`str`, \'test\')');
+        $this->assertTrue($ext->isDirty());
+        $this->assertTrue($ext->save());
+
+        $sqls = [
+            'select * from `user_ext` where `user_ext`.`id` = ? limit 1',
+            'update `user_ext` set `count` = `count` + 1 where `id` = ?',
+            'update `user_ext` set `float_num` = `float_num` + 0.1 where `id` = ?',
+            'update `user_ext` set `str` = concat(`str`, \'test\') where `id` = ?',
+            'update `user_ext` set `count` = `count` + 1, `float_num` = `float_num` + 0.1, `str` = concat(`str`, \'test\') where `id` = ?',
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame($event->sql, array_shift($sqls));
+            }
+        }
+    }
+
     public function testSelectForBindingIntegerWhenUsingVarcharIndex()
     {
         $container = $this->getContainer();


### PR DESCRIPTION
When user money has cast and value is 1, Expression can't work with save().
For example
```
$user=User::find(1);
$user->money=Db::raw('money>0,money-1,money');
$user->save();

$user=User::updateOrCreate(['id'=>1],['money'=>Db::raw('money+100')]);
```





