### PR TITLE
Change google/common-protos version in hyperf/grpc.

### DIFF
--- a/src/grpc/composer.json
+++ b/src/grpc/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "google/common-protos": "^3.2",
+        "google/common-protos": "^4.4",
         "google/protobuf": "^3.6.1"
     },
     "suggest": {

--- a/src/grpc/composer.json
+++ b/src/grpc/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "google/common-protos": "^4.4",
+        "google/common-protos": "^3.2 || ^4.4",
         "google/protobuf": "^3.6.1"
     },
     "suggest": {


### PR DESCRIPTION
hyperf/grpc和google/gax依赖的google/common-protos版本冲突
<img width="1595" alt="image" src="https://github.com/hyperf/hyperf/assets/28034742/ae0a3294-2ec1-43f0-bf62-efa9f8c0f57b">
<img width="1446" alt="image" src="https://github.com/hyperf/hyperf/assets/28034742/72a58446-5cc8-42d8-a1ab-cb84a1990917">
