### PR TITLE
Fixed bug that the relation comments cannot be created by `gen:model`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- [#6561](https://github.com/hyperf/hyperf/pull/6561) Fixed bug that the comments of relation cannot work well for `gen:model`.
 - [#6566](https://github.com/hyperf/hyperf/pull/6566) Fixed bug that the numeric keys will be reset when using `$request->all()`.
 
 # v3.1.11 - 2024-03-01

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#6561](https://github.com/hyperf/hyperf/pull/6561) Fixed bug that the comments of relation cannot work well for `gen:model`.
+- [#6561](https://github.com/hyperf/hyperf/pull/6561) Fixed bug that the relation comments cannot be created by `gen:model`.
 - [#6566](https://github.com/hyperf/hyperf/pull/6566) Fixed bug that the numeric keys will be reset when using `$request->all()`.
 
 # v3.1.11 - 2024-03-01

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -277,7 +277,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            $return = end($methodStmt->stmts);
+            $return = reset($methodStmt->stmts);
             if ($return instanceof Node\Stmt\Return_) {
                 $expr = $return->expr;
                 if (

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -277,7 +277,7 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            $return = reset($methodStmt->stmts);
+            $return = end($methodStmt->stmts);
             if ($return instanceof Node\Stmt\Return_) {
                 $expr = $return->expr;
                 if (

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -278,40 +278,42 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
             }
 
             foreach ($methodStmt->stmts as $return) {
-                if ($return instanceof Node\Stmt\Return_) {
-                    $expr = $return->expr;
-                    if (
-                        $expr instanceof Node\Expr\MethodCall
-                        && $expr->name instanceof Node\Identifier
-                        && is_string($expr->name->name)
-                    ) {
-                        $loop = 0;
-                        while ($expr->var instanceof Node\Expr\MethodCall) {
-                            if ($loop > 32) {
-                                throw new RuntimeException('max loop reached!');
-                            }
-                            ++$loop;
-                            $expr = $expr->var;
+                if (! $return instanceof Node\Stmt\Return_) {
+                    continue;
+                }
+
+                $expr = $return->expr;
+                if (
+                    $expr instanceof Node\Expr\MethodCall
+                    && $expr->name instanceof Node\Identifier
+                    && is_string($expr->name->name)
+                ) {
+                    $loop = 0;
+                    while ($expr->var instanceof Node\Expr\MethodCall) {
+                        if ($loop > 32) {
+                            throw new RuntimeException('max loop reached!');
                         }
-                        $name = $this->getMethodRelationName($method) ?? $expr->name->name;
-                        if (array_key_exists($name, self::RELATION_METHODS)) {
-                            if ($name === 'morphTo') {
-                                // Model isn't specified because relation is polymorphic
-                                $this->setProperty($method->getName(), ['\\' . Model::class], true, false, '', true);
-                            } elseif (isset($expr->args[0]) && $expr->args[0]->value instanceof Node\Expr\ClassConstFetch) {
-                                $related = $expr->args[0]->value->class->toCodeString();
-                                if (str_contains($name, 'Many')) {
-                                    // Collection or array of models (because Collection is Arrayable)
-                                    $this->setProperty($method->getName(), [$this->getCollectionClass($related), $related . '[]'], true, false, '', true);
-                                } else {
-                                    // Single model is returned
-                                    $this->setProperty($method->getName(), [$related], true, false, '', true);
-                                }
+                        ++$loop;
+                        $expr = $expr->var;
+                    }
+                    $name = $this->getMethodRelationName($method) ?? $expr->name->name;
+                    if (array_key_exists($name, self::RELATION_METHODS)) {
+                        if ($name === 'morphTo') {
+                            // Model isn't specified because relation is polymorphic
+                            $this->setProperty($method->getName(), ['\\' . Model::class], true, false, '', true);
+                        } elseif (isset($expr->args[0]) && $expr->args[0]->value instanceof Node\Expr\ClassConstFetch) {
+                            $related = $expr->args[0]->value->class->toCodeString();
+                            if (str_contains($name, 'Many')) {
+                                // Collection or array of models (because Collection is Arrayable)
+                                $this->setProperty($method->getName(), [$this->getCollectionClass($related), $related . '[]'], true, false, '', true);
+                            } else {
+                                // Single model is returned
+                                $this->setProperty($method->getName(), [$related], true, false, '', true);
                             }
                         }
                     }
-                    break;
                 }
+                break;
             }
         }
 

--- a/src/database/tests/GenModelTest.php
+++ b/src/database/tests/GenModelTest.php
@@ -160,6 +160,7 @@ class UserEnum extends Model
     {
         var_dump(1);
         return \$this->hasOne(Book::class, 'user_id', 'id');
+        // ignore
     }
 }", $code);
     }

--- a/src/database/tests/GenModelTest.php
+++ b/src/database/tests/GenModelTest.php
@@ -140,6 +140,7 @@ namespace HyperfTest\\Database\\Stubs\\Model;
  * @property \\HyperfTest\\Database\\Stubs\\Model\\Gender \$gender 
  * @property \\Carbon\\Carbon \$created_at 
  * @property \\Carbon\\Carbon \$updated_at 
+ * @property-read null|Book \$book 
  */
 class UserEnum extends Model
 {
@@ -155,6 +156,11 @@ class UserEnum extends Model
      * The attributes that should be cast to native types.
      */
     protected array \$casts = ['id' => 'integer', 'gender' => Gender::class, 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+    public function book()
+    {
+        var_dump(1);
+        return \$this->hasOne(Book::class, 'user_id', 'id');
+    }
 }", $code);
     }
 

--- a/src/database/tests/Stubs/Model/UserEnum.php
+++ b/src/database/tests/Stubs/Model/UserEnum.php
@@ -34,4 +34,10 @@ class UserEnum extends Model
      * The attributes that should be cast to native types.
      */
     protected array $casts = ['id' => 'integer', 'gender' => Gender::class, 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    public function book()
+    {
+        var_dump(1);
+        return $this->hasOne(Book::class, 'user_id', 'id');
+    }
 }

--- a/src/database/tests/Stubs/Model/UserEnum.php
+++ b/src/database/tests/Stubs/Model/UserEnum.php
@@ -38,6 +38,6 @@ class UserEnum extends Model
     public function book()
     {
         var_dump(1);
-        return $this->hasOne(Book::class, 'user_id', 'id');
+        return $this->hasOne(Book::class, 'user_id', 'id'); // ignore
     }
 }


### PR DESCRIPTION
gen:model can't generate property when relation method has comments behind rentun
```
public function phone()
{
    return $this->belongsTo(User::class);       // @phpstan-ignore-line
}
```