### PR TITLE
Fixed bug that the numeric keys will be reset when using `$request->all()`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.12 - TBD
 
+## Fixed
+
+- [#6566](https://github.com/hyperf/hyperf/pull/6566) Fixed bug that the numeric keys will be reset when using `$request->all()`.
+
 # v3.1.11 - 2024-03-01
 
 ## Fixed

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -565,8 +565,7 @@ class Request implements RequestInterface
             } else {
                 $data = [];
             }
-
-            return array_merge($data, $request->getQueryParams());
+            return $data + $request->getQueryParams();
         });
     }
 

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -565,7 +565,8 @@ class Request implements RequestInterface
             } else {
                 $data = [];
             }
-            return $data + $request->getQueryParams();
+
+            return $request->getQueryParams() + $data;
         });
     }
 

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -86,6 +86,25 @@ class RequestTest extends TestCase
 
         $psrRequest = new Request();
         $this->assertSame(['id' => 1, 123 => '123', 'name' => 'Hyperf'], $psrRequest->all());
+
+        $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
+        $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'Hyperf']);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn(['id' => 1, '123' => '123']);
+        RequestContext::set($psrRequest);
+
+        $psrRequest = new Request();
+        $this->assertSame(['id' => 1, 123 => '123', 'name' => 'Hyperf'], $psrRequest->all());
+    }
+
+    public function testRequestAllByReplace()
+    {
+        $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
+        $psrRequest->shouldReceive('getParsedBody')->andReturn(['id' => 1, 'data' => ['id' => 2]]);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn(['data' => 'Hyperf']);
+        RequestContext::set($psrRequest);
+
+        $psrRequest = new Request();
+        $this->assertEquals(['id' => 1, 'data' => 'Hyperf'], $psrRequest->all());
     }
 
     public function testRequestInputs()

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -80,12 +80,12 @@ class RequestTest extends TestCase
     public function testRequestAll()
     {
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
-        $psrRequest->shouldReceive('getParsedBody')->andReturn(['id' => 1]);
+        $psrRequest->shouldReceive('getParsedBody')->andReturn(['id' => 1, '123' => '123']);
         $psrRequest->shouldReceive('getQueryParams')->andReturn(['name' => 'Hyperf']);
         RequestContext::set($psrRequest);
 
         $psrRequest = new Request();
-        $this->assertSame(['id' => 1, 'name' => 'Hyperf'], $psrRequest->all());
+        $this->assertSame(['id' => 1, 'name' => 'Hyperf', '123' => '123'], $psrRequest->all());
     }
 
     public function testRequestInputs()

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -85,7 +85,7 @@ class RequestTest extends TestCase
         RequestContext::set($psrRequest);
 
         $psrRequest = new Request();
-        $this->assertSame(['id' => 1, 'name' => 'Hyperf', '123' => '123'], $psrRequest->all());
+        $this->assertSame(['id' => 1, 123 => '123', 'name' => 'Hyperf'], $psrRequest->all());
     }
 
     public function testRequestInputs()

--- a/src/http-server/tests/RequestTest.php
+++ b/src/http-server/tests/RequestTest.php
@@ -85,7 +85,7 @@ class RequestTest extends TestCase
         RequestContext::set($psrRequest);
 
         $psrRequest = new Request();
-        $this->assertSame(['id' => 1, 123 => '123', 'name' => 'Hyperf'], $psrRequest->all());
+        $this->assertSame(['name' => 'Hyperf', 'id' => 1, 123 => '123'], $psrRequest->all());
 
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'Hyperf']);
@@ -93,7 +93,8 @@ class RequestTest extends TestCase
         RequestContext::set($psrRequest);
 
         $psrRequest = new Request();
-        $this->assertSame(['id' => 1, 123 => '123', 'name' => 'Hyperf'], $psrRequest->all());
+
+        $this->assertSame(['name' => 'Hyperf', 'id' => 1, 123 => '123'], $psrRequest->all());
     }
 
     public function testRequestAllByReplace()


### PR DESCRIPTION
# Minimum Example

```php
// config/routes.php
Router::post('/example',function (){
    $request = container()->get(\Hyperf\HttpServer\Contract\RequestInterface::class);
    var_dump($request->all(),$request->post());
});
```

```shell
curl --request POST \
  --url http://127.0.0.1:9501/example \
  --header 'content-type: application/json' \
  --data '{
    "123":"123",
    "hello":"hyperf"
}'
```

# Output

![image](https://github.com/hyperf/hyperf/assets/49744633/50721131-14b8-4a6a-9456-ab234f9824f9)


# 看了下 [laravel](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Http/Concerns/InteractsWithInput.php#L304) 的处理是用 + 运算符
