### PR TITLE
perf:db before executing

### DIFF
--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -144,7 +144,7 @@ class Connection implements ConnectionInterface
      *
      * @var Closure[]
      */
-    protected static array $beforeExecutingCallbacks = [];
+    protected array $beforeExecutingCallbacks = [];
 
     /**
      * Error count for executing SQL.
@@ -491,17 +491,17 @@ class Connection implements ConnectionInterface
     /**
      * Register a hook to be run just before a database query is executed.
      */
-    public static function beforeExecuting(Closure $callback): void
+    public function beforeExecuting(Closure $callback): void
     {
-        static::$beforeExecutingCallbacks[] = $callback;
+        $this->beforeExecutingCallbacks[] = $callback;
     }
 
     /**
      * Clear all hooks which will be run before a database query.
      */
-    public static function clearBeforeExecutingCallbacks(): void
+    public function clearBeforeExecutingCallbacks(): void
     {
-        static::$beforeExecutingCallbacks = [];
+        $this->beforeExecutingCallbacks = [];
     }
 
     /**
@@ -1087,7 +1087,7 @@ class Connection implements ConnectionInterface
      */
     protected function run(string $query, array $bindings, Closure $callback)
     {
-        foreach (static::$beforeExecutingCallbacks as $beforeExecutingCallback) {
+        foreach ($this->beforeExecutingCallbacks as $beforeExecutingCallback) {
             $beforeExecutingCallback($query, $bindings, $this);
         }
 

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -490,10 +490,13 @@ class Connection implements ConnectionInterface
 
     /**
      * Register a hook to be run just before a database query is executed.
+     * @return $this
      */
-    public function beforeExecuting(Closure $callback): void
+    public function beforeExecuting(Closure $callback)
     {
         $this->beforeExecutingCallbacks[] = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -715,7 +715,7 @@ class ModelRealBuilderTest extends TestCase
             $this->assertSame(1, $chan->pop(1));
             $this->assertSame(2, $chan->pop(1));
         } finally {
-            Connection::clearBeforeExecutingCallbacks();
+            Db::clearBeforeExecutingCallbacks();
         }
     }
 

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -43,7 +43,7 @@ use Psr\Container\ContainerInterface;
  * @method static array pretend(Closure $callback)
  * @method static Conn connection(string $pool)
  * @method static Conn beforeExecuting(Closure $callback)
- * @method static Conn clearBeforeExecutingCallbacks(Closure $callback)
+ * @method static Conn clearBeforeExecutingCallbacks()
  */
 class Db
 {

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -41,7 +41,9 @@ use Psr\Container\ContainerInterface;
  * @method static void commit()
  * @method static int transactionLevel()
  * @method static array pretend(Closure $callback)
- * @method static ConnectionInterface connection(string $pool)
+ * @method static Conn connection(string $pool)
+ * @method static Conn beforeExecuting(Closure $callback)
+ * @method static Conn clearBeforeExecutingCallbacks(Closure $callback)
  */
 class Db
 {
@@ -70,10 +72,5 @@ class Db
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
         return $resolver->connection($name);
-    }
-
-    public static function beforeExecuting(Closure $closure): void
-    {
-        Conn::beforeExecuting($closure);
     }
 }

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -43,7 +43,7 @@ use Psr\Container\ContainerInterface;
  * @method static array pretend(Closure $callback)
  * @method static Conn connection(string $pool)
  * @method static Conn beforeExecuting(Closure $callback)
- * @method static Conn clearBeforeExecutingCallbacks()
+ * @method static void clearBeforeExecutingCallbacks()
  */
 class Db
 {


### PR DESCRIPTION
Configuring this property as static may lead to unexpected results.
If it's necessary to share in connections, consider use StatementPrepared.
see https://github.com/laravel/framework/blob/c4e8cf5d7e0a4a5f5621e979a07c1ed9167a6e33/src/Illuminate/Database/Connection.php#L197

ps: 
`Hyperf\Database\Connectors\ConnectionFactory::make()`  return  should be `Hyperf\Database\Connection`
`Hyperf\DbConnection\Connection::$connnection` also