### PR TITLE
Support setup command traits before running

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,8 +1,9 @@
-# v3.1.12 - TBD
+# v3.1.13 - TBD
 
 ## Added
 
 - [#6576](https://github.com/hyperf/hyperf/pull/6576) Added `Hyperf\Stringable\Str::apa()` method.
+- [#6577](https://github.com/hyperf/hyperf/pull/6577) Support setup command traits before running.
 
 # v3.1.12 - 2024-03-07
 

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -209,7 +209,7 @@ abstract class Command extends SymfonyCommand
     }
 
     /**
-     * Boot the command traits.
+     * Setup traits of command.
      */
     protected function setUpTraits(): array
     {

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -23,6 +23,8 @@ use Throwable;
 
 use function Hyperf\Collection\collect;
 use function Hyperf\Coroutine\run;
+use function Hyperf\Support\class_basename;
+use function Hyperf\Support\class_uses_recursive;
 use function Hyperf\Support\swoole_hook_flags;
 use function Hyperf\Tappable\tap;
 

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -99,6 +99,8 @@ abstract class Command extends SymfonyCommand
     {
         $this->output = new SymfonyStyle($input, $output);
 
+        $this->setUpTraits();
+
         return parent::run($this->input = $input, $this->output);
     }
 
@@ -202,5 +204,21 @@ abstract class Command extends SymfonyCommand
         }
 
         return $this->exitCode >= 0 && $this->exitCode <= 255 ? $this->exitCode : self::INVALID;
+    }
+
+    /**
+     * Boot the command traits.
+     */
+    protected function setUpTraits(): array
+    {
+        $uses = array_flip(class_uses_recursive(static::class));
+
+        foreach ($uses as $trait) {
+            if (method_exists($this, $method = 'setUp' . class_basename($trait))) {
+                $this->{$method}($this->input, $this->output);
+            }
+        }
+
+        return $uses;
     }
 }

--- a/src/command/tests/Command/FooTraitCommand.php
+++ b/src/command/tests/Command/FooTraitCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Command\Command;
+
+class FooTraitCommand extends \Hyperf\Command\Command
+{
+    use Traits\Foo;
+
+    public function __construct(string $name = null)
+    {
+        parent::__construct($name);
+    }
+
+    public function handle()
+    {
+    }
+}

--- a/src/command/tests/Command/Traits/Foo.php
+++ b/src/command/tests/Command/Traits/Foo.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+namespace HyperfTest\Command\Command\Traits;
+
+trait Foo
+{
+    private ?string $propertyFoo = null;
+
+    public function setUpFoo()
+    {
+        $this->propertyFoo = 'foo';
+    }
+}

--- a/src/command/tests/Command/Traits/Foo.php
+++ b/src/command/tests/Command/Traits/Foo.php
@@ -15,7 +15,7 @@ trait Foo
 {
     private ?string $propertyFoo = null;
 
-    public function setUpFoo()
+    protected function setUpFoo()
     {
         $this->propertyFoo = 'foo';
     }

--- a/src/command/tests/Command/Traits/Foo.php
+++ b/src/command/tests/Command/Traits/Foo.php
@@ -11,11 +11,14 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Command\Command\Traits;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
 trait Foo
 {
     private ?string $propertyFoo = null;
 
-    protected function setUpFoo()
+    protected function setUpFoo(?InputInterface $input, ?OutputInterface $output)
     {
         $this->propertyFoo = 'foo';
     }

--- a/src/command/tests/CommandTest.php
+++ b/src/command/tests/CommandTest.php
@@ -17,6 +17,7 @@ use HyperfTest\Command\Command\DefaultSwooleFlagsCommand;
 use HyperfTest\Command\Command\FooCommand;
 use HyperfTest\Command\Command\FooExceptionCommand;
 use HyperfTest\Command\Command\FooExitCommand;
+use HyperfTest\Command\Command\FooTraitCommand;
 use HyperfTest\Command\Command\SwooleFlagsCommand;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -72,6 +73,11 @@ class CommandTest extends TestCase
         $command = new ClassInvoker(new FooCommand());
         $exitCode = $command->execute($input, $output);
         $this->assertSame(0, $exitCode);
+
+        $command = new FooTraitCommand();
+        $traits = (fn () => $this->setUpTraits())->call($command);
+        $this->assertArrayHasKey(\HyperfTest\Command\Command\Traits\Foo::class, $traits);
+        $this->assertSame('foo', (fn () => $this->propertyFoo)->call($command));
     }
 
     public function testExitCodeWhenThrowExceptionInCoroutine()

--- a/src/command/tests/CommandTest.php
+++ b/src/command/tests/CommandTest.php
@@ -75,8 +75,7 @@ class CommandTest extends TestCase
         $this->assertSame(0, $exitCode);
 
         $command = new FooTraitCommand();
-        $traits = (fn () => $this->setUpTraits())->call($command);
-        $this->assertArrayHasKey(\HyperfTest\Command\Command\Traits\Foo::class, $traits);
+        $this->assertArrayHasKey(\HyperfTest\Command\Command\Traits\Foo::class, (fn () => $this->setUpTraits())->call($command));
         $this->assertSame('foo', (fn () => $this->propertyFoo)->call($command));
     }
 


### PR DESCRIPTION
Bar:

```php
trait Bar
{
    public function setUpBar($input, $output)
    {
        //...
    }
}
```

FooCommand:

```php
class FooCommand extends \Hyperf\Command\Command
{
    use Bar;
    ...
}
```

The setUpBar method will be executed before FooCommand executes run.