### PR TITLE
Typo: removed a whitespace from github link 

### DIFF
--- a/docs/en/db/paginator.md
+++ b/docs/en/db/paginator.md
@@ -1,6 +1,6 @@
 # Query pagination
 
-When using [hyperf/database](https://github.com/hyperf-cloud/database) to query data, it is very convenient to use [hyperf/paginator](https://github.com/hyperf-cloud /paginator) component to easily paginate query results.
+When using [hyperf/database](https://github.com/hyperf-cloud/database) to query data, it is very convenient to use [hyperf/paginator](https://github.com/hyperf-cloud/paginator) component to easily paginate query results.
 
 # Instructions
 


### PR DESCRIPTION
Removed a breaking whitespace from the database paginator souce code github reference link on the docs on the english version