### PR TITLE
Fixed bug that the command description will cause parse error when contains `--`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -9,6 +9,7 @@
 
 ## Fixed
 
+- [#6586](https://github.com/hyperf/hyperf/pull/6586) Fixed bug that the command description will cause parse error when contains `--`.
 - [#6593](https://github.com/hyperf/hyperf/pull/6593) Fixed the error when register multi `AsCommand`.
 
 # v3.1.12 - 2024-03-07

--- a/src/command/src/Parser.php
+++ b/src/command/src/Parser.php
@@ -60,7 +60,7 @@ class Parser
         $options = [];
 
         foreach ($tokens as $token) {
-            if (preg_match('/-{2,}(.*)/', $token, $matches)) {
+            if (preg_match('/^-{2,}(.*)/', $token, $matches)) {
                 $options[] = static::parseOption($matches[1]);
             } else {
                 $arguments[] = static::parseArgument($token);

--- a/src/command/tests/CommandParserTest.php
+++ b/src/command/tests/CommandParserTest.php
@@ -80,6 +80,20 @@ class CommandParserTest extends TestCase
         $this->assertSame('The option description.', $results[2][0]->getDescription());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
+
+        $results = Parser::parse('command:name
+            {argument?* : The argument description --json.}
+            {--option=* : The option description --json.}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
+        $this->assertSame('The argument description --json.', $results[1][0]->getDescription());
+        $this->assertTrue($results[1][0]->isArray());
+        $this->assertFalse($results[1][0]->isRequired());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description --json.', $results[2][0]->getDescription());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isArray());
     }
 
     public function testShortcutNameParsing()


### PR DESCRIPTION
参数的描述含有--，参考这里  https://github.com/laravel/framework/pull/48021