### PR TITLE
Fixed implicitly nullable params

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,14 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
 $header = <<<'EOF'
 This file is part of Hyperf.
 
@@ -23,13 +32,13 @@ return (new PhpCsFixer\Config())
             'location' => 'after_declare_strict',
         ],
         'array_syntax' => [
-            'syntax' => 'short'
+            'syntax' => 'short',
         ],
         'list_syntax' => [
-            'syntax' => 'short'
+            'syntax' => 'short',
         ],
         'concat_space' => [
-            'spacing' => 'one'
+            'spacing' => 'one',
         ],
         'blank_line_before_statement' => [
             'statements' => [
@@ -38,7 +47,7 @@ return (new PhpCsFixer\Config())
         ],
         'general_phpdoc_annotation_remove' => [
             'annotations' => [
-                'author'
+                'author',
             ],
         ],
         'ordered_imports' => [
@@ -85,6 +94,7 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'standardize_not_equals' => true,
         'multiline_comment_opening_closing' => true,
+        'nullable_type_declaration_for_default_null_value' => true, // Since PHP 8.3, default null values can be declared as nullable.
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/src/amqp/src/AMQPConnection.php
+++ b/src/amqp/src/AMQPConnection.php
@@ -64,7 +64,7 @@ class AMQPConnection extends AbstractConnection
         string $login_method = 'AMQPLAIN',
         $login_response = null,
         string $locale = 'en_US',
-        AbstractIO $io = null,
+        ?AbstractIO $io = null,
         int $heartbeat = 0,
         int $connection_timeout = 0,
         float $channel_rpc_timeout = 0.0

--- a/src/async-queue/src/Driver/DriverInterface.php
+++ b/src/async-queue/src/Driver/DriverInterface.php
@@ -48,12 +48,12 @@ interface DriverInterface
     /**
      * Reload failed message into waiting queue.
      */
-    public function reload(string $queue = null): int;
+    public function reload(?string $queue = null): int;
 
     /**
      * Delete all failed message from failed queue.
      */
-    public function flush(string $queue = null): bool;
+    public function flush(?string $queue = null): bool;
 
     /**
      * Return info for current queue.

--- a/src/async-queue/src/Driver/RedisDriver.php
+++ b/src/async-queue/src/Driver/RedisDriver.php
@@ -109,7 +109,7 @@ class RedisDriver extends Driver
         return false;
     }
 
-    public function reload(string $queue = null): int
+    public function reload(?string $queue = null): int
     {
         $channel = $this->channel->getFailed();
         if ($queue) {
@@ -127,7 +127,7 @@ class RedisDriver extends Driver
         return $num;
     }
 
-    public function flush(string $queue = null): bool
+    public function flush(?string $queue = null): bool
     {
         $channel = $this->channel->getFailed();
         if ($queue) {

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -127,7 +127,7 @@ class Arr
     /**
      * Return the first element in an array passing a given truth test.
      */
-    public static function first(array $array, callable $callback = null, mixed $default = null): mixed
+    public static function first(array $array, ?callable $callback = null, mixed $default = null): mixed
     {
         if (is_null($callback)) {
             if (empty($array)) {
@@ -148,7 +148,7 @@ class Arr
     /**
      * Return the last element in an array passing a given truth test.
      */
-    public static function last(array $array, callable $callback = null, mixed $default = null): mixed
+    public static function last(array $array, ?callable $callback = null, mixed $default = null): mixed
     {
         if (is_null($callback)) {
             return empty($array) ? value($default) : end($array);
@@ -419,7 +419,7 @@ class Arr
      *
      * @throws InvalidArgumentException
      */
-    public static function random(array $array, int $number = null): mixed
+    public static function random(array $array, ?int $number = null): mixed
     {
         $requested = is_null($number) ? 1 : $number;
         $count = count($array);
@@ -471,7 +471,7 @@ class Arr
     /**
      * Shuffle the given array and return the result.
      */
-    public static function shuffle(array $array, int $seed = null): array
+    public static function shuffle(array $array, ?int $seed = null): array
     {
         if (empty($array)) {
             return [];

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -188,7 +188,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  (callable(int): TTimesValue)|null  $callback
      * @return static<int, TTimesValue>
      */
-    public static function times(int $number, callable $callback = null): self
+    public static function times(int $number, ?callable $callback = null): self
     {
         if ($number < 1) {
             return new static();
@@ -514,7 +514,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param (callable(TValue, TKey): bool)|null $callback
      * @return static<TKey, TValue>
      */
-    public function filter(callable $callback = null): self
+    public function filter(?callable $callback = null): self
     {
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
@@ -529,7 +529,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param callable($this, $value): $this $default
      * @return $this
      */
-    public function when(bool $value, callable $callback, callable $default = null): self
+    public function when(bool $value, callable $callback, ?callable $default = null): self
     {
         if ($value) {
             return $callback($this, $value);
@@ -547,7 +547,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param callable($this): null|$this $default
      * @return $this
      */
-    public function unless(bool $value, callable $callback, callable $default = null): self
+    public function unless(bool $value, callable $callback, ?callable $default = null): self
     {
         return $this->when(! $value, $callback, $default);
     }
@@ -647,7 +647,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TFirstDefault|TValue
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         return Arr::first($this->items, $callback, $default);
     }
@@ -786,7 +786,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Concatenate values of a given key as a string.
      */
-    public function implode(string $value, string $glue = null): string
+    public function implode(string $value, ?string $glue = null): string
     {
         $first = $this->first();
         if (is_array($first) || is_object($first)) {
@@ -850,7 +850,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TLastDefault|TValue
      */
-    public function last(callable $callback = null, $default = null)
+    public function last(?callable $callback = null, $default = null)
     {
         return Arr::last($this->items, $callback, $default);
     }
@@ -1197,7 +1197,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @return static<int, TValue>|TValue
      * @throws InvalidArgumentException
      */
-    public function random(int $number = null)
+    public function random(?int $number = null)
     {
         if (is_null($number)) {
             return Arr::random($this->items);
@@ -1304,7 +1304,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static<TKey, TValue>
      */
-    public function shuffle(int $seed = null): self
+    public function shuffle(?int $seed = null): self
     {
         return new static(Arr::shuffle($this->items, $seed));
     }
@@ -1314,7 +1314,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static<TKey, TValue>
      */
-    public function slice(int $offset, int $length = null): self
+    public function slice(int $offset, ?int $length = null): self
     {
         return new static(array_slice($this->items, $offset, $length, true));
     }
@@ -1369,7 +1369,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param callable(TValue, TValue): int $callback
      * @return static<TKey, TValue>
      */
-    public function sort(callable $callback = null): self
+    public function sort(?callable $callback = null): self
     {
         $items = $this->items;
         $callback ? uasort($items, $callback) : asort($items);
@@ -1445,7 +1445,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param array<array-key, TValue> $replacement
      * @return static<TKey, TValue>
      */
-    public function splice(int $offset, int $length = null, $replacement = []): self
+    public function splice(int $offset, ?int $length = null, $replacement = []): self
     {
         if (func_num_args() === 1) {
             return new static(array_splice($this->items, $offset));

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -69,7 +69,7 @@ abstract class Command extends SymfonyCommand
      */
     protected int $exitCode = self::SUCCESS;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         $this->name = $name ?? $this->name;
 

--- a/src/command/tests/Command/FooExceptionCommand.php
+++ b/src/command/tests/Command/FooExceptionCommand.php
@@ -18,7 +18,7 @@ use RuntimeException;
 
 class FooExceptionCommand extends Command
 {
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
 

--- a/src/command/tests/Command/FooExitCommand.php
+++ b/src/command/tests/Command/FooExitCommand.php
@@ -17,7 +17,7 @@ use Hyperf\Event\ListenerProvider;
 
 class FooExitCommand extends Command
 {
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
 

--- a/src/command/tests/Command/FooTraitCommand.php
+++ b/src/command/tests/Command/FooTraitCommand.php
@@ -15,7 +15,7 @@ class FooTraitCommand extends \Hyperf\Command\Command
 {
     use Traits\Foo;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
     }

--- a/src/conditionable/src/Conditionable.php
+++ b/src/conditionable/src/Conditionable.php
@@ -27,7 +27,7 @@ trait Conditionable
      * @param null|mixed $value
      * @return $this|TWhenReturnType
      */
-    public function when($value = null, callable $callback = null, callable $default = null)
+    public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
@@ -61,7 +61,7 @@ trait Conditionable
      * @param null|mixed $value
      * @return $this|TUnlessReturnType
      */
-    public function unless($value = null, callable $callback = null, callable $default = null)
+    public function unless($value = null, ?callable $callback = null, ?callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 

--- a/src/consul/src/Client.php
+++ b/src/consul/src/Client.php
@@ -37,7 +37,7 @@ abstract class Client
      */
     private $logger;
 
-    public function __construct(Closure $clientFactory, LoggerInterface $logger = null)
+    public function __construct(Closure $clientFactory, ?LoggerInterface $logger = null)
     {
         $this->clientFactory = $clientFactory;
         $this->logger = $logger ?: new NullLogger();

--- a/src/consul/src/ConsulResponse.php
+++ b/src/consul/src/ConsulResponse.php
@@ -32,7 +32,7 @@ class ConsulResponse
         return $this->response->{$name}(...$arguments);
     }
 
-    public function json(string $key = null, $default = null)
+    public function json(?string $key = null, $default = null)
     {
         if ($this->response->getHeaderLine('content-type') !== 'application/json') {
             throw new ServerException('The Content-Type of response is not equal application/json');

--- a/src/crontab/src/Parser.php
+++ b/src/crontab/src/Parser.php
@@ -78,7 +78,7 @@ class Parser
     /**
      * Parse each segment of crontab string.
      */
-    protected function parseSegment(string $string, int $min, int $max, int $start = null)
+    protected function parseSegment(string $string, int $min, int $max, ?int $start = null)
     {
         if ($start === null || $start < $min) {
             $start = $min;

--- a/src/dag/src/Vertex.php
+++ b/src/dag/src/Vertex.php
@@ -32,7 +32,7 @@ class Vertex
      */
     public array $children = [];
 
-    public static function make(callable $job, string $key = null): self
+    public static function make(callable $job, ?string $key = null): self
     {
         $closure = Closure::fromCallable($job);
         if ($key === null) {
@@ -45,7 +45,7 @@ class Vertex
         return $v;
     }
 
-    public static function of(Runner $job, string $key = null): self
+    public static function of(Runner $job, ?string $key = null): self
     {
         if ($key === null) {
             $key = spl_object_hash($job);

--- a/src/database-sqlite/src/Schema/Grammars/SQLiteGrammar.php
+++ b/src/database-sqlite/src/Schema/Grammars/SQLiteGrammar.php
@@ -429,7 +429,7 @@ class SQLiteGrammar extends Grammar
         return 'multipolygon';
     }
 
-    protected function getIndexColumns(Connection $connection, string $tableName = null): array
+    protected function getIndexColumns(Connection $connection, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
             SELECT t.name AS table_name,
@@ -460,7 +460,7 @@ SQL;
     /**
      * @see http://ezcomponents.org/docs/api/trunk/DatabaseSchema/ezcDbSchemaPgsqlReader.html
      */
-    protected function getTableIndexesList(Connection $connection, array $tableIndexes, string $tableName = null): array
+    protected function getTableIndexesList(Connection $connection, array $tableIndexes, ?string $tableName = null): array
     {
         $indexBuffer = [];
 

--- a/src/database-sqlite/src/Schema/SQLiteBuilder.php
+++ b/src/database-sqlite/src/Schema/SQLiteBuilder.php
@@ -83,7 +83,7 @@ class SQLiteBuilder extends Builder
      *
      * @param array|string $index
      */
-    public function hasIndex(string $table, $index, string $type = null): bool
+    public function hasIndex(string $table, $index, ?string $type = null): bool
     {
         $type = is_null($type) ? $type : strtolower($type);
 

--- a/src/database/src/Migrations/MigrationCreator.php
+++ b/src/database/src/Migrations/MigrationCreator.php
@@ -36,7 +36,7 @@ class MigrationCreator
      *
      * @throws Exception
      */
-    public function create(string $name, string $path, string $table = null, bool $create = false): string
+    public function create(string $name, string $path, ?string $table = null, bool $create = false): string
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 

--- a/src/database/src/Model/Builder.php
+++ b/src/database/src/Model/Builder.php
@@ -261,7 +261,7 @@ class Builder
      *
      * @return $this
      */
-    public function withoutGlobalScopes(array $scopes = null)
+    public function withoutGlobalScopes(?array $scopes = null)
     {
         if (! is_array($scopes)) {
             $scopes = array_keys($this->scopes);
@@ -559,7 +559,7 @@ class Builder
      * @param array|Closure $columns
      * @return \Hyperf\Database\Model\Model|mixed|static
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/database/src/Model/Concerns/HasAttributes.php
+++ b/src/database/src/Model/Concerns/HasAttributes.php
@@ -542,7 +542,7 @@ trait HasAttributes
     /**
      * Sync the changed attributes.
      */
-    public function syncChanges(array $columns = null): static
+    public function syncChanges(?array $columns = null): static
     {
         $changes = $this->getDirty();
 

--- a/src/database/src/Model/Concerns/HasGlobalScopes.php
+++ b/src/database/src/Model/Concerns/HasGlobalScopes.php
@@ -26,7 +26,7 @@ trait HasGlobalScopes
      *
      * @throws InvalidArgumentException
      */
-    public static function addGlobalScope($scope, Closure $implementation = null)
+    public static function addGlobalScope($scope, ?Closure $implementation = null)
     {
         if (is_string($scope) && ! is_null($implementation)) {
             return GlobalScope::$container[static::class][$scope] = $implementation;

--- a/src/database/src/Model/Concerns/QueriesRelationships.php
+++ b/src/database/src/Model/Concerns/QueriesRelationships.php
@@ -32,7 +32,7 @@ trait QueriesRelationships
      * @param string $boolean
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             if (str_contains($relation, '.')) {
@@ -94,7 +94,7 @@ trait QueriesRelationships
      * @param string $boolean
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->has($relation, '<', 1, $boolean, $callback);
     }
@@ -118,7 +118,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -132,7 +132,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'or', $callback);
     }
@@ -143,7 +143,7 @@ trait QueriesRelationships
      * @param string $relation
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function whereDoesntHave($relation, Closure $callback = null)
+    public function whereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'and', $callback);
     }
@@ -155,7 +155,7 @@ trait QueriesRelationships
      * @param Closure $callback
      * @return \Hyperf\Database\Model\Builder|static
      */
-    public function orWhereDoesntHave($relation, Closure $callback = null)
+    public function orWhereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
     }
@@ -328,7 +328,7 @@ trait QueriesRelationships
      * @param int $count
      * @return $this
      */
-    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
     }
@@ -340,7 +340,7 @@ trait QueriesRelationships
      * @param Closure $callback
      * @return $this
      */
-    public function orWhereHasMorph(string $relation, $types, Closure $callback = null, string $operator = '>=', int $count = 1)
+    public function orWhereHasMorph(string $relation, $types, ?Closure $callback = null, string $operator = '>=', int $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
     }
@@ -351,7 +351,7 @@ trait QueriesRelationships
      * @param array|string $types
      * @return $this
      */
-    public function whereDoesntHaveMorph(string $relation, $types, Closure $callback = null)
+    public function whereDoesntHaveMorph(string $relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'and', $callback);
     }
@@ -363,7 +363,7 @@ trait QueriesRelationships
      * @param Closure $callback
      * @return $this
      */
-    public function orWhereDoesntHaveMorph(string $relation, $types, Closure $callback = null)
+    public function orWhereDoesntHaveMorph(string $relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'or', $callback);
     }
@@ -378,7 +378,7 @@ trait QueriesRelationships
      * @param string $boolean
      * @return $this
      */
-    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         $relation = $this->getRelationWithoutConstraints($relation);
 
@@ -417,7 +417,7 @@ trait QueriesRelationships
      * @param string $boolean
      * @return $this
      */
-    public function doesntHaveMorph(string $relation, $types, $boolean = 'and', Closure $callback = null)
+    public function doesntHaveMorph(string $relation, $types, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }

--- a/src/database/src/Model/Model.php
+++ b/src/database/src/Model/Model.php
@@ -884,7 +884,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @return static
      */
-    public function replicate(array $except = null)
+    public function replicate(?array $except = null)
     {
         $defaults = [
             $this->getKeyName(),

--- a/src/database/src/Model/Relations/BelongsToMany.php
+++ b/src/database/src/Model/Relations/BelongsToMany.php
@@ -544,7 +544,7 @@ class BelongsToMany extends Relation
     /**
      * Get a paginator for the "select" statement.
      */
-    public function paginate(int $perPage = null, array $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginatorInterface
+    public function paginate(?int $perPage = null, array $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginatorInterface
     {
         $this->query->addSelect($this->shouldSelect($columns));
 

--- a/src/database/src/Model/Relations/HasManyThrough.php
+++ b/src/database/src/Model/Relations/HasManyThrough.php
@@ -330,7 +330,7 @@ class HasManyThrough extends Relation
     /**
      * Get a paginator for the "select" statement.
      */
-    public function paginate(int $perPage = null, array $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginatorInterface
+    public function paginate(?int $perPage = null, array $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginatorInterface
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
@@ -547,7 +547,7 @@ class HasManyThrough extends Relation
     /**
      * Set the join clause on the query.
      */
-    protected function performJoin(Builder $query = null)
+    protected function performJoin(?Builder $query = null)
     {
         $query = $query ?: $this->query;
 

--- a/src/database/src/Model/Relations/Relation.php
+++ b/src/database/src/Model/Relations/Relation.php
@@ -313,7 +313,7 @@ abstract class Relation
      * @param bool $merge
      * @return array
      */
-    public static function morphMap(array $map = null, $merge = true)
+    public static function morphMap(?array $map = null, $merge = true)
     {
         $map = static::buildMorphMapFromModels($map);
 
@@ -382,7 +382,7 @@ abstract class Relation
      * @param null|string[] $models
      * @return null|array
      */
-    protected static function buildMorphMapFromModels(array $models = null)
+    protected static function buildMorphMapFromModels(?array $models = null)
     {
         if (is_null($models) || Arr::isAssoc($models)) {
             return $models;

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -256,8 +256,8 @@ class Builder
      */
     public function __construct(
         ConnectionInterface $connection,
-        Grammar $grammar = null,
-        Processor $processor = null
+        ?Grammar $grammar = null,
+        ?Processor $processor = null
     ) {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -98,7 +98,7 @@ class Blueprint
      * @param string $table
      * @param string $prefix
      */
-    public function __construct($table, Closure $callback = null, $prefix = '')
+    public function __construct($table, ?Closure $callback = null, $prefix = '')
     {
         $this->table = $table;
         $this->prefix = $prefix;

--- a/src/database/src/Schema/Builder.php
+++ b/src/database/src/Schema/Builder.php
@@ -302,7 +302,7 @@ class Builder
      * @param string $table
      * @return \Hyperf\Database\Schema\Blueprint
      */
-    protected function createBlueprint($table, Closure $callback = null)
+    protected function createBlueprint($table, ?Closure $callback = null)
     {
         $prefix = $this->connection->getConfig('prefix_indexes')
             ? $this->connection->getConfig('prefix')

--- a/src/di/src/Aop/ProxyManager.php
+++ b/src/di/src/Aop/ProxyManager.php
@@ -95,7 +95,7 @@ class ProxyManager
         return $proxyFilePath;
     }
 
-    protected function isModified(string $className, string $proxyFilePath = null): bool
+    protected function isModified(string $className, ?string $proxyFilePath = null): bool
     {
         $proxyFilePath = $proxyFilePath ?? $this->getProxyFilePath($className);
         $time = $this->filesystem->lastModified($proxyFilePath);

--- a/src/di/src/Definition/DefinitionSource.php
+++ b/src/di/src/Definition/DefinitionSource.php
@@ -120,7 +120,7 @@ class DefinitionSource implements DefinitionSourceInterface
         return null;
     }
 
-    protected function autowire(string $name, ObjectDefinition $definition = null): ?ObjectDefinition
+    protected function autowire(string $name, ?ObjectDefinition $definition = null): ?ObjectDefinition
     {
         $className = $definition ? $definition->getClassName() : $name;
         if (! class_exists($className) && ! interface_exists($className)) {

--- a/src/di/src/Definition/ObjectDefinition.php
+++ b/src/di/src/Definition/ObjectDefinition.php
@@ -23,7 +23,7 @@ class ObjectDefinition implements DefinitionInterface
 
     private bool $instantiable = false;
 
-    public function __construct(private string $name, string $className = null)
+    public function __construct(private string $name, ?string $className = null)
     {
         $this->setClassName($className ?? $name);
     }
@@ -44,7 +44,7 @@ class ObjectDefinition implements DefinitionInterface
         return $this;
     }
 
-    public function setClassName(string $className = null): void
+    public function setClassName(?string $className = null): void
     {
         $this->className = $className;
 

--- a/src/di/src/Exception/InvalidDefinitionException.php
+++ b/src/di/src/Exception/InvalidDefinitionException.php
@@ -15,7 +15,7 @@ use Hyperf\Di\Definition\DefinitionInterface;
 
 class InvalidDefinitionException extends Exception
 {
-    public static function create(DefinitionInterface $definition, string $message, \Exception $previous = null): self
+    public static function create(DefinitionInterface $definition, string $message, ?\Exception $previous = null): self
     {
         return new self(sprintf('%s' . PHP_EOL . 'Full definition:' . PHP_EOL . '%s', $message, (string) $definition), 0, $previous);
     }

--- a/src/di/src/Resolver/ParameterResolver.php
+++ b/src/di/src/Resolver/ParameterResolver.php
@@ -24,8 +24,8 @@ class ParameterResolver
     }
 
     public function resolveParameters(
-        MethodInjection $definition = null,
-        ReflectionMethod $method = null,
+        ?MethodInjection $definition = null,
+        ?ReflectionMethod $method = null,
         array $parameters = []
     ): array {
         $args = [];

--- a/src/framework/src/SymfonyEventDispatcher.php
+++ b/src/framework/src/SymfonyEventDispatcher.php
@@ -30,7 +30,7 @@ if (interface_exists(EventDispatcherInterface::class)) {
             $this->psrDispatcher = $psrDispatcher;
         }
 
-        public function dispatch(object $event, string $eventName = null): object
+        public function dispatch(object $event, ?string $eventName = null): object
         {
             return $this->psrDispatcher->dispatch($event);
         }

--- a/src/grpc-client/src/GrpcClient.php
+++ b/src/grpc-client/src/GrpcClient.php
@@ -223,7 +223,7 @@ class GrpcClient
         return $this->getHttpClient()->write($streamId, $data, $end);
     }
 
-    public function recv(int $streamId, float $timeout = null)
+    public function recv(int $streamId, ?float $timeout = null)
     {
         if (! $this->isConnected() || $streamId <= 0 || ! $this->isStreamExist($streamId)) {
             return false;

--- a/src/grpc-client/src/Request.php
+++ b/src/grpc-client/src/Request.php
@@ -25,7 +25,7 @@ class Request extends BaseRequest
      */
     public $usePipelineRead;
 
-    public function __construct(string $method, Message $argument = null, $headers = [])
+    public function __construct(string $method, ?Message $argument = null, $headers = [])
     {
         $this->method = 'POST';
         $this->headers = array_replace($this->getDefaultHeaders(), $headers);

--- a/src/grpc-server/src/Exception/GrpcStatusException.php
+++ b/src/grpc-server/src/Exception/GrpcStatusException.php
@@ -38,7 +38,7 @@ class GrpcStatusException extends GrpcException
      */
     protected array $statusDetails = [];
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null, protected ?Status $status = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null, protected ?Status $status = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/guzzle/src/RetryMiddleware.php
+++ b/src/guzzle/src/RetryMiddleware.php
@@ -23,7 +23,7 @@ class RetryMiddleware implements MiddlewareInterface
 
     public function getMiddleware(): callable
     {
-        return Middleware::retry(function ($retries, RequestInterface $request, ResponseInterface $response = null) {
+        return Middleware::retry(function ($retries, RequestInterface $request, ?ResponseInterface $response = null) {
             if (! $this->isOk($response) && $retries < $this->retries) {
                 return true;
             }

--- a/src/helper/src/Functions.php
+++ b/src/helper/src/Functions.php
@@ -51,7 +51,7 @@ if (! function_exists('with')) {
      *
      * @param mixed $value
      */
-    function with($value, callable $callback = null)
+    function with($value, ?callable $callback = null)
     {
         return \Hyperf\Support\with($value, $callback);
     }
@@ -271,7 +271,7 @@ if (! function_exists('optional')) {
      * @param mixed $value
      * @return mixed
      */
-    function optional($value = null, callable $callback = null)
+    function optional($value = null, ?callable $callback = null)
     {
         return \Hyperf\Support\optional($value, $callback);
     }

--- a/src/http-message/src/Base/Response.php
+++ b/src/http-message/src/Base/Response.php
@@ -319,7 +319,7 @@ class Response implements ResponseInterface, ResponsePlusInterface, Stringable
     /**
      * Is the response a redirect of some form?
      */
-    public function isRedirect(string $location = null): bool
+    public function isRedirect(?string $location = null): bool
     {
         return in_array($this->statusCode, [
             201,

--- a/src/http-message/src/Exception/BadRequestHttpException.php
+++ b/src/http-message/src/Exception/BadRequestHttpException.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class BadRequestHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null, protected ?ServerRequestInterface $request = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null, protected ?ServerRequestInterface $request = null)
     {
         parent::__construct(400, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/ForbiddenHttpException.php
+++ b/src/http-message/src/Exception/ForbiddenHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class ForbiddenHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(403, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/HttpException.php
+++ b/src/http-message/src/Exception/HttpException.php
@@ -22,7 +22,7 @@ class HttpException extends RuntimeException
      * @param null|string $message error message
      * @param int $code error code
      */
-    public function __construct(public int $statusCode, $message = '', $code = 0, Throwable $previous = null)
+    public function __construct(public int $statusCode, $message = '', $code = 0, ?Throwable $previous = null)
     {
         if (is_null($message)) {
             $message = Response::getReasonPhraseByCode($statusCode);

--- a/src/http-message/src/Exception/MethodNotAllowedHttpException.php
+++ b/src/http-message/src/Exception/MethodNotAllowedHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class MethodNotAllowedHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(405, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/NotAcceptableHttpException.php
+++ b/src/http-message/src/Exception/NotAcceptableHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class NotAcceptableHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(406, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/NotFoundHttpException.php
+++ b/src/http-message/src/Exception/NotFoundHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class NotFoundHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(404, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/RangeNotSatisfiableHttpException.php
+++ b/src/http-message/src/Exception/RangeNotSatisfiableHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class RangeNotSatisfiableHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(416, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/ServerErrorHttpException.php
+++ b/src/http-message/src/Exception/ServerErrorHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class ServerErrorHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(500, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/UnauthorizedHttpException.php
+++ b/src/http-message/src/Exception/UnauthorizedHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class UnauthorizedHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(401, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/UnprocessableEntityHttpException.php
+++ b/src/http-message/src/Exception/UnprocessableEntityHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class UnprocessableEntityHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(422, $message, $code, $previous);
     }

--- a/src/http-message/src/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/http-message/src/Exception/UnsupportedMediaTypeHttpException.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class UnsupportedMediaTypeHttpException extends HttpException
 {
-    public function __construct($message = null, $code = 0, Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(415, $message, $code, $previous);
     }

--- a/src/http-server/src/Contract/RequestInterface.php
+++ b/src/http-server/src/Contract/RequestInterface.php
@@ -39,7 +39,7 @@ interface RequestInterface extends ServerRequestInterface
     /**
      * Retrieve the input data from request via multi keys, include query parameters, parsed body and json body.
      */
-    public function inputs(array $keys, array $default = null): array;
+    public function inputs(array $keys, ?array $default = null): array;
 
     /**
      * Determine if the $keys is existed in parameters.

--- a/src/http-server/src/Request.php
+++ b/src/http-server/src/Request.php
@@ -103,7 +103,7 @@ class Request implements RequestInterface
     /**
      * Retrieve the input data from request via multi keys, include query parameters, parsed body and json body.
      */
-    public function inputs(array $keys, array $default = null): array
+    public function inputs(array $keys, ?array $default = null): array
     {
         $data = $this->getInputData();
         $result = [];

--- a/src/ide-helper/output/Hyperf/CircuitBreaker/Annotation/CircuitBreaker.php
+++ b/src/ide-helper/output/Hyperf/CircuitBreaker/Annotation/CircuitBreaker.php
@@ -20,7 +20,7 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
 #[Attribute(Attribute::TARGET_METHOD)]
 class CircuitBreaker extends AbstractAnnotation
 {
-    public function __construct(string $handler = 'Hyperf\\CircuitBreaker\\Handler\\TimeoutHandler', ?string $fallback = null, float $duration = 10.0, int $successCounter = 10, int $failCounter = 10, array $value = null)
+    public function __construct(string $handler = 'Hyperf\\CircuitBreaker\\Handler\\TimeoutHandler', ?string $fallback = null, float $duration = 10.0, int $successCounter = 10, int $failCounter = 10, ?array $value = null)
     {
     }
 }

--- a/src/json-rpc/src/ResponseBuilder.php
+++ b/src/json-rpc/src/ResponseBuilder.php
@@ -40,7 +40,7 @@ class ResponseBuilder
     {
     }
 
-    public function buildErrorResponse(ServerRequestInterface $request, int $code, Throwable $error = null): ResponsePlusInterface
+    public function buildErrorResponse(ServerRequestInterface $request, int $code, ?Throwable $error = null): ResponsePlusInterface
     {
         $body = new SwooleStream($this->formatErrorResponse($request, $code, $error));
         return $this->response()->addHeader('content-type', 'application/json')->setBody($body);
@@ -67,7 +67,7 @@ class ResponseBuilder
         return $this->packer->pack($response);
     }
 
-    protected function formatErrorResponse(ServerRequestInterface $request, int $code, Throwable $error = null): string
+    protected function formatErrorResponse(ServerRequestInterface $request, int $code, ?Throwable $error = null): string
     {
         [$code, $message] = $this->error($code, $error?->getMessage());
         $response = $this->dataFormatter->formatErrorResponse(

--- a/src/nats/src/Connection.php
+++ b/src/nats/src/Connection.php
@@ -290,7 +290,7 @@ class Connection
      * @param string $sid subscription ID
      * @param int $quantity quantity of messages
      */
-    public function unsubscribe(string $sid, int $quantity = null): void
+    public function unsubscribe(string $sid, ?int $quantity = null): void
     {
         $msg = 'UNSUB ' . $sid;
         if ($quantity !== null) {

--- a/src/phar/src/Package.php
+++ b/src/phar/src/Package.php
@@ -77,7 +77,7 @@ class Package
     /**
      * Get resource bundle object.
      */
-    public function bundle(Finder $finder = null): Bundle
+    public function bundle(?Finder $finder = null): Bundle
     {
         $bundle = new Bundle();
         $dir = $this->getDirectory();

--- a/src/phar/src/TargetPhar.php
+++ b/src/phar/src/TargetPhar.php
@@ -72,7 +72,7 @@ class TargetPhar implements Stringable
     /**
      * Create the default execution file.
      */
-    public function createDefaultStub(string $indexFile, string $webIndexFile = null): string
+    public function createDefaultStub(string $indexFile, ?string $webIndexFile = null): string
     {
         $params = [$indexFile];
         if ($webIndexFile != null) {

--- a/src/reactive-x/src/IpcSubject.php
+++ b/src/reactive-x/src/IpcSubject.php
@@ -57,7 +57,7 @@ class IpcSubject implements MessageBusInterface
         $this->isSubscribed = true;
     }
 
-    public function subscribe($onNextOrObserver = null, callable $onError = null, callable $onCompleted = null): DisposableInterface
+    public function subscribe($onNextOrObserver = null, ?callable $onError = null, ?callable $onCompleted = null): DisposableInterface
     {
         $this->init();
         return $this->subject->subscribe($onNextOrObserver, $onError, $onCompleted);

--- a/src/redis/src/Traits/MultiExec.php
+++ b/src/redis/src/Traits/MultiExec.php
@@ -23,7 +23,7 @@ trait MultiExec
      *
      * @return array|Redis
      */
-    public function pipeline(callable $callback = null)
+    public function pipeline(?callable $callback = null)
     {
         $pipeline = $this->__call('pipeline', []);
 
@@ -35,7 +35,7 @@ trait MultiExec
      *
      * @return array|Redis|RedisCluster
      */
-    public function transaction(callable $callback = null)
+    public function transaction(?callable $callback = null)
     {
         $transaction = $this->__call('multi', []);
 

--- a/src/resource/tests/HttpResponse.php
+++ b/src/resource/tests/HttpResponse.php
@@ -309,7 +309,7 @@ class HttpResponse
      * @param null|array $responseData
      * @return $this
      */
-    public function assertJsonStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructure(?array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
             return $this->assertExactJson($this->json());

--- a/src/rpc-client/src/AbstractServiceClient.php
+++ b/src/rpc-client/src/AbstractServiceClient.php
@@ -134,7 +134,7 @@ abstract class AbstractServiceClient
         return $this->container->get(IdGenerator\UniqidIdGenerator::class);
     }
 
-    protected function createLoadBalancer(array $nodes, callable $refresh = null, bool $isLongPolling = false): LoadBalancerInterface
+    protected function createLoadBalancer(array $nodes, ?callable $refresh = null, bool $isLongPolling = false): LoadBalancerInterface
     {
         $loadBalancer = $this->loadBalancerManager->getInstance($this->serviceName, $this->loadBalancer)->setNodes($nodes);
         $refresh && $loadBalancer->refresh($refresh, $isLongPolling ? 1 : 5000);

--- a/src/rpc-multiplex/src/CoreMiddleware.php
+++ b/src/rpc-multiplex/src/CoreMiddleware.php
@@ -90,7 +90,7 @@ class CoreMiddleware extends \Hyperf\RpcServer\CoreMiddleware
         return $this->responseBuilder->buildResponse($request, $response);
     }
 
-    protected function buildErrorData(ServerRequestInterface $request, int $code, string $message = null, Throwable $throwable = null): array
+    protected function buildErrorData(ServerRequestInterface $request, int $code, ?string $message = null, ?Throwable $throwable = null): array
     {
         $id = $request->getAttribute(Constant::REQUEST_ID);
 

--- a/src/rpc-multiplex/src/TcpServer.php
+++ b/src/rpc-multiplex/src/TcpServer.php
@@ -61,7 +61,7 @@ class TcpServer extends Server
         ExceptionHandlerDispatcher $exceptionDispatcher,
         ProtocolManager $protocolManager,
         StdoutLoggerInterface $logger,
-        string $protocol = null
+        ?string $protocol = null
     ) {
         parent::__construct($container, $dispatcher, $exceptionDispatcher, $logger);
 

--- a/src/serializer/src/ExceptionNormalizer.php
+++ b/src/serializer/src/ExceptionNormalizer.php
@@ -26,7 +26,7 @@ class ExceptionNormalizer implements NormalizerInterface, DenormalizerInterface,
 {
     protected ?Instantiator $instantiator = null;
 
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
         if (is_string($data)) {
             $ex = unserialize($data);
@@ -70,7 +70,7 @@ class ExceptionNormalizer implements NormalizerInterface, DenormalizerInterface,
         return class_exists($type) && is_a($type, Throwable::class, true);
     }
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         if ($object instanceof Serializable) {
             return serialize($object);
@@ -84,7 +84,7 @@ class ExceptionNormalizer implements NormalizerInterface, DenormalizerInterface,
         ];
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $data instanceof Throwable;
     }

--- a/src/serializer/src/ScalarNormalizer.php
+++ b/src/serializer/src/ScalarNormalizer.php
@@ -25,7 +25,7 @@ class ScalarNormalizer implements NormalizerInterface, DenormalizerInterface, Ca
         return get_class($this) === __CLASS__;
     }
 
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
         return match ($type) {
             'int' => (int) $data,
@@ -36,7 +36,7 @@ class ScalarNormalizer implements NormalizerInterface, DenormalizerInterface, Ca
         };
     }
 
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization($data, $type, ?string $format = null)
     {
         return in_array($type, [
             'int',
@@ -48,12 +48,12 @@ class ScalarNormalizer implements NormalizerInterface, DenormalizerInterface, Ca
         ]);
     }
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         return $object;
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return is_scalar($data);
     }

--- a/src/serializer/src/Serializer.php
+++ b/src/serializer/src/Serializer.php
@@ -150,7 +150,7 @@ class Serializer implements Normalizer, SerializerInterface, ContextAwareNormali
         return $this->denormalize($data, $type, $format, $context);
     }
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         // If a normalizer supports the given data, use it
         if ($normalizer = $this->getNormalizer($object, $format, $context)) {
@@ -189,7 +189,7 @@ class Serializer implements Normalizer, SerializerInterface, ContextAwareNormali
      * @param mixed $data
      * @throws NotNormalizableValueException
      */
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
         if (isset(self::SCALAR_TYPES[$type])) {
             if (is_scalar($data)) {
@@ -217,12 +217,12 @@ class Serializer implements Normalizer, SerializerInterface, ContextAwareNormali
         throw new NotNormalizableValueException(sprintf('Could not denormalize object of type "%s", no supporting normalizer found.', $type));
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $this->getNormalizer($data, $format, $context) !== null;
     }
 
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return isset(self::SCALAR_TYPES[$type]) || $this->getDenormalizer($data, $type, $format, $context) !== null;
     }

--- a/src/socketio-server/src/Collector/SocketIORouter.php
+++ b/src/socketio-server/src/Collector/SocketIORouter.php
@@ -26,7 +26,7 @@ class SocketIORouter extends MetadataCollector
         static::set('backward.' . $className, $nsp);
     }
 
-    public static function clear(string $key = null): void
+    public static function clear(?string $key = null): void
     {
         if ($key !== null) {
             parent::clear('backward.' . $key);

--- a/src/socketio-server/src/SocketIO.php
+++ b/src/socketio-server/src/SocketIO.php
@@ -209,7 +209,7 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
         return ApplicationContext::getContainer()->get($class);
     }
 
-    public function addCallback(string $ackId, Channel $channel, int $timeoutMs = null)
+    public function addCallback(string $ackId, Channel $channel, ?int $timeoutMs = null)
     {
         $this->clientCallbacks[$ackId] = $channel;
         // Clean up using timer to avoid memory leak.

--- a/src/support/src/Composer.php
+++ b/src/support/src/Composer.php
@@ -88,7 +88,7 @@ class Composer
         return '';
     }
 
-    public static function getMergedExtra(string $key = null)
+    public static function getMergedExtra(?string $key = null)
     {
         if (! self::$extra) {
             self::getLockContent();

--- a/src/support/src/Filesystem/Filesystem.php
+++ b/src/support/src/Filesystem/Filesystem.php
@@ -422,7 +422,7 @@ class Filesystem
     /**
      * Copy a directory from one location to another.
      */
-    public function copyDirectory(string $directory, string $destination, int $options = null): bool
+    public function copyDirectory(string $directory, string $destination, ?int $options = null): bool
     {
         if (! $this->isDirectory($directory)) {
             return false;

--- a/src/support/src/Functions.php
+++ b/src/support/src/Functions.php
@@ -95,7 +95,7 @@ function retry($times, callable $callback, int $sleep = 0)
  *
  * @param mixed $value
  */
-function with($value, callable $callback = null)
+function with($value, ?callable $callback = null)
 {
     return is_null($callback) ? $value : $callback($value);
 }
@@ -222,7 +222,7 @@ function swoole_hook_flags(): int
  * @param mixed $value
  * @return mixed
  */
-function optional($value = null, callable $callback = null)
+function optional($value = null, ?callable $callback = null)
 {
     if (is_null($callback)) {
         return new Optional($value);

--- a/src/testing/src/AssertableJsonString.php
+++ b/src/testing/src/AssertableJsonString.php
@@ -256,7 +256,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      * @param null|array $responseData
      * @return $this
      */
-    public function assertStructure(array $structure = null, $responseData = null)
+    public function assertStructure(?array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
             return $this->assertSimilar($this->decoded);

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -44,7 +44,7 @@ class Client extends Server
 
     protected string $baseUri = 'http://127.0.0.1/';
 
-    public function __construct(ContainerInterface $container, PackerInterface $packer = null, $server = 'http')
+    public function __construct(ContainerInterface $container, ?PackerInterface $packer = null, $server = 'http')
     {
         parent::__construct(
             $container,

--- a/src/testing/src/Concerns/InteractsWithContainer.php
+++ b/src/testing/src/Concerns/InteractsWithContainer.php
@@ -58,7 +58,7 @@ trait InteractsWithContainer
      * @param string $abstract
      * @return \Mockery\MockInterface
      */
-    protected function mock($abstract, Closure $mock = null)
+    protected function mock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
@@ -69,7 +69,7 @@ trait InteractsWithContainer
      * @param string $abstract
      * @return \Mockery\MockInterface
      */
-    protected function partialMock($abstract, Closure $mock = null)
+    protected function partialMock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
@@ -80,7 +80,7 @@ trait InteractsWithContainer
      * @param string $abstract
      * @return \Mockery\MockInterface
      */
-    protected function spy($abstract, Closure $mock = null)
+    protected function spy($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }

--- a/src/testing/src/Fluent/AssertableJson.php
+++ b/src/testing/src/Fluent/AssertableJson.php
@@ -45,7 +45,7 @@ class AssertableJson implements Arrayable
     /**
      * Create a new fluent, assertable JSON data instance.
      */
-    protected function __construct(array $props, string $path = null)
+    protected function __construct(array $props, ?string $path = null)
     {
         $this->path = $path;
         $this->props = $props;
@@ -148,7 +148,7 @@ class AssertableJson implements Arrayable
      *
      * @return mixed
      */
-    protected function prop(string $key = null)
+    protected function prop(?string $key = null)
     {
         return Arr::get($this->props, $key);
     }

--- a/src/testing/src/Fluent/Concerns/Debugging.php
+++ b/src/testing/src/Fluent/Concerns/Debugging.php
@@ -18,7 +18,7 @@ trait Debugging
      *
      * @return $this
      */
-    public function dump(string $prop = null): self
+    public function dump(?string $prop = null): self
     {
         dump($this->prop($prop));
 
@@ -30,7 +30,7 @@ trait Debugging
      *
      * @return never
      */
-    public function dd(string $prop = null): void
+    public function dd(?string $prop = null): void
     {
         dd($this->prop($prop));
     }
@@ -40,5 +40,5 @@ trait Debugging
      *
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/testing/src/Fluent/Concerns/Has.php
+++ b/src/testing/src/Fluent/Concerns/Has.php
@@ -23,7 +23,7 @@ trait Has
      * @param int|string $key
      * @return $this
      */
-    public function count($key, int $length = null): self
+    public function count($key, ?int $length = null): self
     {
         if (is_null($length)) {
             $path = $this->dotPath();
@@ -55,7 +55,7 @@ trait Has
      * @param null|Closure|int $length
      * @return $this
      */
-    public function has($key, $length = null, Closure $callback = null): self
+    public function has($key, $length = null, ?Closure $callback = null): self
     {
         $prop = $this->prop();
 
@@ -198,7 +198,7 @@ trait Has
      *
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 
     /**
      * Instantiate a new "scope" at the path of the given key.

--- a/src/testing/src/Fluent/Concerns/Interaction.php
+++ b/src/testing/src/Fluent/Concerns/Interaction.php
@@ -66,5 +66,5 @@ trait Interaction
      *
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/testing/src/Fluent/Concerns/Matching.php
+++ b/src/testing/src/Fluent/Concerns/Matching.php
@@ -198,7 +198,7 @@ trait Matching
      * @param null $value
      * @return $this
      */
-    abstract public function has(string $key, $value = null, Closure $scope = null);
+    abstract public function has(string $key, $value = null, ?Closure $scope = null);
 
     /**
      * Ensures that all properties are sorted the same way, recursively.
@@ -228,5 +228,5 @@ trait Matching
      *
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/testing/src/Http/TestResponse.php
+++ b/src/testing/src/Http/TestResponse.php
@@ -355,7 +355,7 @@ class TestResponse implements ArrayAccess
      * @param null|array $responseData
      * @return $this
      */
-    public function assertJsonStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructure(?array $structure = null, $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData);
 

--- a/src/testing/src/HttpClient.php
+++ b/src/testing/src/HttpClient.php
@@ -26,7 +26,7 @@ class HttpClient
 
     protected PackerInterface $packer;
 
-    public function __construct(protected ContainerInterface $container, PackerInterface $packer = null, $baseUri = 'http://127.0.0.1:9501')
+    public function __construct(protected ContainerInterface $container, ?PackerInterface $packer = null, $baseUri = 'http://127.0.0.1:9501')
     {
         $this->packer = $packer ?? new JsonPacker();
         $handler = null;

--- a/src/tracer/class_map/ThriftUdpTransport.php
+++ b/src/tracer/class_map/ThriftUdpTransport.php
@@ -51,7 +51,7 @@ class ThriftUdpTransport extends TTransport
      */
     private $chan;
 
-    public function __construct(string $host, int $port, LoggerInterface $logger = null)
+    public function __construct(string $host, int $port, ?LoggerInterface $logger = null)
     {
         $this->host = $host;
         $this->port = $port;

--- a/src/tracer/src/Adapter/Reporter/Kafka.php
+++ b/src/tracer/src/Adapter/Reporter/Kafka.php
@@ -32,8 +32,8 @@ class Kafka implements Reporter
     public function __construct(
         private array $options,
         private KafkaClientFactory $clientFactory,
-        LoggerInterface $logger = null,
-        SpanSerializer $serializer = null
+        ?LoggerInterface $logger = null,
+        ?SpanSerializer $serializer = null
     ) {
         $this->serializer = $serializer ?? new JsonV2Serializer();
         $this->logger = $logger ?? new NullLogger();

--- a/src/view-engine/src/Contract/Enumerable.php
+++ b/src/view-engine/src/Contract/Enumerable.php
@@ -49,7 +49,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @return static
      */
-    public static function times(int $number, callable $callback = null);
+    public static function times(int $number, ?callable $callback = null);
 
     /**
      * Wrap the given value in a collection if applicable.
@@ -258,7 +258,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @return static
      */
-    public function filter(callable $callback = null);
+    public function filter(?callable $callback = null);
 
     /**
      * Apply the callback if the value is truthy.
@@ -266,21 +266,21 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param bool $value
      * @return mixed|static
      */
-    public function when($value, callable $callback, callable $default = null);
+    public function when($value, callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is empty.
      *
      * @return mixed|static
      */
-    public function whenEmpty(callable $callback, callable $default = null);
+    public function whenEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is not empty.
      *
      * @return mixed|static
      */
-    public function whenNotEmpty(callable $callback, callable $default = null);
+    public function whenNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the value is falsy.
@@ -288,21 +288,21 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param bool $value
      * @return mixed|static
      */
-    public function unless($value, callable $callback, callable $default = null);
+    public function unless($value, callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.
      *
      * @return mixed|static
      */
-    public function unlessEmpty(callable $callback, callable $default = null);
+    public function unlessEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is not empty.
      *
      * @return mixed|static
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null);
+    public function unlessNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Filter items by the given key value pair.
@@ -393,7 +393,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param mixed $default
      * @return mixed
      */
-    public function first(callable $callback = null, $default = null);
+    public function first(?callable $callback = null, $default = null);
 
     /**
      * Get the first item by the given key value pair.
@@ -507,7 +507,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param mixed $default
      * @return mixed
      */
-    public function last(callable $callback = null, $default = null);
+    public function last(?callable $callback = null, $default = null);
 
     /**
      * Run a map over each of the items.

--- a/src/view-engine/src/Finder.php
+++ b/src/view-engine/src/Finder.php
@@ -40,7 +40,7 @@ class Finder implements FinderInterface
     /**
      * Create a new file view loader instance.
      */
-    public function __construct(protected Filesystem $files, array $paths, array $extensions = null)
+    public function __construct(protected Filesystem $files, array $paths, ?array $extensions = null)
     {
         $this->paths = array_map([$this, 'resolvePath'], $paths);
 

--- a/src/view-engine/src/View.php
+++ b/src/view-engine/src/View.php
@@ -133,7 +133,7 @@ class View implements ArrayAccess, Htmlable, ViewInterface
      *
      * @throws Throwable
      */
-    public function render(callable $callback = null): array|string
+    public function render(?callable $callback = null): array|string
     {
         try {
             $contents = $this->renderContents();

--- a/src/websocket-client/src/Client.php
+++ b/src/websocket-client/src/Client.php
@@ -72,7 +72,7 @@ class Client
     /**
      * @param int $flags SWOOLE_WEBSOCKET_FLAG_FIN or SWOOLE_WEBSOCKET_FLAG_COMPRESS
      */
-    public function push(string $data, int $opcode = WEBSOCKET_OPCODE_TEXT, int $flags = null): bool
+    public function push(string $data, int $opcode = WEBSOCKET_OPCODE_TEXT, ?int $flags = null): bool
     {
         return $this->client->push($data, $opcode, $flags);
     }


### PR DESCRIPTION
Fixes deprecation on PHP 8.4 https://wiki.php.net/rfc/deprecate-implicitly-nullable-types