### PR TITLE
Use PHP_BINARY instead of hardcoding in hyperf/watcher component

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -5,6 +5,10 @@
 - [#6652](https://github.com/hyperf/hyperf/pull/6652) Added Str trim methods.
 - [#6658](https://github.com/hyperf/hyperf/pull/6658) HEAD requests, attempt fallback to GET in `MiddlewareManager`
 
+# Changed
+
+- [#6661](https://github.com/hyperf/hyperf/pull/6661) Use `PHP_BINARY` instead of `php` as default php binary path for `hyperf/watcher`.
+
 # v3.1.16 - 2024-04-02
 
 ## Added

--- a/docs/zh-cn/watcher.md
+++ b/docs/zh-cn/watcher.md
@@ -6,7 +6,7 @@
 
 ## 安装
 
-```
+```bash
 composer require hyperf/watcher --dev
 ```
 
@@ -23,7 +23,7 @@ php bin/hyperf.php vendor:publish hyperf/watcher
 |      配置      |      默认值      |                           备注                            |
 | :------------: | :--------------: | :-------------------------------------------------------: |
 |     driver     | `ScanFileDriver` |                   默认定时扫描文件驱动                    |
-|      bin       |      `php`       | 用于启动服务的脚本 例如 `php -d swoole.use_shortname=Off` |
+|      bin       |   `PHP_BINARY`   | 用于启动服务的脚本 例如 `php -d swoole.use_shortname=Off` |
 |   watch.dir    | `app`, `config`  |                         监听目录                          |
 |   watch.file   |      `.env`      |                         监听文件                          |
 | watch.interval |      `2000`      |                      扫描间隔(毫秒)                       |
@@ -74,5 +74,4 @@ php bin/hyperf.php server:watch
 
 - 暂时 Alpine Docker 环境下，稍微有点问题，后续会完善。
 - 删除文件和修改`.env`需要手动重启才能生效。
-- vendor 中的文件需要使用 classmap 形式自动加载才能被扫描。（即执行`composer dump-autoload -o`)
-
+- vendor 中的文件需要使用 classmap 形式自动加载才能被扫描。（即执行`composer dump-autoload -o`）

--- a/src/watcher/publish/watcher.php
+++ b/src/watcher/publish/watcher.php
@@ -13,7 +13,7 @@ use Hyperf\Watcher\Driver\ScanFileDriver;
 
 return [
     'driver' => ScanFileDriver::class,
-    'bin' => 'php',
+    'bin' => PHP_BINARY,
     'watch' => [
         'dir' => ['app', 'config'],
         'file' => ['.env'],

--- a/src/watcher/src/Option.php
+++ b/src/watcher/src/Option.php
@@ -18,7 +18,7 @@ class Option
 {
     protected string $driver = ScanFileDriver::class;
 
-    protected string $bin = 'php';
+    protected string $bin = PHP_BINARY;
 
     protected string $command = 'vendor/hyperf/watcher/watcher.php start';
 


### PR DESCRIPTION
子进程应该使用和执行命令同一个php版本。

close #6660