### PR TITLE
Fixed bug that `isset` cannot check `null` in `Hyperf\Collection\Collection`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.18 - TBD
 
+## Fixed
+
+- [#6664](https://github.com/hyperf/hyperf/pull/6664) Fixed bug that `isset` cannot check `null` in `Hyperf\Collection\Collection`.
+
 # v3.1.17 - 2024-04-10
 
 ## Added

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -1669,7 +1669,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function offsetExists(mixed $offset): bool
     {
-        return array_key_exists($offset, $this->items);
+        return isset($this->items[$offset]);
     }
 
     /**

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -258,4 +258,14 @@ class CollectionTest extends TestCase
             $c->replaceRecursive(new Collection(['z', 2 => [1 => 'e']]))->all()
         );
     }
+
+    public function testIssetAndPassword()
+    {
+        $data = [null,1];
+        $c = new Collection($data);
+        $this->assertFalse(isset($data[0]));
+        $this->assertFalse(isset($c[0]));
+        $this->assertTrue(isset($data[1]));
+        $this->assertTrue(isset($c[1]));
+    }
 }

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -259,7 +259,7 @@ class CollectionTest extends TestCase
         );
     }
 
-    public function testIssetAndPassword()
+    public function testIsset()
     {
         $data = [null, 1];
         $c = new Collection($data);

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -261,7 +261,7 @@ class CollectionTest extends TestCase
 
     public function testIssetAndPassword()
     {
-        $data = [null,1];
+        $data = [null, 1];
         $c = new Collection($data);
         $this->assertFalse(isset($data[0]));
         $this->assertFalse(isset($c[0]));


### PR DESCRIPTION
# Collection offsetExists 与 isset 预期不符合，理应一致

## Minimum Example

```php
$data = [null,0];
$collection = collection($data);

var_dump(isset($data[0),isset($collection[0]));
```

## Output

```console
bool(false)
bool(true)
```