### PR TITLE
fix Hyperf\Database\Query\Builder::paginate() paramater $page expects

### DIFF
--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -1972,7 +1972,7 @@ class Builder
      * @param int $perPage
      * @param string[] $columns
      * @param string $pageName
-     * @param null $page
+     * @param null|int $page
      */
     public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null): LengthAwarePaginatorInterface
     {


### PR DESCRIPTION
phpstan report  Parameter $page of method Hyperf\Database\Query\Builder::paginate() expects null, int<1, max> given.