### PR TITLE
Optimized the implementation of `Pluralizer`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.20 - TBD
 
+## Optimized
+
+- [#6700](https://github.com/hyperf/hyperf/pull/6700) Optimized the implementation of `Pluralizer`.
+
 # v3.1.19 - 2024-04-18
 
 ## Fixed

--- a/src/stringable/src/Pluralizer.php
+++ b/src/stringable/src/Pluralizer.php
@@ -37,12 +37,8 @@ class Pluralizer
 
     /**
      * Get the plural form of an English word.
-     *
-     * @param string $value
-     * @param array|Countable|int $count
-     * @return string
      */
-    public static function plural($value, $count = 2)
+    public static function plural(string $value, array|Countable|int $count = 2): string
     {
         if (is_countable($count)) {
             $count = count($count);
@@ -59,11 +55,8 @@ class Pluralizer
 
     /**
      * Get the singular form of an English word.
-     *
-     * @param string $value
-     * @return string
      */
-    public static function singular($value)
+    public static function singular(string $value): string
     {
         $singular = static::getInflector()->singularize($value);
 
@@ -107,12 +100,8 @@ class Pluralizer
 
     /**
      * Attempt to match the case on two strings.
-     *
-     * @param string $value
-     * @param string $comparison
-     * @return string
      */
-    protected static function matchCase($value, $comparison)
+    protected static function matchCase(string $value, string $comparison): string
     {
         $functions = ['mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords'];
 

--- a/src/stringable/src/Pluralizer.php
+++ b/src/stringable/src/Pluralizer.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Hyperf\Stringable;
 
-use Doctrine\Inflector\CachedWordInflector;
+use Countable;
 use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\Rules\English;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\Language;
 
 class Pluralizer
 {
@@ -24,48 +24,14 @@ class Pluralizer
      */
     public static array $uncountable
         = [
-            'audio',
-            'bison',
-            'cattle',
-            'chassis',
-            'compensation',
-            'coreopsis',
-            'data',
-            'deer',
-            'education',
-            'emoji',
-            'equipment',
-            'evidence',
-            'feedback',
-            'firmware',
-            'fish',
-            'furniture',
-            'gold',
-            'hardware',
-            'information',
-            'jedi',
-            'kin',
-            'knowledge',
-            'love',
-            'metadata',
-            'money',
-            'moose',
-            'news',
-            'nutrition',
-            'offspring',
-            'plankton',
-            'pokemon',
-            'police',
-            'rain',
-            'rice',
-            'series',
-            'sheep',
-            'software',
-            'species',
-            'swine',
-            'traffic',
-            'wheat',
+            'recommended',
+            'related',
         ];
+
+    /**
+     * The language that should be used by the inflector.
+     */
+    protected static string $language = Language::ENGLISH;
 
     protected static ?Inflector $inflector = null;
 
@@ -73,12 +39,16 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param string $value
-     * @param int $count
+     * @param array|Countable|int $count
      * @return string
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) abs($count) === 1 || static::uncountable($value)) {
+        if (is_countable($count)) {
+            $count = count($count);
+        }
+
+        if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
             return $value;
         }
 
@@ -111,17 +81,17 @@ class Pluralizer
     public static function getInflector(): Inflector
     {
         if (is_null(static::$inflector)) {
-            static::$inflector = new Inflector(
-                new CachedWordInflector(new RulesetInflector(
-                    English\Rules::getSingularRuleset()
-                )),
-                new CachedWordInflector(new RulesetInflector(
-                    English\Rules::getPluralRuleset()
-                ))
-            );
+            static::$inflector = InflectorFactory::createForLanguage(static::$language)->build();
         }
 
         return static::$inflector;
+    }
+
+    public static function useLanguage(string $language): void
+    {
+        static::$language = $language;
+
+        static::$inflector = null;
     }
 
     /**
@@ -147,8 +117,8 @@ class Pluralizer
         $functions = ['mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords'];
 
         foreach ($functions as $function) {
-            if (call_user_func($function, $comparison) === $comparison) {
-                return call_user_func($function, $value);
+            if ($function($comparison) === $comparison) {
+                return $function($value);
             }
         }
 

--- a/src/stringable/src/Str.php
+++ b/src/stringable/src/Str.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Stringable;
 
 use Closure;
+use Countable;
 use DateTimeInterface;
 use Hyperf\Collection\Arr;
 use Hyperf\Collection\Collection;
@@ -547,9 +548,8 @@ class Str
 
     /**
      * Get the plural form of an English word.
-     * @param mixed $count
      */
-    public static function plural(string $value, $count = 2): string
+    public static function plural(string $value, array|Countable|int $count = 2): string
     {
         return Pluralizer::plural($value, $count);
     }

--- a/src/stringable/src/Str.php
+++ b/src/stringable/src/Str.php
@@ -534,8 +534,9 @@ class Str
 
     /**
      * Pluralize the last word of an English, studly caps case string.
+     * @param mixed $count
      */
-    public static function pluralStudly(string $value, int $count = 2): string
+    public static function pluralStudly(string $value, $count = 2): string
     {
         $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -546,8 +547,9 @@ class Str
 
     /**
      * Get the plural form of an English word.
+     * @param mixed $count
      */
-    public static function plural(string $value, int $count = 2): string
+    public static function plural(string $value, $count = 2): string
     {
         return Pluralizer::plural($value, $count);
     }

--- a/src/stringable/tests/PluralizerTest.php
+++ b/src/stringable/tests/PluralizerTest.php
@@ -131,8 +131,9 @@ class PluralizerTest extends TestCase
 
     public function testPluralizerAboutData()
     {
-        $this->assertSame('datum', Str::singular('data'));
+        $this->assertSame('xxx_datum', Str::singular('xxx_data'));
         $this->assertSame('data', Str::plural('datum'));
+        $this->assertSame('data', Str::singular('data'));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2): void

--- a/src/stringable/tests/PluralizerTest.php
+++ b/src/stringable/tests/PluralizerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Stringable;
+
+use Hyperf\Stringable\Str;
+use PHPUnit\Framework\TestCase;
+
+use function Hyperf\Collection\collect;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class PluralizerTest extends TestCase
+{
+    public function testBasicSingular(): void
+    {
+        $this->assertSame('child', Str::singular('children'));
+    }
+
+    public function testBasicPlural(): void
+    {
+        $this->assertSame('children', Str::plural('child'));
+        $this->assertSame('cod', Str::plural('cod'));
+        $this->assertSame('The words', Str::plural('The word'));
+        $this->assertSame('Bouquetés', Str::plural('Bouqueté'));
+    }
+
+    public function testCaseSensitiveSingularUsage(): void
+    {
+        $this->assertSame('Child', Str::singular('Children'));
+        $this->assertSame('CHILD', Str::singular('CHILDREN'));
+        $this->assertSame('Test', Str::singular('Tests'));
+    }
+
+    public function testCaseSensitiveSingularPlural(): void
+    {
+        $this->assertSame('Children', Str::plural('Child'));
+        $this->assertSame('CHILDREN', Str::plural('CHILD'));
+        $this->assertSame('Tests', Str::plural('Test'));
+        $this->assertSame('children', Str::plural('cHiLd'));
+    }
+
+    public function testIfEndOfWordPlural(): void
+    {
+        $this->assertSame('VortexFields', Str::plural('VortexField'));
+        $this->assertSame('MatrixFields', Str::plural('MatrixField'));
+        $this->assertSame('IndexFields', Str::plural('IndexField'));
+        $this->assertSame('VertexFields', Str::plural('VertexField'));
+
+        // This is expected behavior, use "Str::pluralStudly" instead.
+        $this->assertSame('RealHumen', Str::plural('RealHuman'));
+    }
+
+    public function testPluralWithNegativeCount(): void
+    {
+        $this->assertSame('test', Str::plural('test', 1));
+        $this->assertSame('tests', Str::plural('test', 2));
+        $this->assertSame('test', Str::plural('test', -1));
+        $this->assertSame('tests', Str::plural('test', -2));
+    }
+
+    public function testPluralStudly(): void
+    {
+        $this->assertPluralStudly('RealHumans', 'RealHuman');
+        $this->assertPluralStudly('Models', 'Model');
+        $this->assertPluralStudly('VortexFields', 'VortexField');
+        $this->assertPluralStudly('MultipleWordsInOneStrings', 'MultipleWordsInOneString');
+    }
+
+    public function testPluralStudlyWithCount(): void
+    {
+        $this->assertPluralStudly('RealHuman', 'RealHuman', 1);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', 2);
+        $this->assertPluralStudly('RealHuman', 'RealHuman', -1);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', -2);
+    }
+
+    public function testPluralNotAppliedForStringEndingWithNonAlphanumericCharacter(): void
+    {
+        $this->assertSame('Alien.', Str::plural('Alien.'));
+        $this->assertSame('Alien!', Str::plural('Alien!'));
+        $this->assertSame('Alien ', Str::plural('Alien '));
+        $this->assertSame('50%', Str::plural('50%'));
+    }
+
+    public function testPluralAppliedForStringEndingWithNumericCharacter(): void
+    {
+        $this->assertSame('User1s', Str::plural('User1'));
+        $this->assertSame('User2s', Str::plural('User2'));
+        $this->assertSame('User3s', Str::plural('User3'));
+    }
+
+    public function testPluralSupportsArrays(): void
+    {
+        $this->assertSame('users', Str::plural('user', []));
+        $this->assertSame('user', Str::plural('user', ['one']));
+        $this->assertSame('users', Str::plural('user', ['one', 'two']));
+    }
+
+    public function testPluralSupportsCollections()
+    {
+        $this->assertSame('users', Str::plural('user', collect()));
+        $this->assertSame('user', Str::plural('user', collect(['one'])));
+        $this->assertSame('users', Str::plural('user', collect(['one', 'two'])));
+    }
+
+    public function testPluralStudlySupportsArrays()
+    {
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', []);
+        $this->assertPluralStudly('SomeUser', 'SomeUser', ['one']);
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', ['one', 'two']);
+    }
+
+    public function testPluralStudlySupportsCollections(): void
+    {
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect());
+        $this->assertPluralStudly('SomeUser', 'SomeUser', collect(['one']));
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
+    }
+
+    private function assertPluralStudly($expected, $value, $count = 2): void
+    {
+        $this->assertSame($expected, Str::pluralStudly($value, $count));
+    }
+}

--- a/src/stringable/tests/PluralizerTest.php
+++ b/src/stringable/tests/PluralizerTest.php
@@ -129,6 +129,12 @@ class PluralizerTest extends TestCase
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
     }
 
+    public function testPluralizerAboutData()
+    {
+        $this->assertSame('datum', Str::singular('data'));
+        $this->assertSame('data', Str::plural('datum'));
+    }
+
     private function assertPluralStudly($expected, $value, $count = 2): void
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));


### PR DESCRIPTION
* 使用 `InflectorFactory::createForLanguage` 生成实例
* 删除了 `Pluralizer::$uncountable` 绝大部分内容 参考：https://github.com/doctrine/inflector/pull/194 
* 增加了 `Pluralizer::useLanguage(string $language): void` 方法
* 向 Str::plural 方法添加了对可计算数值的支持
*  当 `Str::plural` 传入字符串以非字母数字字符结尾，则不将其复数化
