### PR TITLE
Fixed bug that the enum mode cannot work when using `hyperf/constants`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -10,6 +10,10 @@
 - [#6721](https://github.com/hyperf/hyperf/pull/6721) Optimized the implementation of `When` Method.
 - [#6731](https://github.com/hyperf/hyperf/pull/6731) Updated InteractsWithModelFactory to handle missing dependencies.
 
+## Fixed
+
+- [#6728](https://github.com/hyperf/hyperf/pull/6728) Fixed bug that the enum mode cannot work when using `hyperf/constants`.
+
 # v3.1.20 - 2024-04-26
 
 ## Added

--- a/src/watcher/src/Ast/RewriteClassNameVisitor.php
+++ b/src/watcher/src/Ast/RewriteClassNameVisitor.php
@@ -27,7 +27,7 @@ class RewriteClassNameVisitor extends NodeVisitorAbstract
             case $node instanceof Node\Stmt\Namespace_:
                 $this->metadata->namespace = $node->name->toCodeString();
                 return $node;
-            case $node instanceof Node\Stmt\Class_:
+            case $node instanceof Node\Stmt\Class_ || $node instanceof Node\Stmt\Enum_:
                 $className = $node->name->name;
                 $this->metadata->className = $className;
                 return $node;


### PR DESCRIPTION
枚举类注解热启动无效,  枚举类发生变更, meta返回为null 导致只是重启未处理文件

 src/watcher/src/Process.php +52
 ```
 $meta = $this->getMetadata($this->file);
        if ($meta === null) {
            return;
        }
```

src/watcher/src/Process.php 中$meta->isClass 方法中 className 为null  
```
protected function getMetadata(string $file): ?Metadata
    {
        $stmts = $this->ast->parse($this->filesystem->get($file));
        $meta = new Metadata();
        $meta->path = $file;
        $traverser = new NodeTraverser();
        $traverser->addVisitor(new RewriteClassNameVisitor($meta));
        $traverser->traverse($stmts);
        if (! $meta->isClass()) {
            return null;
        }
        return $meta;
    }

```

src/watcher/src/Ast/RewriteClassNameVisitor.php   增加className赋值..