### PR TITLE
Added useIndex,forceIndex,ignoreIndex to Builder

### DIFF
--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -121,6 +121,12 @@ class Builder
     public $forceIndexes = [];
 
     /**
+     * The index hint for the query.
+     * @var IndexHint
+     */
+    public $indexHint;
+
+    /**
      * The table joins for the query.
      *
      * @var array
@@ -419,6 +425,38 @@ class Builder
     public function forceIndexes(array $forceIndexes)
     {
         $this->forceIndexes = $forceIndexes;
+        return $this;
+    }
+
+    /**
+     * Add an index hint to suggest a query index.
+     */
+    public function useIndex(string $index): static
+    {
+        $this->indexHint = new IndexHint('hint', $index);
+
+        return $this;
+    }
+
+    /**
+     * Add an index hint to force a query index.
+     */
+    public function forceIndex(string $index): static
+    {
+        $this->indexHint = new IndexHint('force', $index);
+
+        return $this;
+    }
+
+    /**
+     * Add an index hint to ignore a query index.
+     *
+     * @return $this
+     */
+    public function ignoreIndex(string $index): static
+    {
+        $this->indexHint = new IndexHint('ignore', $index);
+
         return $this;
     }
 

--- a/src/database/src/Query/Grammars/MySqlGrammar.php
+++ b/src/database/src/Query/Grammars/MySqlGrammar.php
@@ -14,6 +14,7 @@ namespace Hyperf\Database\Query\Grammars;
 
 use Hyperf\Collection\Arr;
 use Hyperf\Database\Query\Builder;
+use Hyperf\Database\Query\IndexHint;
 use Hyperf\Database\Query\JsonExpression;
 
 use function Hyperf\Collection\collect;
@@ -40,6 +41,7 @@ class MySqlGrammar extends Grammar
         'limit',
         'offset',
         'lock',
+        'indexHint',
     ];
 
     /**
@@ -191,6 +193,18 @@ class MySqlGrammar extends Grammar
         return array_values(
             array_merge($bindings['join'], Arr::flatten($cleanBindings))
         );
+    }
+
+    /**
+     * Compile the index hints for the query.
+     */
+    protected function compileIndexHint(Builder $query, IndexHint $indexHint): string
+    {
+        return match ($indexHint->type) {
+            'hint' => "use index ({$indexHint->index})",
+            'force' => "force index ({$indexHint->index})",
+            default => "ignore index ({$indexHint->index})",
+        };
     }
 
     /**

--- a/src/database/src/Query/IndexHint.php
+++ b/src/database/src/Query/IndexHint.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Database\Query;
+
+class IndexHint
+{
+    public function __construct(
+        public string $type,
+        public string $index,
+    ) {
+    }
+}

--- a/src/database/tests/DatabaseQueryBuilderTest.php
+++ b/src/database/tests/DatabaseQueryBuilderTest.php
@@ -133,6 +133,44 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "prefix_users"', $builder->toSql());
     }
 
+    public function testUseIndex(): void
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->useIndex('index1');
+        $this->assertSame('select * from `users` use index (index1)', $builder->toSql());
+
+        $builder->select('*')->from('users')->useIndex('index2');
+        $this->assertSame('select * from `users` use index (index2)', $builder->toSql());
+
+        $builder->select('*')->from('users')->useIndex('index1,index2');
+        $this->assertSame('select * from `users` use index (index1,index2)', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder()->select('*')->from('users');
+        $this->assertSame('select * from `users`', $builder->toSql());
+    }
+
+    public function testForceIndex(): void
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->forceIndex('index1');
+        $this->assertSame('select * from `users` force index (index1)', $builder->toSql());
+        $builder->select('*')->from('users')->forceIndex('index2');
+        $this->assertSame('select * from `users` force index (index2)', $builder->toSql());
+        $builder->select('*')->from('users')->forceIndex('index1,index2');
+        $this->assertSame('select * from `users` force index (index1,index2)', $builder->toSql());
+    }
+
+    public function testIgnoreIndex(): void
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->ignoreIndex('index1');
+        $this->assertSame('select * from `users` ignore index (index1)', $builder->toSql());
+        $builder->select('*')->from('users')->ignoreIndex('index2');
+        $this->assertSame('select * from `users` ignore index (index2)', $builder->toSql());
+        $builder->select('*')->from('users')->ignoreIndex('index1,index2');
+        $this->assertSame('select * from `users` ignore index (index1,index2)', $builder->toSql());
+    }
+
     public function testBasicSelectDistinct(): void
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
# 对 Builder 增加 `ignoreIndex` `forceIndex` `useIndex` 等方法

## Usage

```php

$builder->select('*')->from('users')->useIndex('index1');
// select * from `users` use index (index1)

$builder->select('*')->from('users')->useIndex('index1,index2');
// select * from `users` use index (index1,index2)

//... 其他索引操作同上

```