### PR TITLE
[Docs] Add a brief explanation that returning `true` in `isValid` does not stop the exception handler call loop

### DIFF
--- a/src/exception-handler/src/ExceptionHandler.php
+++ b/src/exception-handler/src/ExceptionHandler.php
@@ -29,7 +29,7 @@ abstract class ExceptionHandler
      * an exception, as returning `true` in `isValid` does not stop the handlers call loop.
      *
      * @return bool If return true, then this exception handler will handle the exception and then call the next handler,
-     *              If return false, this handler will be ignored and the next will be called.
+     *              If return false, this handler will be ignored and the next will be called
      */
     abstract public function isValid(Throwable $throwable): bool;
 

--- a/src/exception-handler/src/ExceptionHandler.php
+++ b/src/exception-handler/src/ExceptionHandler.php
@@ -25,9 +25,11 @@ abstract class ExceptionHandler
     /**
      * Determine if the current exception handler should handle the exception.
      *
-     * @return bool
-     *              If return true, then this exception handler will handle the exception,
-     *              If return false, then delegate to next handler
+     * @see ExceptionHandler::stopPropagation() if you want to stop propagation after handling
+     * an exception, as returning `true` in `isValid` does not stop the handlers call loop.
+     *
+     * @return bool If return true, then this exception handler will handle the exception and then call the next handler,
+     *              If return false, this handler will be ignored and the next will be called.
      */
     abstract public function isValid(Throwable $throwable): bool;
 


### PR DESCRIPTION
Hey! 👋 I believe the current documentation for the `isValid` method is kinda too open to interpretation, so I'm adding a few lines to clarify that this is not the guy you want to look at if you intend to build a final exception handler.