### PR TITLE
Support `whereAll/orWhereAll` `whereAny/orWhereAny` for `Hyperf\Database\Query\Builder`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,9 +2,9 @@
 
 ## Added
 
-- [#6767](https://github.com/hyperf/hyperf/pull/6767) Support `whereAll/orWhereAll` `whereAny/orWhereAny` for `Hyperf\Database\Query\Builder`. 
 - [#6757](https://github.com/hyperf/hyperf/pull/6757) Added `Hyperf\Collection\LazyCollection`.
 - [#6763](https://github.com/hyperf/hyperf/pull/6763) Added `Premature end of data` into `DetectsLostConnections`.
+- [#6767](https://github.com/hyperf/hyperf/pull/6767) Support `whereAll/orWhereAll` `whereAny/orWhereAny` for `Hyperf\Database\Query\Builder`.
 
 # v3.1.22 - 2024-05-16
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- [#6767](https://github.com/hyperf/hyperf/pull/6767) Support `whereAll/orWhereAll` `whereAny/orWhereAny` for `Hyperf\Database\Query\Builder`. 
 - [#6757](https://github.com/hyperf/hyperf/pull/6757) Added `Hyperf\Collection\LazyCollection`.
 - [#6763](https://github.com/hyperf/hyperf/pull/6763) Added `Premature end of data` into `DetectsLostConnections`.
 

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -1562,6 +1562,84 @@ class Builder
     }
 
     /**
+     * Add a "where" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param string[] $columns
+     * @param mixed $operator
+     * @param mixed $value
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereAll($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+            foreach ($columns as $column) {
+                $query->where($column, $operator, $value, 'and');
+            }
+        }, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param string[] $columns
+     * @param string $operator
+     * @param mixed $value
+     * @return $this
+     */
+    public function orWhereAll($columns, $operator = null, $value = null)
+    {
+        return $this->whereAll($columns, $operator, $value, 'or');
+    }
+
+    /**
+     * Add an "where" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param string[] $columns
+     * @param string $operator
+     * @param mixed $value
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereAny($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+            foreach ($columns as $column) {
+                $query->where($column, $operator, $value, 'or');
+            }
+        }, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param string[] $columns
+     * @param string $operator
+     * @param mixed $value
+     * @return $this
+     */
+    public function orWhereAny($columns, $operator = null, $value = null)
+    {
+        return $this->whereAny($columns, $operator, $value, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param array|string ...$groups

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -1565,12 +1565,8 @@ class Builder
      * Add a "where" clause to the query for multiple columns with "and" conditions between them.
      *
      * @param string[] $columns
-     * @param mixed $operator
-     * @param mixed $value
-     * @param string $boolean
-     * @return $this
      */
-    public function whereAll($columns, $operator = null, $value = null, $boolean = 'and')
+    public function whereAll(array $columns, mixed $operator = null, mixed $value = null, string $boolean = 'and'): static
     {
         [$value, $operator] = $this->prepareValueAndOperator(
             $value,
@@ -1591,11 +1587,8 @@ class Builder
      * Add an "or where" clause to the query for multiple columns with "and" conditions between them.
      *
      * @param string[] $columns
-     * @param string $operator
-     * @param mixed $value
-     * @return $this
      */
-    public function orWhereAll($columns, $operator = null, $value = null)
+    public function orWhereAll(array $columns, mixed $operator = null, mixed $value = null): static
     {
         return $this->whereAll($columns, $operator, $value, 'or');
     }
@@ -1604,12 +1597,8 @@ class Builder
      * Add an "where" clause to the query for multiple columns with "or" conditions between them.
      *
      * @param string[] $columns
-     * @param string $operator
-     * @param mixed $value
-     * @param string $boolean
-     * @return $this
      */
-    public function whereAny($columns, $operator = null, $value = null, $boolean = 'and')
+    public function whereAny(array $columns, mixed $operator = null, mixed $value = null, string $boolean = 'and'): static
     {
         [$value, $operator] = $this->prepareValueAndOperator(
             $value,
@@ -1630,11 +1619,8 @@ class Builder
      * Add an "or where" clause to the query for multiple columns with "or" conditions between them.
      *
      * @param string[] $columns
-     * @param string $operator
-     * @param mixed $value
-     * @return $this
      */
-    public function orWhereAny($columns, $operator = null, $value = null)
+    public function orWhereAny(array $columns, mixed $operator = null, mixed $value = null): static
     {
         return $this->whereAny($columns, $operator, $value, 'or');
     }

--- a/src/database/tests/DatabaseQueryBuilderTest.php
+++ b/src/database/tests/DatabaseQueryBuilderTest.php
@@ -845,6 +845,68 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['Car,Plane'], $builder->getBindings());
     }
 
+    public function testWhereAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll(['last_name', 'email'], 'not like', '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" not like ? and "email" not like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testOrWhereAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereAll(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testWhereAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testOrWhereAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereAny(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     protected function getBuilder(): Builder
     {
         $grammar = new Grammar();


### PR DESCRIPTION
# Usage

## whereAny

```php
$search = '%keyword%';

// new 
User::query()
      ->whereAny([
          'first_name',
          'last_name',
          'email',
          'phone'
      ], 'LIKE', $search);
// old 
User::query()
      ->where(function ($query) use ($search) {
          $query
              ->where('first_name', 'LIKE', $search)
              ->orWhere('last_name', 'LIKE', $search)
              ->orWhere('email', 'LIKE', $search)
              ->orWhere('phone', 'LIKE', $search);
      })

```

### SQL statment

```sql
SELECT * FROM "users" WHERE (
  "first_name" LIKE "%keyword%" 
  OR "last_name" LIKE "%keyword%" 
  OR "email" LIKE "%keyword%"
)
```

## whereAll

```php
// new 
$search = 'keyword';

User::whereAll([
  'first_name',
  'last_name',
  'email',
], 'LIKE', "%$search%")

// old
User::query()
      ->where(function ($query) use ($search) {
          $query
              ->where('first_name', 'LIKE', $search)
              ->where('last_name', 'LIKE', $search)
              ->where('email', 'LIKE', $search)
              ->where('phone', 'LIKE', $search);
      })

```

### SQL statment

```
SELECT * FROM "users" WHERE (
  "first_name" LIKE "%keyword%" 
  AND "last_name" LIKE "%keyword%" 
  AND "email" LIKE "%keyword%"
)
```
