### PR TITLE
docs(en): update documentations

### DIFF
--- a/docs/en/db/db.md
+++ b/docs/en/db/db.md
@@ -1,6 +1,6 @@
 # Minimalist DB component
 
-[hyperf/database](https://github.com/hyperf/database) The function is very powerful, but it is undeniable that the efficiency is indeed a little insufficient. Here is a minimalist `hyperf/db` component that supports `PDO` and `Swoole Mysql`.
+[hyperf/database](https://github.com/hyperf/database) The function is very powerful, but it is undeniable that the efficiency is indeed a little insufficient. Here is a minimalist `hyperf/db` component.
 
 ## Install
 
@@ -22,7 +22,7 @@ The default configuration `config/autoload/db.php` is as follows, the database s
 
 |  configuration item  |  type  |       default      |                          remark                          |
 |:--------------------:|:------:|:------------------:|:--------------------------------------------------------:|
-|        driver        | string |        none        |       The database engine supports `pdo` and `mysql`     |
+|        driver        | string |        none        |                    The database engine                   |
 |         host         | string |    `localhost`     |                      database address                    |
 |         port         |  int   |        3306        |                      database address                    |
 |       database       | string |        none        |                    Database default DB                   |

--- a/docs/en/db/quick-start.md
+++ b/docs/en/db/quick-start.md
@@ -364,7 +364,7 @@ var_dump(Arr::last(Db::getQueryLog()));
 
 ## Driver list
 
-Different from [illuminate/database](https://github.com/illuminate/database), [hyperf/database](https://github.com/hyperf/database) only provides MySQL driver by default, and currently also provides [PgSQL](https://github.com/hyperf/database-pgsql), [SQLite](https://github.com/hyperf/database-sqlite) and [SQLserver](https://github.com/ hyperf/database-sqlserver-incubator) and other drivers
+Different from [illuminate/database](https://github.com/illuminate/database), [hyperf/database](https://github.com/hyperf/database) only provides MySQL driver by default, and currently also provides [PgSQL](https://github.com/hyperf/database-pgsql), [SQLite](https://github.com/hyperf/database-sqlite) and [SQL Server](https://github.com/hyperf/database-sqlserver-incubator) and other drivers
 If the default mysql cannot meet the usage needs, you can install the corresponding driver yourself.
 
 ### PgSql driver

--- a/docs/en/db/quick-start.md
+++ b/docs/en/db/quick-start.md
@@ -361,3 +361,93 @@ $book = Book::query()->find(1);
 // Print the last SQL query
 var_dump(Arr::last(Db::getQueryLog()));
 ```
+
+## Driver list
+
+Different from [illuminate/database](https://github.com/illuminate/database), [hyperf/database](https://github.com/hyperf/database) only provides MySQL driver by default, and currently also provides [PgSQL](https://github.com/hyperf/database-pgsql), [SQLite](https://github.com/hyperf/database-sqlite) and [SQLserver](https://github.com/ hyperf/database-sqlserver-incubator) and other drivers
+If the default mysql cannot meet the usage needs, you can install the corresponding driver yourself.
+
+### PgSql driver
+
+#### Install
+
+Requires `Swoole >= 5.1.0` and `--enable-swoole-pgsql` is enabled when compiling
+
+```bash
+composer require hyperf/database-pgsql
+```
+
+#### Configuration file
+
+```php
+// config/autoload/databases.php
+return [
+    // Other configurations
+    'pgsql'=> [
+        'driver' => env('DB_DRIVER', 'pgsql'),
+        'host' => env('DB_HOST', 'localhost'),
+        'database' => env('DB_DATABASE', 'hyperf'),
+        'port' => env('DB_PORT', 5432),
+        'username' => env('DB_USERNAME', 'postgres'),
+        'password' => env('DB_PASSWORD'),
+        'charset' => env('DB_CHARSET', 'utf8'),
+    ]
+];
+```
+
+### SQLite driver
+
+#### Install
+
+Requires `Swoole >= 5.1.0` and `--enable-swoole-sqlite` is enabled when compiling
+
+```bash
+composer require hyperf/database-pgsql
+```
+
+#### Configuration file
+
+```php
+// config/autoload/databases.php
+return [
+    // Other configurations
+    'sqlite'=>[
+        'driver' => env('DB_DRIVER', 'sqlite'),
+        'host' => env('DB_HOST', 'localhost'),
+        // :memory: For an in-memory database, you can also specify the absolute path to the file.
+        'database' => env('DB_DATABASE', ':memory:'),
+        // other sqlite config
+    ]
+];
+```
+
+### SQL Server driver
+
+#### Install
+
+> In the incubation stage, we currently cannot guarantee that all functions will work properly. Feedback is welcome.
+
+Requirements `Swoole >= 5.1.0` depends on pdo_odbc, and needs to be enabled during compilation `--with-swoole-odbc`
+
+```bash
+composer require hyperf/database-sqlserver-incubator
+```
+
+#### Configuration file
+
+```php
+// config/autoload/databases.php
+return [
+    // Other configurations
+    'sqlserver' => [
+        'driver' => env('DB_DRIVER', 'sqlsrv'),
+        'host' => env('DB_HOST', 'mssql'),
+        'database' => env('DB_DATABASE', 'hyperf'),
+        'port' => env('DB_PORT', 1443),
+        'username' => env('DB_USERNAME', 'SA'),
+        'password' => env('DB_PASSWORD'),
+        'odbc_datasource_name' => 'DRIVER={ODBC Driver 18 for SQL Server};SERVER=127.0.0.1,1433;TrustServerCertificate=yes;database=hyperf',
+        'odbc'  =>  true,
+    ]
+];
+```

--- a/docs/en/redis.md
+++ b/docs/en/redis.md
@@ -67,8 +67,7 @@ use Hyperf\Context\ApplicationContext;
 
 $container = ApplicationContext::getContainer();
 
-$redis = $this->container->get(\Redis::class);
-
+$redis = $container->get(\Hyperf\Redis\Redis::class);
 $result = $redis->keys('*');
 
 ```

--- a/docs/zh-cn/db/quick-start.md
+++ b/docs/zh-cn/db/quick-start.md
@@ -439,7 +439,9 @@ composer require hyperf/database-sqlserver-incubator
 #### 配置文件
 
 ```php
+// config/autoload/databases.php
 return [
+     // 其他配置
     'sqlserver' => [
         'driver' => env('DB_DRIVER', 'sqlsrv'),
         'host' => env('DB_HOST', 'mssql'),

--- a/docs/zh-hk/db/quick-start.md
+++ b/docs/zh-hk/db/quick-start.md
@@ -439,7 +439,9 @@ composer require hyperf/database-sqlserver-incubator
 #### 配置文件
 
 ```php
+// config/autoload/databases.php
 return [
+     // 其他配置
     'sqlserver' => [
         'driver' => env('DB_DRIVER', 'sqlsrv'),
         'host' => env('DB_HOST', 'mssql'),

--- a/docs/zh-tw/db/quick-start.md
+++ b/docs/zh-tw/db/quick-start.md
@@ -439,7 +439,9 @@ composer require hyperf/database-sqlserver-incubator
 #### 配置檔案
 
 ```php
+// config/autoload/databases.php
 return [
+     // 其他配置
     'sqlserver' => [
         'driver' => env('DB_DRIVER', 'sqlsrv'),
         'host' => env('DB_HOST', 'mssql'),


### PR DESCRIPTION
This PR updates the following documentation:
- `db.md` and `db/quick-start.md` with new updates in [Release v3.1.21](https://github.com/hyperf/hyperf/pull/6742) and [Release v3.1.22](https://github.com/hyperf/hyperf/pull/6759).
- `redis.md` fix wrong code.