### PR TITLE
chore: Update php-cs-fixer configuration to use parallel processing

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfig;
+
 $header = <<<'EOF'
 This file is part of Hyperf.
 
@@ -18,7 +22,10 @@ This file is part of Hyperf.
 @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
 EOF;
 
-return (new PhpCsFixer\Config())
+$maxProcesses = function_exists('swoole_cpu_num') ? swoole_cpu_num() : 4;
+
+return (new Config())
+    ->setParallelConfig(new ParallelConfig($maxProcesses, 20))
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
@@ -99,7 +106,7 @@ return (new PhpCsFixer\Config())
         'single_line_empty_body' => false,
     ])
     ->setFinder(
-        PhpCsFixer\Finder::create()
+        Finder::create()
             ->exclude('bin')
             ->exclude('public')
             ->exclude('runtime')

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,10 @@ parameters:
   level: 5
   bootstrapFiles:
     - "bootstrap.php"
+  parallel:
+    jobSize: 20
+    maximumNumberOfProcesses: 32
+    minimumNumberOfJobsPerProcess: 2
   inferPrivatePropertyTypeFromConstructor: true
   treatPhpDocTypesAsCertain: true
   reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Before

```shell
Fixed 0 of 2845 files in 80.344 seconds, 52.000 MB memory used
composer cs  78.75s user 0.67s system 97% cpu 1:21.13 total
```

After

```shell
Fixed 0 of 2845 files in 18.851 seconds, 28.000 MB memory used
composer cs  117.41s user 1.25s system 605% cpu 19.607 total
```