### PR TITLE
Set the value of `$this` in macro closures

### DIFF
--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -88,6 +88,8 @@ trait Macroable
      *
      * @param string $name
      * @param callable|object $macro
+     *
+     * @param-closure-this static  $macro
      */
     public static function macro($name, $macro)
     {

--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -89,7 +89,7 @@ trait Macroable
      * @param string $name
      * @param callable|object $macro
      *
-     * @param-closure-this static  $macro
+     * @param-closure-this static $macro
      */
     public static function macro($name, $macro)
     {


### PR DESCRIPTION
See: https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot#what-is-a-passed-closure-bound-to%3F