### PR TITLE
add setRoot and getRootId to Context class

### DIFF
--- a/src/context/src/Context.php
+++ b/src/context/src/Context.php
@@ -123,4 +123,22 @@ class Context
 
         return static::$nonCoContext;
     }
+
+    public static function setRoot(): void
+    {
+        Coroutine::getContextFor()->offsetSet('#root', true);
+    }
+
+    public static function getRootId(): int
+    {
+        $cid = Coroutine::id();
+        while (!Coroutine::getContextFor($cid)->offsetExists('#root')) {
+            $cid = Coroutine::pid($cid);
+            if ($cid < 1) {
+                break;
+            }
+        }
+
+        return $cid;
+    }
 }


### PR DESCRIPTION
- 使用方法
1. 定义一个Middleware，执行 `Hyperf\Context\Context::setRoot()`
2. 在任意子协程中使用 `Context::get(ServerRequestInterface::class, null, Context::getRootId())`即可获得request对象

- 说明
移植自think-swoole

- 优势
相比biz-skeleton的copy方案，这个要简单得多，不需要重新定义Coroutine，也不需要为子协程注入key