### PR TITLE
Support some methods to `\Hyperf\Collection\Arr`

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -5,6 +5,7 @@
 - [#6757](https://github.com/hyperf/hyperf/pull/6757) Added `Hyperf\Collection\LazyCollection`.
 - [#6763](https://github.com/hyperf/hyperf/pull/6763) Added `Premature end of data` into `DetectsLostConnections`.
 - [#6767](https://github.com/hyperf/hyperf/pull/6767) Support `whereAll/orWhereAll` `whereAny/orWhereAny` for `Hyperf\Database\Query\Builder`.
+- [#6781](https://github.com/hyperf/hyperf/pull/6781) Added some methods to `Hyperf\Collection\Arr`.
 
 ## Optimized
 

--- a/src/collection/composer.json
+++ b/src/collection/composer.json
@@ -19,7 +19,8 @@
         "php": ">=8.1",
         "hyperf/conditionable": "~3.1.0",
         "hyperf/contract": "~3.1.0",
-        "hyperf/macroable": "~3.1.0"
+        "hyperf/macroable": "~3.1.0",
+        "hyperf/stringable": "~3.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 
 namespace Hyperf\Collection;
 
+use ArgumentCountError;
 use ArrayAccess;
 use Hyperf\Macroable\Macroable;
+use Hyperf\Stringable\Str;
 use InvalidArgumentException;
 
 /**
@@ -500,18 +502,19 @@ class Arr
 
     /**
      * Recursively sort an array by keys and values.
+     * @param mixed $descending
      */
-    public static function sortRecursive(array $array): array
+    public static function sortRecursive(array $array, int $options = SORT_REGULAR, $descending = false): array
     {
         foreach ($array as &$value) {
             if (is_array($value)) {
-                $value = static::sortRecursive($value);
+                $value = static::sortRecursive($value, $options, $descending);
             }
         }
         if (static::isAssoc($array)) {
-            ksort($array);
+            $descending ? krsort($array, $options) : ksort($array, $options);
         } else {
-            sort($array);
+            $descending ? rsort($array, $options) : sort($array, $options);
         }
         return $array;
     }
@@ -623,6 +626,163 @@ class Arr
             static::set($result, $key, $value);
         }
         return $result;
+    }
+
+    /**
+     * Conditionally compile classes from an array into a CSS class list.
+     */
+    public static function toCssClasses(array $array): string
+    {
+        $classList = static::wrap($array);
+
+        $classes = [];
+
+        foreach ($classList as $class => $constraint) {
+            if (is_numeric($class)) {
+                $classes[] = $constraint;
+            } elseif ($constraint) {
+                $classes[] = $class;
+            }
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Conditionally compile styles from an array into a style list.
+     */
+    public static function toCssStyles(array $array): string
+    {
+        $styleList = static::wrap($array);
+
+        $styles = [];
+
+        foreach ($styleList as $class => $constraint) {
+            if (is_numeric($class)) {
+                $styles[] = Str::finish($constraint, ';');
+            } elseif ($constraint) {
+                $styles[] = Str::finish($class, ';');
+            }
+        }
+
+        return implode(' ', $styles);
+    }
+
+    /**
+     * Join all items using a string. The final items can use a separate glue string.
+     */
+    public static function join(array $array, string $glue, string $finalGlue = ''): string
+    {
+        if ($finalGlue === '') {
+            return implode($glue, $array);
+        }
+
+        if (count($array) === 0) {
+            return '';
+        }
+
+        if (count($array) === 1) {
+            return end($array);
+        }
+
+        $finalItem = array_pop($array);
+
+        return implode($glue, $array) . $finalGlue . $finalItem;
+    }
+
+    /**
+     * Key an associative array by a field or using a callback.
+     */
+    public static function keyBy(array $array, array|callable|string $keyBy): array
+    {
+        return Collection::make($array)->keyBy($keyBy)->all();
+    }
+
+    /**
+     * Prepend the key names of an associative array.
+     */
+    public static function prependKeysWith(array $array, string $prependWith): array
+    {
+        return static::mapWithKeys($array, fn ($item, $key) => [$prependWith . $key => $item]);
+    }
+
+    /**
+     * Select an array of values from an array.
+     */
+    public static function select(array $array, array|string $keys): array
+    {
+        $keys = static::wrap($keys);
+
+        return static::map($array, static function ($item) use ($keys) {
+            $result = [];
+
+            foreach ($keys as $key) {
+                if (Arr::accessible($item) && Arr::exists($item, $key)) {
+                    $result[$key] = $item[$key];
+                } elseif (is_object($item) && isset($item->{$key})) {
+                    $result[$key] = $item->{$key};
+                }
+            }
+
+            return $result;
+        });
+    }
+
+    /**
+     * Run a map over each nested chunk of items.
+     *
+     * @template TMapSpreadValue
+     *
+     * @param callable(mixed...): TMapSpreadValue $callback
+     * @return array<TKey, TMapSpreadValue>
+     */
+    public static function mapSpread(array $array, callable $callback): array
+    {
+        return static::map($array, function ($chunk, $key) use ($callback) {
+            $chunk[] = $key;
+
+            return $callback(...$chunk);
+        });
+    }
+
+    /**
+     * Run a map over each of the items in the array.
+     */
+    public static function map(array $array, callable $callback): array
+    {
+        $keys = array_keys($array);
+
+        try {
+            $items = array_map($callback, $array, $keys);
+        } catch (ArgumentCountError) {
+            $items = array_map($callback, $array);
+        }
+
+        return array_combine($keys, $items);
+    }
+
+    /**
+     * Sort the array in descending order using the given callback or "dot" notation.
+     */
+    public static function sortDesc(array $array, null|array|callable|string $callback = null): array
+    {
+        return Collection::make($array)->sortByDesc($callback)->all();
+    }
+
+    /**
+     * Recursively sort an array by keys and values in descending order.
+     */
+    public static function sortRecursiveDesc(array $array, int $options = SORT_REGULAR): array
+    {
+        return static::sortRecursive($array, $options, true);
+    }
+
+    /**
+     * Filter items where the value is not null.
+     */
+    public static function whereNotNull(array $array): array
+    {
+        return static::where($array, static fn ($value) => ! is_null($value));
     }
 
     /**

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -19,6 +19,9 @@ use Hyperf\Stringable\Str;
 use InvalidArgumentException;
 
 /**
+ * @template TKey of array-key
+ * @template TValue
+ *
  * Most of the methods in this file come from illuminate/collections,
  * thanks Laravel Team provide such a useful class.
  */
@@ -329,8 +332,6 @@ class Arr
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @template TKey
-     * @template TValue
      * @template TMapWithKeysKey of array-key
      * @template TMapWithKeysValue
      *
@@ -388,9 +389,6 @@ class Arr
 
     /**
      * Push an item onto the beginning of an array.
-     *
-     * @template TKey of array-key
-     * @template TValue
      *
      * @param array<TKey, TValue> $array
      * @param null|TKey $key

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -502,9 +502,8 @@ class Arr
 
     /**
      * Recursively sort an array by keys and values.
-     * @param mixed $descending
      */
-    public static function sortRecursive(array $array, int $options = SORT_REGULAR, $descending = false): array
+    public static function sortRecursive(array $array, int $options = SORT_REGULAR, bool $descending = false): array
     {
         foreach ($array as &$value) {
             if (is_array($value)) {

--- a/src/collection/tests/ArrTest.php
+++ b/src/collection/tests/ArrTest.php
@@ -371,4 +371,280 @@ class ArrTest extends TestCase
 
         $this->assertSame($data, Arr::undot($dotData));
     }
+
+    public function testToCssClasses(): void
+    {
+        $this->assertSame('foo bar', Arr::toCssClasses(['foo', 'bar']));
+        $this->assertSame('foo bar', Arr::toCssClasses(['foo' => true, 'bar' => true]));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => false]));
+        $this->assertSame('foo', Arr::toCssClasses(['foo', 'bar' => false]));
+        $this->assertSame('foo bar', Arr::toCssClasses(['foo' => true, 'bar']));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => null]));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => '']));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => 0]));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => '0']));
+        $this->assertSame('foo', Arr::toCssClasses(['foo' => true, 'bar' => []]));
+        $this->assertSame('foo bar', Arr::toCssClasses(['foo' => true, 'bar' => 'baz']));
+        $this->assertSame('foo bar', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => false]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => false]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => null]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => '']));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => 0]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => '0']));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => []]));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => '0', 'quux' => '0']));
+        $this->assertSame('foo bar baz', Arr::toCssClasses(['foo' => true, 'bar' => 'baz', 'baz' => true, 'qux' => '0', 'quux' => '0', 'quuz' => '0']));
+    }
+
+    public function testToCssStyles(): void
+    {
+        $this->assertSame('color: red; background-color: blue;', Arr::toCssStyles([
+            'color: red' => true,
+            'background-color: blue' => true,
+        ]));
+        $this->assertSame('color: red;', Arr::toCssStyles([
+            'color: red' => true,
+            'background-color: blue' => false,
+        ]));
+        $stylesArray = [
+            'margin: 0 auto' => true,
+            'padding: 10px' => true,
+            'display: block' => true,
+            'color' => false,
+        ];
+        $expectedCss = 'margin: 0 auto; padding: 10px; display: block;';
+        $this->assertSame($expectedCss, Arr::toCssStyles($stylesArray));
+        $numericArray = [
+            'font-size: 12px' => true,
+            'color: #000000' => true,
+            0 => 'width: 100%',
+            1 => 'height: 100%',
+        ];
+        $expectedNumericCss = 'font-size: 12px; color: #000000; width: 100%; height: 100%;';
+        $this->assertSame($expectedNumericCss, Arr::toCssStyles($numericArray));
+        $expectedCss = 'margin: 0 auto; padding: 10px; display: block; font-size: 12px; color: #000000; width: 100%; height: 100%;';
+        $this->assertSame($expectedCss, Arr::toCssStyles(array_merge($stylesArray, $numericArray)));
+    }
+
+    public function testJoin(): void
+    {
+        $this->assertSame('', Arr::join([], ','), 'Join with empty array should return an empty string.');
+        $this->assertSame('item1', Arr::join(['item1'], ','), 'Join with single element array should return the element itself.');
+        $array = ['item1', 'item2', 'item3'];
+        $this->assertSame('item1,item2,item3', Arr::join($array, ','), 'Join with multiple elements and default glue.');
+        $array = ['item1', 'item2', 'item3'];
+        $this->assertSame('item1|item2|item3', Arr::join($array, '|'), 'Join with multiple elements and custom glue.');
+        $array = ['item1', 'item2', 'item3'];
+        $this->assertSame('item1,item2 and item3', Arr::join($array, ',', ' and '), 'Join with multiple elements, default glue, and custom final glue.');
+        $array = ['item1'];
+        $this->assertSame('item1', Arr::join($array, ',', ' and '), 'Join with single element and custom final glue should ignore the final glue.');
+        $array = ['', ''];
+        $this->assertSame(',', Arr::join($array, ','), 'Join with array of empty strings should return an empty string.');
+        $array = [1, 'item2', 3.0];
+        $this->assertSame('1,item2,3', Arr::join($array, ','), 'Join should handle different data types correctly.');
+    }
+
+    public function testKeyBy(): void
+    {
+        $array = [
+            ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
+            ['id' => 3, 'name' => 'Charlie'],
+        ];
+        $expected = [
+            1 => ['id' => 1, 'name' => 'Alice'],
+            2 => ['id' => 2, 'name' => 'Bob'],
+            3 => ['id' => 3, 'name' => 'Charlie'],
+        ];
+        $result = Arr::keyBy($array, 'id');
+        $this->assertEquals($expected, $result);
+
+        $array = [
+            ['product_id' => 101, 'name' => 'Apple'],
+            ['product_id' => 102, 'name' => 'Banana'],
+            ['product_id' => 103, 'name' => 'Cherry'],
+        ];
+        $expected = [
+            101 => ['product_id' => 101, 'name' => 'Apple'],
+            102 => ['product_id' => 102, 'name' => 'Banana'],
+            103 => ['product_id' => 103, 'name' => 'Cherry'],
+        ];
+        $result = Arr::keyBy($array, function ($item) {
+            return $item['product_id'];
+        });
+        $this->assertEquals($expected, $result);
+        $array = [
+            ['employee_id' => 1001, 'first_name' => 'John', 'last_name' => 'Doe'],
+            ['employee_id' => 1002, 'first_name' => 'Jane', 'last_name' => 'Smith'],
+            ['employee_id' => 1003, 'first_name' => 'Jim', 'last_name' => 'Beam'],
+        ];
+        $expected = [
+            1001 => ['employee_id' => 1001, 'first_name' => 'John', 'last_name' => 'Doe'],
+            1002 => ['employee_id' => 1002, 'first_name' => 'Jane', 'last_name' => 'Smith'],
+            1003 => ['employee_id' => 1003, 'first_name' => 'Jim', 'last_name' => 'Beam'],
+        ];
+        $result = Arr::keyBy($array, 'employee_id');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testPrependKeysWith(): void
+    {
+        $array1 = ['name' => 'Alice', 'age' => 25];
+        $expected1 = ['user_name' => 'Alice', 'user_age' => 25];
+        $this->assertEquals($expected1, Arr::prependKeysWith($array1, 'user_'));
+
+        $array2 = [];
+        $expected2 = [];
+        $this->assertEquals($expected2, Arr::prependKeysWith($array2, 'user_'));
+
+        $array3 = ['name' => 'Bob'];
+        $expected3 = ['name' => 'Bob'];
+        $this->assertEquals($expected3, Arr::prependKeysWith($array3, ''));
+
+        $array4 = ['details' => ['name' => 'Charlie']];
+        $expected4 = ['user_details' => ['name' => 'Charlie']];
+        $this->assertEquals($expected4, Arr::prependKeysWith($array4, 'user_'));
+
+        $object = new stdClass();
+        $object->name = 'David';
+        $array5 = ['person' => $object];
+        $expected5 = ['user_person' => $object];
+        $this->assertEquals($expected5, Arr::prependKeysWith($array5, 'user_'));
+    }
+
+    public function testSelect()
+    {
+        $array = [
+            [
+                'name' => 'Taylor',
+                'role' => 'Developer',
+                'age' => 1,
+            ],
+            [
+                'name' => 'Abigail',
+                'role' => 'Infrastructure',
+                'age' => 2,
+            ],
+        ];
+
+        $this->assertEquals([
+            [
+                'name' => 'Taylor',
+                'age' => 1,
+            ],
+            [
+                'name' => 'Abigail',
+                'age' => 2,
+            ],
+        ], Arr::select($array, ['name', 'age']));
+
+        $this->assertEquals([
+            [
+                'name' => 'Taylor',
+            ],
+            [
+                'name' => 'Abigail',
+            ],
+        ], Arr::select($array, 'name'));
+    }
+
+    public function testMapSpread(): void
+    {
+        $c = [[1, 'a'], [2, 'b']];
+
+        $result = Arr::mapSpread($c, static function ($number, $character) {
+            return "{$number}-{$character}";
+        });
+        $this->assertEquals(['1-a', '2-b'], $result);
+
+        $result = Arr::mapSpread($c, static function ($number, $character, $key) {
+            return "{$number}-{$character}-{$key}";
+        });
+        $this->assertEquals(['1-a-0', '2-b-1'], $result);
+    }
+
+    public function testSortDesc(): void
+    {
+        $unsorted = [
+            ['name' => 'Chair'],
+            ['name' => 'Desk'],
+        ];
+
+        $expected = [
+            ['name' => 'Desk'],
+            ['name' => 'Chair'],
+        ];
+
+        $sorted = array_values(Arr::sortDesc($unsorted));
+        $this->assertEquals($expected, $sorted);
+
+        // sort with closure
+        $sortedWithClosure = array_values(Arr::sortDesc($unsorted, function ($value) {
+            return $value['name'];
+        }));
+        $this->assertEquals($expected, $sortedWithClosure);
+
+        // sort with dot notation
+        $sortedWithDotNotation = array_values(Arr::sortDesc($unsorted, 'name'));
+        $this->assertEquals($expected, $sortedWithDotNotation);
+    }
+
+    public function testSortRecursive(): void
+    {
+        $array = [
+            'users' => [
+                [
+                    // should sort associative arrays by keys
+                    'name' => 'joe',
+                    'mail' => 'joe@example.com',
+                    // should sort deeply nested arrays
+                    'numbers' => [2, 1, 0],
+                ],
+                [
+                    'name' => 'jane',
+                    'age' => 25,
+                ],
+            ],
+            'repositories' => [
+                // should use weird `sort()` behavior on arrays of arrays
+                ['id' => 1],
+                ['id' => 0],
+            ],
+            // should sort non-associative arrays by value
+            20 => [2, 1, 0],
+            30 => [
+                // should sort non-incrementing numerical keys by keys
+                2 => 'a',
+                1 => 'b',
+                0 => 'c',
+            ],
+        ];
+
+        $expect = [
+            20 => [0, 1, 2],
+            30 => [
+                0 => 'c',
+                1 => 'b',
+                2 => 'a',
+            ],
+            'repositories' => [
+                ['id' => 0],
+                ['id' => 1],
+            ],
+            'users' => [
+                [
+                    'age' => 25,
+                    'name' => 'jane',
+                ],
+                [
+                    'mail' => 'joe@example.com',
+                    'name' => 'joe',
+                    'numbers' => [0, 1, 2],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expect, Arr::sortRecursive($array));
+    }
 }


### PR DESCRIPTION
This pr adds the following methods to `\Hyperf\Collection\Arr`

- toCssClasses
- toCssStyles
- join
- keyBy
- prependKeysWith
- select
- mapSpread
- map
- sortDesc
- sortRecursiveDesc
- whereNotNull