### PR TITLE
Added config `rate_limit.storage.options.expired_time` for `rate-limit`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -8,6 +8,7 @@
 
 - [#6792](https://github.com/hyperf/hyperf/pull/6792) Support `IncrementEach` and `DecrementEach` for `Hyperf\Database\Query\Builder`.
 - [#6793](https://github.com/hyperf/hyperf/pull/6793) Added the request body and response body to the tracer.
+- [#6795](https://github.com/hyperf/hyperf/pull/6795) Added config `rate_limit.storage.options.expired_time` for `rate-limit`.
 
 ## Optimized
 

--- a/src/rate-limit/publish/rate_limit.php
+++ b/src/rate-limit/publish/rate_limit.php
@@ -21,7 +21,7 @@ return [
         'class' => RedisStorage::class,
         'options' => [
             'pool' => 'default',
-            'expire' => 0,
+            'expired_time' => 0,
         ],
     ],
 ];

--- a/src/rate-limit/publish/rate_limit.php
+++ b/src/rate-limit/publish/rate_limit.php
@@ -21,6 +21,7 @@ return [
         'class' => RedisStorage::class,
         'options' => [
             'pool' => 'default',
+            'expire' => 0,
         ],
     ],
 ];

--- a/src/rate-limit/src/Storage/RedisStorage.php
+++ b/src/rate-limit/src/Storage/RedisStorage.php
@@ -38,11 +38,14 @@ class RedisStorage implements Storage, GlobalScope, StorageInterface
 
     private Redis $redis;
 
+    private array $options;
+
     public function __construct(protected ContainerInterface $container, string $key, $timeout = 0, array $options = [])
     {
         $this->redis = $container->get(RedisFactory::class)->get(
             $options['pool'] ?? 'default'
         );
+        $this->options = $options;
         $this->key = self::KEY_PREFIX . $key;
         $this->mutex = make(PHPRedisMutex::class, [
             'redisAPIs' => [$this->redis],
@@ -88,6 +91,9 @@ class RedisStorage implements Storage, GlobalScope, StorageInterface
 
             if (! $this->redis->set($this->key, $data)) {
                 throw new StorageException('Failed to store microtime');
+            }
+            if (! empty($this->options['expire'])) {
+                $this->redis->expire($this->key, $this->options['expire']);
             }
         } catch (InvalidArgumentException $e) {
             throw new StorageException('Failed to store microtime', 0, $e);

--- a/src/rate-limit/src/Storage/RedisStorage.php
+++ b/src/rate-limit/src/Storage/RedisStorage.php
@@ -92,8 +92,8 @@ class RedisStorage implements Storage, GlobalScope, StorageInterface
             if (! $this->redis->set($this->key, $data)) {
                 throw new StorageException('Failed to store microtime');
             }
-            if (! empty($this->options['expire']) && $this->options['expire'] > 0) {
-                $this->redis->expire($this->key, $this->options['expire']);
+            if (! empty($this->options['expired_time']) && $this->options['expired_time'] > 0) {
+                $this->redis->expire($this->key, $this->options['expired_time']);
             }
         } catch (InvalidArgumentException $e) {
             throw new StorageException('Failed to store microtime', 0, $e);

--- a/src/rate-limit/src/Storage/RedisStorage.php
+++ b/src/rate-limit/src/Storage/RedisStorage.php
@@ -92,7 +92,7 @@ class RedisStorage implements Storage, GlobalScope, StorageInterface
             if (! $this->redis->set($this->key, $data)) {
                 throw new StorageException('Failed to store microtime');
             }
-            if (! empty($this->options['expire'])) {
+            if (! empty($this->options['expire']) && $this->options['expire'] > 0) {
                 $this->redis->expire($this->key, $this->options['expire']);
             }
         } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
限流的 key未设置过期的时间，导致redis存在很多永久的key，加个参数`expire`在有需要场景下使用