### PR TITLE
Fixed bug that cannot read the messages from non-lower keys for `Hyperf\Constants\Annotation\Message`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,10 @@
 
 - [#6811](https://github.com/hyperf/hyperf/pull/6811) Added `list` rule for `hyperf/validation`.
 
+## Fixed
+
+- [#6813](https://github.com/hyperf/hyperf/pull/6813) Fixed bug that cannot read the messages from non-lower keys for `Hyperf\Constants\Annotation\Message`.
+
 # v3.1.24 - 2024-05-30
 
 ## Fixed

--- a/src/constants/src/Annotation/Message.php
+++ b/src/constants/src/Annotation/Message.php
@@ -20,4 +20,9 @@ class Message
     public function __construct(public string $value, public string $key = 'message')
     {
     }
+
+    public function getLowerCaseKey(): string
+    {
+        return strtolower(str_replace('_', '', $this->key));
+    }
 }

--- a/src/constants/src/AnnotationReader.php
+++ b/src/constants/src/AnnotationReader.php
@@ -41,7 +41,7 @@ class AnnotationReader
             foreach ($classConstant->getAttributes() as $ref) {
                 $attribute = $ref->newInstance();
                 if ($attribute instanceof Message) {
-                    $result[$code][$attribute->key] = $attribute->value;
+                    $result[$code][$attribute->getLowerCaseKey()] = $attribute->value;
                 }
             }
         }

--- a/src/constants/tests/AnnotationReaderTest.php
+++ b/src/constants/tests/AnnotationReaderTest.php
@@ -51,6 +51,11 @@ class AnnotationReaderTest extends TestCase
         $data = $reader->getAnnotations($classConstants);
         ConstantsCollector::set(WarnCode::class, $data);
 
+        $ref = new ReflectionClass(MessageMoreCaseKey::class);
+        $classConstants = $ref->getReflectionConstants();
+        $data = $reader->getAnnotations($classConstants);
+        ConstantsCollector::set(MessageMoreCaseKey::class, $data);
+
         Context::set(sprintf('%s::%s', TranslatorInterface::class, 'locale'), null);
     }
 

--- a/src/constants/tests/AnnotationReaderTest.php
+++ b/src/constants/tests/AnnotationReaderTest.php
@@ -22,6 +22,7 @@ use Hyperf\Translation\ArrayLoader;
 use Hyperf\Translation\Translator;
 use HyperfTest\Constants\Stub\CannotNewInstance;
 use HyperfTest\Constants\Stub\ErrorCodeStub;
+use HyperfTest\Constants\Stub\MessageMoreCaseKey;
 use HyperfTest\Constants\Stub\WarnCode;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -153,6 +154,17 @@ class AnnotationReaderTest extends TestCase
 
         $this->expectExceptionMessage('Attribute class "HyperfTest\Constants\Stub\NotFound" not found');
         $data = $reader->getAnnotations($classConstants);
+    }
+
+    public function testMessageMoreCaseKey()
+    {
+        $this->getContainer(true);
+
+        $this->assertSame('snake key value', MessageMoreCaseKey::FOO->getSnakeKey());
+        $this->assertSame('snake key1 value', MessageMoreCaseKey::FOO->getSnakeKey1());
+        $this->assertSame('camel case value', MessageMoreCaseKey::FOO->getCamelCase());
+        $this->assertSame('big camel case value', MessageMoreCaseKey::FOO->getBigCamel());
+        $this->assertSame('value of lowercase key', MessageMoreCaseKey::FOO->getLowercaseValue());
     }
 
     protected function getContainer($has = false)

--- a/src/constants/tests/Stub/MessageMoreCaseKey.php
+++ b/src/constants/tests/Stub/MessageMoreCaseKey.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Constants\Stub;
+
+use Hyperf\Constants\Annotation\Constants;
+use Hyperf\Constants\Annotation\Message;
+
+/**
+ * @method string getSnakeKey()
+ * @method string getSnakeKey1()
+ * @method string getCamelCase()
+ * @method string getBigCamel()
+ * @method string getLowercaseValue()
+ */
+#[Constants]
+enum MessageMoreCaseKey
+{
+    #[Message('snake key value', 'snake_key')]
+    #[Message('snake key1 value', 'snake_key_1')]
+    #[Message('camel case value', 'camelCase')]
+    #[Message('big camel case value', 'BigCamel')]
+    #[Message('value of lowercase key', 'lowercasevalue')]
+    case FOO;
+}

--- a/src/constants/tests/Stub/MessageMoreCaseKey.php
+++ b/src/constants/tests/Stub/MessageMoreCaseKey.php
@@ -14,6 +14,7 @@ namespace HyperfTest\Constants\Stub;
 
 use Hyperf\Constants\Annotation\Constants;
 use Hyperf\Constants\Annotation\Message;
+use Hyperf\Constants\EnumConstantsTrait;
 
 /**
  * @method string getSnakeKey()
@@ -25,6 +26,8 @@ use Hyperf\Constants\Annotation\Message;
 #[Constants]
 enum MessageMoreCaseKey
 {
+    use EnumConstantsTrait;
+
     #[Message('snake key value', 'snake_key')]
     #[Message('snake key1 value', 'snake_key_1')]
     #[Message('camel case value', 'camelCase')]


### PR DESCRIPTION
feat: support more case key for Message Annotation
https://github.com/hyperf/hyperf/issues/6812