### PR TITLE
feat: Add aliases support to RpcService annotation

### DIFF
--- a/src/rpc-server/src/Annotation/RpcService.php
+++ b/src/rpc-server/src/Annotation/RpcService.php
@@ -22,7 +22,8 @@ class RpcService extends AbstractAnnotation
         public string $name = '',
         public string $server = 'jsonrpc-http',
         public string $protocol = 'jsonrpc-http',
-        public string $publishTo = ''
+        public string $publishTo = '',
+        public array|string $aliases = ''
     ) {
     }
 }

--- a/src/rpc-server/src/Router/DispatcherFactory.php
+++ b/src/rpc-server/src/Router/DispatcherFactory.php
@@ -100,8 +100,8 @@ class DispatcherFactory
         array $middlewares = []
     ): void {
         $prefix = $annotation->name ?: $className;
+        $aliases = $annotation->aliases;
         $router = $this->getRouter($annotation->server);
-
         $publicMethods = ReflectionManager::reflectClass($className)->getMethods(ReflectionMethod::IS_PUBLIC);
 
         foreach ($publicMethods as $reflectionMethod) {
@@ -114,6 +114,13 @@ class DispatcherFactory
                 $className,
                 $methodName,
             ]);
+
+            foreach ((array) $aliases as $alias) {
+                $router->addRoute($this->pathGenerator->generate($alias, $methodName), [
+                    $className,
+                    $methodName,
+                ]);
+            }
 
             $methodMiddlewares = $middlewares;
             // Handle method level middlewares.


### PR DESCRIPTION
```php
#[RpcService(name:'foo')]
```

因为某些原因，需要更换 name

```php
#[RpcService(name:'bar', aliases:'foo')] # 兼容原来的 foo
```