### PR TITLE
add snowflake redis heartbeat

### DIFF
--- a/src/snowflake/src/MetaGenerator/RedisMetaGenerator.php
+++ b/src/snowflake/src/MetaGenerator/RedisMetaGenerator.php
@@ -12,18 +12,26 @@ declare(strict_types=1);
 
 namespace Hyperf\Snowflake\MetaGenerator;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Coroutine\Locker;
 use Hyperf\Redis\RedisProxy;
 use Hyperf\Snowflake\ConfigurationInterface;
 use Hyperf\Snowflake\MetaGenerator;
 use Redis;
+use Throwable;
 
 use function Hyperf\Support\make;
 
 abstract class RedisMetaGenerator extends MetaGenerator
 {
     public const DEFAULT_REDIS_KEY = 'hyperf:snowflake:workerId';
+
+    public const REDIS_EXPIRE = 60 * 60;
 
     protected ?int $workerId = null;
 
@@ -65,17 +73,52 @@ abstract class RedisMetaGenerator extends MetaGenerator
     {
         if (is_null($this->workerId) || is_null($this->dataCenterId)) {
             $pool = $this->config->get(sprintf('snowflake.%s.pool', static::class), 'default');
-
-            /** @var Redis $redis */
-            $redis = make(RedisProxy::class, [
-                'pool' => $pool,
-            ]);
-
             $key = $this->config->get(sprintf('snowflake.%s.key', static::class), static::DEFAULT_REDIS_KEY);
-            $id = $redis->incr($key);
 
-            $this->workerId = $id % $this->configuration->maxWorkerId();
-            $this->dataCenterId = intval($id / $this->configuration->maxWorkerId()) % $this->configuration->maxDataCenterId();
+            $this->setDataCenterIdAndWorkerId($key, $pool);
         }
+    }
+
+    private function setDataCenterIdAndWorkerId(string $key, string $pool): void
+    {
+        /** @var Redis $redis */
+        $redis = make(RedisProxy::class, [
+            'pool' => $pool,
+        ]);
+
+        $id = $redis->incr($key);
+
+        $workerId = $id % $this->configuration->maxWorkerId();
+        $dataCenterId = intval($id / $this->configuration->maxWorkerId()) % $this->configuration->maxDataCenterId();
+
+        $workerIdDataCenterIdKey = sprintf('%s:%d_%d', $key, $workerId, $dataCenterId);
+        $result = $redis->set($workerIdDataCenterIdKey, date('Y-m-d H:i:s'), ['NX', 'PX' => static::REDIS_EXPIRE * 1000]);
+        if ($result === false) {
+            $this->setDataCenterIdAndWorkerId($key, $pool);
+        } else {
+            $this->workerId = $workerId;
+            $this->dataCenterId = $dataCenterId;
+            $this->heartbeat($workerIdDataCenterIdKey, $pool);
+        }
+    }
+
+    private function heartbeat(string $workerIdDataCenterIdKey, $pool): void
+    {
+        Coroutine::create(function () use ($workerIdDataCenterIdKey, $pool) {
+            while (true) {
+                if (CoordinatorManager::until(Constants::WORKER_EXIT)->yield(5 * 60)) {
+                    break;
+                }
+                try {
+                    /** @var Redis $redis */
+                    $redis = make(RedisProxy::class, [
+                        'pool' => $pool,
+                    ]);
+                    $redis->set($workerIdDataCenterIdKey, date('Y-m-d H:i:s'), ['PX' => static::REDIS_EXPIRE * 1000]);
+                } catch (Throwable $throwable) {
+                    ApplicationContext::getContainer()?->get(StdoutLoggerInterface::class)?->error($throwable);
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
在一些情况, 记录工作机器 ID 可能会重复

redis的 hyperf:snowflake:workerId的值是自增的
例: 值等于1 或 962

根据算法
生成出来的 workerId 和 dataCenterId 相同,都等于 1  , 0

避免这种情况, 增加心跳和判重处理 