### PR TITLE
Optimized the return type of `Collection::groupBy` to `self|static`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.26 - TBD
 
+## Optimized
+
+- [#6841](https://github.com/hyperf/hyperf/pull/6841) Optimized the return type of `Collection::groupBy` to `self|static`.
+
 ## Added
 
 - [#6837](https://github.com/hyperf/hyperf/pull/6837) Added method `Model\Concerns\QueriesRelationships::withWhereHas()`.

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -459,7 +459,7 @@ class Collection implements Enumerable, ArrayAccess
      * Group an associative array by a field or using a callback.
      * @param mixed $groupBy
      */
-    public function groupBy($groupBy, bool $preserveKeys = false): static
+    public function groupBy($groupBy, bool $preserveKeys = false): static|self
     {
         if (is_array($groupBy)) {
             $nextGroups = $groupBy;

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -459,7 +459,7 @@ class Collection implements Enumerable, ArrayAccess
      * Group an associative array by a field or using a callback.
      * @param mixed $groupBy
      */
-    public function groupBy($groupBy, bool $preserveKeys = false): static|self
+    public function groupBy($groupBy, bool $preserveKeys = false): self|static
     {
         if (is_array($groupBy)) {
             $nextGroups = $groupBy;

--- a/src/collection/src/Enumerable.php
+++ b/src/collection/src/Enumerable.php
@@ -504,7 +504,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param array|(callable(TValue, TKey): array-key)|string $groupBy
      * @return static<array-key, static<array-key, TValue>>
      */
-    public function groupBy($groupBy, bool $preserveKeys = false);
+    public function groupBy($groupBy, bool $preserveKeys = false): self|static;
 
     /**
      * Key an associative array by a field or using a callback.

--- a/src/collection/src/LazyCollection.php
+++ b/src/collection/src/LazyCollection.php
@@ -538,7 +538,7 @@ class LazyCollection implements Enumerable
      * @param array|(callable(TValue, TKey): array-key)|string $groupBy
      * @return static<array-key, static<array-key, TValue>>
      */
-    public function groupBy($groupBy, bool $preserveKeys = false)
+    public function groupBy($groupBy, bool $preserveKeys = false): self|static
     {
         return $this->passthru('groupBy', func_get_args());
     }


### PR DESCRIPTION
$arr = [
            ['key' => 'a', 'value' => 1],
            ['key' => 'a', 'value' => 2],
            ['key' => 'a', 'value' => 3],
            ['key' => 'b', 'value' => 1],
            ['key' => 'b', 'value' => 2],
            ['key' => 'c', 'value' => 1],
        ];
collect($arr)->groupBy('key')->map(fn (\Hyperf\Collection\Collection $item) => $item->max('value'));
phpstan会认为groupBy返回值还是Collection<int,array<string,int|string>>