### PR TITLE
Fixed bug that `LazyCollection::splitIn()` cannot work caused by type hint.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.26 - TBD
 
+## Fixed
+
+- [#6848](https://github.com/hyperf/hyperf/pull/6848) Fixed bug that `LazyCollection::splitIn()` cannot work caused by type hint.
+
 # v3.1.25.1 - 2024-06-07
 
 ## Added

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -15,7 +15,6 @@ namespace Hyperf\Collection;
 use ArrayAccess;
 use ArrayIterator;
 use Closure;
-use Exception;
 use Hyperf\Collection\Traits\EnumeratesValues;
 use Hyperf\Contract\Arrayable;
 use Hyperf\Contract\Jsonable;
@@ -395,7 +394,7 @@ class Collection implements Enumerable, ArrayAccess
     /**
      * Remove an item from the collection by key.
      *
-     * @param \Hyperf\Contract\Arrayable<array-key, TValue>|iterable<array-key, TKey>|TKey $keys
+     * @param Arrayable<array-key, TValue>|iterable<array-key, TKey>|TKey $keys
      * @return $this
      */
     public function forget($keys): static
@@ -1556,8 +1555,6 @@ class Collection implements Enumerable, ArrayAccess
 
                 $ascending = Arr::get($comparison, 1, true) === true
                     || Arr::get($comparison, 1, true) === 'asc';
-
-                $result = 0;
 
                 if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);

--- a/src/collection/src/LazyCollection.php
+++ b/src/collection/src/LazyCollection.php
@@ -1294,7 +1294,7 @@ class LazyCollection implements Enumerable
      */
     public function splitIn(int $numberOfGroups)
     {
-        return $this->chunk(ceil($this->count() / $numberOfGroups));
+        return $this->chunk((int) ceil($this->count() / $numberOfGroups));
     }
 
     /**

--- a/src/collection/src/LazyCollection.php
+++ b/src/collection/src/LazyCollection.php
@@ -37,8 +37,6 @@ use Traversable;
  */
 class LazyCollection implements Enumerable
 {
-    use Macroable;
-
     /**
      * @use EnumeratesValues<TKey, TValue>
      */


### PR DESCRIPTION
1、optimize code for collection
2、Convert chunk method parameters in splitIn to int type
error : Expected parameter of type 'int', 'float' provided