### PR TITLE
Added `hyperf/paginator` to suggest

### DIFF
--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -22,7 +22,6 @@
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
         "hyperf/utils": "~3.1.0",
-        "hyperf/paginator": "~3.1.0",
         "nesbot/carbon": "^2.0",
         "psr/container": "^1.0|^2.0",
         "psr/event-dispatcher": "^1.0"
@@ -30,7 +29,8 @@
     "suggest": {
         "doctrine/dbal": "Required to rename columns (^3.0).",
         "nikic/php-parser": "Required to use ModelCommand. (^4.0)",
-        "php-di/phpdoc-reader": "Required to use ModelCommand. (^2.2)"
+        "php-di/phpdoc-reader": "Required to use ModelCommand. (^2.2)",
+        "hyperf/paginator": "Required to paginate the result set (^3.1.0)."
     },
     "autoload": {
         "psr-4": {

--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -22,6 +22,7 @@
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
         "hyperf/utils": "~3.1.0",
+        "hyperf/paginator": "~3.1.0",
         "nesbot/carbon": "^2.0",
         "psr/container": "^1.0|^2.0",
         "psr/event-dispatcher": "^1.0"

--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -30,7 +30,7 @@
         "doctrine/dbal": "Required to rename columns (^3.0).",
         "nikic/php-parser": "Required to use ModelCommand. (^4.0)",
         "php-di/phpdoc-reader": "Required to use ModelCommand. (^2.2)",
-        "hyperf/paginator": "Required to paginate the result set (^3.1.0)."
+        "hyperf/paginator": "Required to paginate the result set (~3.1.0)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
hyperf/database组件的composer.json未引入hyperf/paginator，导致调用paginate方法报错
```
Table::query()->paginate(10);
```
```
Class "Hyperf\Paginator\Paginator" not found
[ERROR] Error: Class "Hyperf\Paginator\Paginator" not found in /home/hyperf-test/vendor/hyperf/database/src/Model/Builder.php:769
Stack trace:
```
![image](https://github.com/hyperf/hyperf/assets/162444894/99684619-d0ec-4ddf-a04f-3756e0758748)
