### PR TITLE
Remove methods BuildsQueries::chunkById

### DIFF
--- a/src/database/src/Concerns/BuildsQueries.php
+++ b/src/database/src/Concerns/BuildsQueries.php
@@ -189,14 +189,6 @@ trait BuildsQueries
     }
 
     /**
-     * Chunk the results of a query by comparing IDs.
-     */
-    public function chunkById(int $count, callable $callback, ?string $column = null, ?string $alias = null): bool
-    {
-        return $this->orderedChunkById($count, $callback, $column, $alias);
-    }
-
-    /**
      * Chunk the results of a query by comparing IDs in descending order.
      */
     public function chunkByIdDesc(int $count, callable $callback, ?string $column = null, ?string $alias = null): bool


### PR DESCRIPTION
相关: https://github.com/hyperf/hyperf/pull/6846

此处 pr 经测试，有点问题

ChunkById 函数实际已经在 [\Hyperf\Database\Query\Builder::chunkById](https://github.com/hyperf/hyperf/blob/master/src/database/src/Query/Builder.php#L2201)和[\Hyperf\Database\Model\Builder::chunkById](https://github.com/hyperf/hyperf/blob/master/src/database/src/Model/Builder.php#L710)中实现了。

现在在 [\Hyperf\Database\Concerns\BuildsQueries::chunkById](https://github.com/hyperf/hyperf/blob/master/src/database/src/Concerns/BuildsQueries.php#L194) (`Query\Builder` 和 `Model\Builder`都有 use 这个 trait )  ，存在重复定义

导致实际 chunkById 方法还是走的原先的 `Query\Builder` 和 `Model\Builder` 逻辑。

实际使用不会有什么影响，逻辑一样，考虑稳定性 以及  `BuildsQueries` 中新增的 `ChunkById` 没什么用（`ChunkByIdDesc` 可以)。这里单独创建个 pr 看看是否有必要去除 `BuildsQueries::chunkById`
