### PR TITLE
cache的RedisDriver添加参数，允许支持使用多库Redis

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,6 +7,7 @@
 ## Added
 
 - [#6398](https://github.com/hyperf/hyperf/pull/6398) Added `timezone` parameter to `hyperf/crontab` component.
+- [#6402](https://github.com/hyperf/hyperf/pull/6402) Add `template_suffix` configuration to `twig` engine.
 
 # v3.1.2 - 2023-12-15
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,7 +7,7 @@
 ## Added
 
 - [#6398](https://github.com/hyperf/hyperf/pull/6398) Added `timezone` parameter to `hyperf/crontab` component.
-- [#6402](https://github.com/hyperf/hyperf/pull/6402) Add `template_suffix` configuration to `twig` engine.
+- [#6402](https://github.com/hyperf/hyperf/pull/6402) Added `template_suffix` configuration to `twig` engine.
 
 # v3.1.2 - 2023-12-15
 

--- a/src/cache/src/Driver/RedisDriver.php
+++ b/src/cache/src/Driver/RedisDriver.php
@@ -9,151 +9,153 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\Cache\Driver;
 
 use Hyperf\Cache\Exception\InvalidArgumentException;
 use Hyperf\Redis\Redis;
+use Hyperf\Redis\RedisFactory;
 use Psr\Container\ContainerInterface;
 
 class RedisDriver extends Driver implements KeyCollectorInterface
 {
-    protected Redis $redis;
+  protected Redis $redis;
 
-    public function __construct(ContainerInterface $container, array $config)
-    {
-        parent::__construct($container, $config);
+  public function __construct(ContainerInterface $container, array $config)
+  {
+    parent::__construct($container, $config);
 
-        $this->redis = $container->get(Redis::class);
+    $this->redis = $container->get(RedisFactory::class)->get($config['options']['poolName']  ?? 'default');
+  }
+
+  public function get($key, $default = null): mixed
+  {
+    $res = $this->redis->get($this->getCacheKey($key));
+    if ($res === false) {
+      return $default;
     }
 
-    public function get($key, $default = null): mixed
-    {
-        $res = $this->redis->get($this->getCacheKey($key));
-        if ($res === false) {
-            return $default;
-        }
+    return $this->packer->unpack($res);
+  }
 
-        return $this->packer->unpack($res);
+  public function fetch(string $key, $default = null): array
+  {
+    $res = $this->redis->get($this->getCacheKey($key));
+    if ($res === false) {
+      return [false, $default];
     }
 
-    public function fetch(string $key, $default = null): array
-    {
-        $res = $this->redis->get($this->getCacheKey($key));
-        if ($res === false) {
-            return [false, $default];
-        }
+    return [true, $this->packer->unpack($res)];
+  }
 
-        return [true, $this->packer->unpack($res)];
+  public function set($key, $value, $ttl = null): bool
+  {
+    $seconds = $this->secondsUntil($ttl);
+    $res = $this->packer->pack($value);
+    if ($seconds > 0) {
+      return $this->redis->set($this->getCacheKey($key), $res, $seconds);
     }
 
-    public function set($key, $value, $ttl = null): bool
-    {
-        $seconds = $this->secondsUntil($ttl);
-        $res = $this->packer->pack($value);
-        if ($seconds > 0) {
-            return $this->redis->set($this->getCacheKey($key), $res, $seconds);
-        }
+    return $this->redis->set($this->getCacheKey($key), $res);
+  }
 
-        return $this->redis->set($this->getCacheKey($key), $res);
+  public function delete($key): bool
+  {
+    return (bool) $this->redis->del($this->getCacheKey($key));
+  }
+
+  public function clear(): bool
+  {
+    return $this->clearPrefix('');
+  }
+
+  public function getMultiple($keys, $default = null): iterable
+  {
+    $cacheKeys = array_map(function ($key) {
+      return $this->getCacheKey($key);
+    }, $keys);
+
+    $values = $this->redis->mget($cacheKeys);
+    $result = [];
+    foreach ($keys as $i => $key) {
+      $result[$key] = $values[$i] === false ? $default : $this->packer->unpack($values[$i]);
     }
 
-    public function delete($key): bool
-    {
-        return (bool) $this->redis->del($this->getCacheKey($key));
+    return $result;
+  }
+
+  public function setMultiple($values, $ttl = null): bool
+  {
+    if (!is_array($values)) {
+      throw new InvalidArgumentException('The values is invalid!');
     }
 
-    public function clear(): bool
-    {
-        return $this->clearPrefix('');
+    $cacheKeys = [];
+    foreach ($values as $key => $value) {
+      $cacheKeys[$this->getCacheKey($key)] = $this->packer->pack($value);
     }
 
-    public function getMultiple($keys, $default = null): iterable
-    {
-        $cacheKeys = array_map(function ($key) {
-            return $this->getCacheKey($key);
-        }, $keys);
+    $seconds = $this->secondsUntil($ttl);
+    if ($seconds > 0) {
+      foreach ($cacheKeys as $key => $value) {
+        $this->redis->set($key, $value, $seconds);
+      }
 
-        $values = $this->redis->mget($cacheKeys);
-        $result = [];
-        foreach ($keys as $i => $key) {
-            $result[$key] = $values[$i] === false ? $default : $this->packer->unpack($values[$i]);
-        }
-
-        return $result;
+      return true;
     }
 
-    public function setMultiple($values, $ttl = null): bool
-    {
-        if (! is_array($values)) {
-            throw new InvalidArgumentException('The values is invalid!');
-        }
+    return $this->redis->mset($cacheKeys);
+  }
 
-        $cacheKeys = [];
-        foreach ($values as $key => $value) {
-            $cacheKeys[$this->getCacheKey($key)] = $this->packer->pack($value);
-        }
+  public function deleteMultiple($keys): bool
+  {
+    $cacheKeys = array_map(function ($key) {
+      return $this->getCacheKey($key);
+    }, $keys);
 
-        $seconds = $this->secondsUntil($ttl);
-        if ($seconds > 0) {
-            foreach ($cacheKeys as $key => $value) {
-                $this->redis->set($key, $value, $seconds);
-            }
+    return (bool) $this->redis->del(...$cacheKeys);
+  }
 
-            return true;
-        }
+  public function has($key): bool
+  {
+    return (bool) $this->redis->exists($this->getCacheKey($key));
+  }
 
-        return $this->redis->mset($cacheKeys);
+  public function clearPrefix(string $prefix): bool
+  {
+    $iterator = null;
+    $key = $prefix . '*';
+    while (true) {
+      $keys = $this->redis->scan($iterator, $this->getCacheKey($key), 10000);
+      if (!empty($keys)) {
+        $this->redis->del(...$keys);
+      }
+
+      if (empty($iterator)) {
+        break;
+      }
     }
 
-    public function deleteMultiple($keys): bool
-    {
-        $cacheKeys = array_map(function ($key) {
-            return $this->getCacheKey($key);
-        }, $keys);
+    return true;
+  }
 
-        return (bool) $this->redis->del(...$cacheKeys);
-    }
+  public function addKey(string $collector, string $key): bool
+  {
+    return (bool) $this->redis->sAdd($this->getCacheKey($collector), $key);
+  }
 
-    public function has($key): bool
-    {
-        return (bool) $this->redis->exists($this->getCacheKey($key));
-    }
+  public function keys(string $collector): array
+  {
+    return $this->redis->sMembers($this->getCacheKey($collector));
+  }
 
-    public function clearPrefix(string $prefix): bool
-    {
-        $iterator = null;
-        $key = $prefix . '*';
-        while (true) {
-            $keys = $this->redis->scan($iterator, $this->getCacheKey($key), 10000);
-            if (! empty($keys)) {
-                $this->redis->del(...$keys);
-            }
+  public function delKey(string $collector, string ...$key): bool
+  {
+    return (bool) $this->redis->sRem($this->getCacheKey($collector), ...$key);
+  }
 
-            if (empty($iterator)) {
-                break;
-            }
-        }
-
-        return true;
-    }
-
-    public function addKey(string $collector, string $key): bool
-    {
-        return (bool) $this->redis->sAdd($this->getCacheKey($collector), $key);
-    }
-
-    public function keys(string $collector): array
-    {
-        return $this->redis->sMembers($this->getCacheKey($collector));
-    }
-
-    public function delKey(string $collector, string ...$key): bool
-    {
-        return (bool) $this->redis->sRem($this->getCacheKey($collector), ...$key);
-    }
-
-    public function getConnection(): mixed
-    {
-        return $this->redis;
-    }
+  public function getConnection(): mixed
+  {
+    return $this->redis;
+  }
 }

--- a/src/view/src/Engine/TwigEngine.php
+++ b/src/view/src/Engine/TwigEngine.php
@@ -21,6 +21,10 @@ class TwigEngine implements EngineInterface
         $loader = new FilesystemLoader($config['view_path']);
         $twig = new Environment($loader, ['cache' => $config['cache_path']]);
 
+        if($suffix = $config['template_suffix'] ?? '') {
+            $template .= $suffix;
+        }
+
         return $twig->render($template, $data);
     }
 }

--- a/src/view/src/Engine/TwigEngine.php
+++ b/src/view/src/Engine/TwigEngine.php
@@ -21,7 +21,7 @@ class TwigEngine implements EngineInterface
         $loader = new FilesystemLoader($config['view_path']);
         $twig = new Environment($loader, ['cache' => $config['cache_path']]);
 
-        if($suffix = $config['template_suffix'] ?? '') {
+        if ($suffix = $config['template_suffix'] ?? '') {
             $template .= $suffix;
         }
 

--- a/src/view/tests/TwigTest.php
+++ b/src/view/tests/TwigTest.php
@@ -43,4 +43,27 @@ Hello, Hyperf. You are using twig template now.
 </body>
 </html>', $res);
     }
+
+    public function testConfig()
+    {
+        $config = [
+            'view_path' => __DIR__ . '/tpl',
+            'cache_path' => __DIR__ . '/runtime',
+            'template_suffix' => '.twig',
+        ];
+
+        $engine = new TwigEngine();
+        $res = $engine->render('index', ['name' => 'Hyperf'], $config);
+
+        $this->assertEquals('<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hyperf</title>
+</head>
+<body>
+Hello, Hyperf. You are using twig template now.
+</body>
+</html>', $res);
+    }
 }


### PR DESCRIPTION
redis配置：
`
    'wx' => [
        'host' => env('REDIS_HOST', 'localhost'),
        'auth' => [env('REDIS_USERNAME', null), env('REDIS_PASSWORD', null)],
        'port' => (int) env('REDIS_PORT', 6379),
        'db' => (int) env('REDIS_WX_DB', 0),
    ],
`
cache配置：
`
    'default' => [
        'driver' => RedisDriver::class,
        'packer' => PhpSerializerPacker::class,
        'prefix' => 'c:',
    ],
    'wx' => [
        'driver' => RedisDriver::class,
        'packer' => PhpSerializerPacker::class,
        'prefix' => 'wx:',
        'options' => [
            'poolName' => 'wx',
        ],
    ],
`

使用：
`
$this->container->get(CacheManager::class)->getDriver('wx')->set('xx', 'xx');
`