### PR TITLE
Fixed bug that `Aop` doesn't work on `Trait`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#6900](https://github.com/hyperf/hyperf/pull/6900) Fixed bug that `LengthAwarePaginator::addQuery()` cannot support array `$values`.
+- [#6909](https://github.com/hyperf/hyperf/pull/6909) Fixed bug that `Aop` doesn't work on `Trait`.
 
 ## Optimized
 

--- a/src/di/src/Aop/Ast.php
+++ b/src/di/src/Aop/Ast.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Di\Aop;
 
 use Hyperf\Support\Composer;
-use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\Enum_;
-use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
@@ -64,7 +62,7 @@ class Ast
             if ($stmt instanceof Namespace_ && $stmt->name) {
                 $namespace = $stmt->name->toString();
                 foreach ($stmt->stmts as $node) {
-                    if (($node instanceof Class_ || $node instanceof Interface_ || $node instanceof Enum_) && $node->name) {
+                    if (($node instanceof ClassLike) && $node->name) {
                         $className = $node->name->toString();
                         break;
                     }

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -421,4 +421,67 @@ class FooConstruct
     }
 }', $code);
     }
+
+    public function testParseClassByStmtsMethods()
+    {
+        $parser = new Ast();
+        $testCases = [
+            [
+                'code' => <<<'CODE'
+<?php
+namespace HyperfTest\Di\Stub\Ast;
+
+class FooClass
+{
+    public function bar(){}
+}
+CODE,
+                'expected' => 'HyperfTest\Di\Stub\Ast\FooClass',
+            ],
+            [
+                'code' => <<<'CODE'
+<?php
+namespace HyperfTest\Di\Stub\Ast;
+
+class FooTrait
+{
+    public function bar(){}
+}
+CODE,
+                'expected' => 'HyperfTest\Di\Stub\Ast\FooTrait',
+            ],
+            [
+                'code' => <<<'CODE'
+<?php
+namespace HyperfTest\Di\Stub\Ast;
+
+interface FooInterface
+{
+    public function bar();
+}
+CODE,
+                'expected' => 'HyperfTest\Di\Stub\Ast\FooInterface',
+            ],
+            [
+                'code' => <<<'CODE'
+<?php
+namespace HyperfTest\Di\Stub\Ast;
+
+enum FooEnum
+{
+    case Pending = 'pending';
+    case Processing = 'processing';
+    case Completed = 'completed';
+    case Canceled = 'canceled';
+}
+CODE,
+                'expected' => 'HyperfTest\Di\Stub\Ast\FooEnum',
+            ],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $stmts = $parser->parse($testCase['code']);
+            $this->assertEquals($testCase['expected'], $parser->parseClassByStmts($stmts));
+        }
+    }
 }

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -17,6 +17,7 @@ use Hyperf\Di\ReflectionManager;
 use HyperfTest\Di\Stub\AspectCollector;
 use HyperfTest\Di\Stub\Ast\Abs;
 use HyperfTest\Di\Stub\Ast\AbsAspect;
+use HyperfTest\Di\Stub\Ast\Bar;
 use HyperfTest\Di\Stub\Ast\Bar2;
 use HyperfTest\Di\Stub\Ast\Bar3;
 use HyperfTest\Di\Stub\Ast\Bar4;
@@ -26,6 +27,7 @@ use HyperfTest\Di\Stub\Ast\BarInterface;
 use HyperfTest\Di\Stub\Ast\Chi;
 use HyperfTest\Di\Stub\Ast\Foo;
 use HyperfTest\Di\Stub\Ast\FooConstruct;
+use HyperfTest\Di\Stub\Ast\FooEnum;
 use HyperfTest\Di\Stub\Ast\FooTrait;
 use HyperfTest\Di\Stub\FooAspect;
 use HyperfTest\Di\Stub\FooEnumStruct;
@@ -33,6 +35,7 @@ use HyperfTest\Di\Stub\Par2;
 use HyperfTest\Di\Stub\PathStub;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @internal
@@ -427,60 +430,27 @@ class FooConstruct
         $parser = new Ast();
         $testCases = [
             [
-                'code' => <<<'CODE'
-<?php
-namespace HyperfTest\Di\Stub\Ast;
-
-class FooClass
-{
-    public function bar(){}
-}
-CODE,
-                'expected' => 'HyperfTest\Di\Stub\Ast\FooClass',
+                'class' => Bar::class,
+                'expected' => 'HyperfTest\Di\Stub\Ast\Bar',
             ],
             [
-                'code' => <<<'CODE'
-<?php
-namespace HyperfTest\Di\Stub\Ast;
-
-class FooTrait
-{
-    public function bar(){}
-}
-CODE,
+                'class' => FooTrait::class,
                 'expected' => 'HyperfTest\Di\Stub\Ast\FooTrait',
             ],
             [
-                'code' => <<<'CODE'
-<?php
-namespace HyperfTest\Di\Stub\Ast;
-
-interface FooInterface
-{
-    public function bar();
-}
-CODE,
-                'expected' => 'HyperfTest\Di\Stub\Ast\FooInterface',
+                'class' => BarInterface::class,
+                'expected' => 'HyperfTest\Di\Stub\Ast\BarInterface',
             ],
             [
-                'code' => <<<'CODE'
-<?php
-namespace HyperfTest\Di\Stub\Ast;
-
-enum FooEnum
-{
-    case Pending = 'pending';
-    case Processing = 'processing';
-    case Completed = 'completed';
-    case Canceled = 'canceled';
-}
-CODE,
+                'class' => FooEnum::class,
                 'expected' => 'HyperfTest\Di\Stub\Ast\FooEnum',
             ],
         ];
 
         foreach ($testCases as $testCase) {
-            $stmts = $parser->parse($testCase['code']);
+            $reflector = new ReflectionClass($testCase['class']);
+            $fileName = $reflector->getFileName();
+            $stmts = $parser->parse(file_get_contents($fileName));
             $this->assertEquals($testCase['expected'], $parser->parseClassByStmts($stmts));
         }
     }

--- a/src/di/tests/ReflectionTest.php
+++ b/src/di/tests/ReflectionTest.php
@@ -107,9 +107,21 @@ class ReflectionTest extends TestCase
     {
         $reflections = ReflectionManager::getAllClasses([__DIR__ . '/Stub']);
         $this->assertGreaterThan(0, count($reflections));
+        $classes = [];
+        $interfaces = [];
+        $traits = [];
+        $enums = [];
         foreach ($reflections as $name => $reflection) {
-            $this->assertTrue(class_exists($name) || interface_exists($name) || trait_exists($name));
+            $this->assertTrue(class_exists($name) || interface_exists($name) || trait_exists($name) || enum_exists($name));
             $this->assertInstanceOf(ReflectionClass::class, $reflection);
+            match (true) {
+                enum_exists($name) => $enums[] = $name,
+                class_exists($name) => $classes[] = $name,
+                interface_exists($name) => $interfaces[] = $name,
+                trait_exists($name) => $traits[] = $name,
+            };
         }
+
+        $this->assertTrue($classes && $interfaces && $traits && $enums);
     }
 }

--- a/src/di/tests/Stub/Ast/FooEnum.php
+++ b/src/di/tests/Stub/Ast/FooEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Di\Stub\Ast;
+
+enum FooEnum: string
+{
+    case A = 'A';
+    case B = 'B';
+    case C = 'C';
+    case D = 'D';
+}


### PR DESCRIPTION
因为 `reflection manager`遗漏了 `trait` ,导致 `AOP` 无法作用于`Trait`