### PR TITLE
Fix sortByMany return is not same to sortBy & Perf sortBy

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -396,8 +396,6 @@ jobs:
         run: |
           cp .travis/.env.example .env
           
-          composer analyse src/collection
-          composer test src/collection
           composer analyse src/command
           composer test src/command
           composer analyse src/config

--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -396,6 +396,8 @@ jobs:
         run: |
           cp .travis/.env.example .env
           
+          composer analyse src/collection
+          composer test src/collection
           composer analyse src/command
           composer test src/command
           composer analyse src/config

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.29 - TBD
 
+## Fixed
+
+- [#6925](https://github.com/hyperf/hyperf/pull/6925) Fixed bug that `sortByMany` cannot support options like `sortBy`.
+
 ## Added
 
 - [#6896](https://github.com/hyperf/hyperf/pull/6896) Added `SftpAdapter` for `hyperf/filesystem`.

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -1117,6 +1117,16 @@ class Collection implements Enumerable, ArrayAccess
      */
     public function sortByDesc($callback, int $options = SORT_REGULAR): static
     {
+        if (is_array($callback) && ! is_callable($callback)) {
+            foreach ($callback as $index => $key) {
+                $comparison = Arr::wrap($key);
+
+                $comparison[1] = 'desc';
+
+                $callback[$index] = $comparison;
+            }
+        }
+
         return $this->sortBy($callback, $options, true);
     }
 

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -1112,7 +1112,7 @@ class Collection implements Enumerable, ArrayAccess
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param (callable(TValue, TKey): mixed)|string $callback
+     * @param array|(callable(TValue, TKey): mixed)|string $callback
      * @return static<TKey, TValue>
      */
     public function sortByDesc($callback, int $options = SORT_REGULAR): static

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -1593,7 +1593,7 @@ class Collection implements Enumerable, ArrayAccess
     {
         $items = $this->items;
 
-        usort($items, function ($a, $b) use ($comparisons) {
+        uasort($items, function ($a, $b) use ($comparisons) {
             foreach ($comparisons as $comparison) {
                 $comparison = Arr::wrap($comparison);
 

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -1088,7 +1088,7 @@ class Collection implements Enumerable, ArrayAccess
     public function sortBy($callback, int $options = SORT_REGULAR, bool $descending = false): static
     {
         if (is_array($callback) && ! is_callable($callback)) {
-            return $this->sortByMany($callback);
+            return $this->sortByMany($callback, $options);
         }
 
         $results = [];
@@ -1589,11 +1589,11 @@ class Collection implements Enumerable, ArrayAccess
      *
      * @return static
      */
-    protected function sortByMany(array $comparisons = [])
+    protected function sortByMany(array $comparisons = [], int $options = SORT_REGULAR)
     {
         $items = $this->items;
 
-        uasort($items, function ($a, $b) use ($comparisons) {
+        uasort($items, function ($a, $b) use ($comparisons, $options) {
             foreach ($comparisons as $comparison) {
                 $comparison = Arr::wrap($comparison);
 
@@ -1611,7 +1611,21 @@ class Collection implements Enumerable, ArrayAccess
                         $values = array_reverse($values);
                     }
 
-                    $result = $values[0] <=> $values[1];
+                    if (($options & SORT_FLAG_CASE) === SORT_FLAG_CASE) {
+                        if (($options & SORT_NATURAL) === SORT_NATURAL) {
+                            $result = strnatcasecmp($values[0], $values[1]);
+                        } else {
+                            $result = strcasecmp($values[0], $values[1]);
+                        }
+                    } else {
+                        $result = match ($options) {
+                            SORT_NUMERIC => intval($values[0]) <=> intval($values[1]),
+                            SORT_STRING => strcmp($values[0], $values[1]),
+                            SORT_NATURAL => strnatcmp($values[0], $values[1]),
+                            SORT_LOCALE_STRING => strcoll($values[0], $values[1]),
+                            default => $values[0] <=> $values[1],
+                        };
+                    }
                 }
 
                 if ($result === 0) {

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -1142,15 +1142,15 @@ class CollectionTest extends TestCase
             [
                 ['id' => 5, 'name' => '5a'],
                 ['id' => 4, 'name' => '4b'],
-                ['id' => 3, 'name' => '3c'],
+                ['id' => 3, 'name' => 'c3'],
                 ['id' => 2, 'name' => '2d'],
                 ['id' => 1, 'name' => '1e'],
             ]
         ))->sortBy('name', SORT_NUMERIC);
         $this->assertEquals(json_encode([
+            2 => ['id' => 3, 'name' => 'c3'],
             4 => ['id' => 1, 'name' => '1e'],
             3 => ['id' => 2, 'name' => '2d'],
-            2 => ['id' => 3, 'name' => '3c'],
             1 => ['id' => 4, 'name' => '4b'],
             0 => ['id' => 5, 'name' => '5a'],
         ]), (string) $data);
@@ -1158,38 +1158,38 @@ class CollectionTest extends TestCase
             [
                 ['id' => 5, 'name' => '5a'],
                 ['id' => 4, 'name' => '4b'],
-                ['id' => 3, 'name' => '3c'],
+                ['id' => 3, 'name' => 'c3'],
                 ['id' => 2, 'name' => '2d'],
                 ['id' => 1, 'name' => '1e'],
             ]
-        ))->sortBy(['name', 'asc'], SORT_NUMERIC);
+        ))->sortBy([['name', 'asc']], SORT_NUMERIC);
         $this->assertEquals((string) $data, (string) $dataMany);
 
         $data = (new $collection(
             [
-                ['id' => 5, 'name' => 'e'],
-                ['id' => 4, 'name' => 'd'],
-                ['id' => 3, 'name' => 'c'],
-                ['id' => 2, 'name' => 'b'],
-                ['id' => 1, 'name' => 'a'],
+                ['id' => 5, 'name' => '5a'],
+                ['id' => 4, 'name' => '4b'],
+                ['id' => 3, 'name' => 'c3'],
+                ['id' => 2, 'name' => '2d'],
+                ['id' => 1, 'name' => '1e'],
             ]
         ))->sortBy('name', SORT_STRING);
         $this->assertEquals(json_encode([
-            4 => ['id' => 1, 'name' => 'a'],
-            3 => ['id' => 2, 'name' => 'b'],
-            2 => ['id' => 3, 'name' => 'c'],
-            1 => ['id' => 4, 'name' => 'd'],
-            0 => ['id' => 5, 'name' => 'e'],
+            4 => ['id' => 1, 'name' => '1e'],
+            3 => ['id' => 2, 'name' => '2d'],
+            1 => ['id' => 4, 'name' => '4b'],
+            0 => ['id' => 5, 'name' => '5a'],
+            2 => ['id' => 3, 'name' => 'c3'],
         ]), (string) $data);
         $dataMany = (new $collection(
             [
-                ['id' => 5, 'name' => 'e'],
-                ['id' => 4, 'name' => 'd'],
-                ['id' => 3, 'name' => 'c'],
-                ['id' => 2, 'name' => 'b'],
-                ['id' => 1, 'name' => 'a'],
+                ['id' => 5, 'name' => '5a'],
+                ['id' => 4, 'name' => '4b'],
+                ['id' => 3, 'name' => 'c3'],
+                ['id' => 2, 'name' => '2d'],
+                ['id' => 1, 'name' => '1e'],
             ]
-        ))->sortBy(['name', 'asc'], SORT_STRING);
+        ))->sortBy([['name', 'asc']], SORT_STRING);
         $this->assertEquals((string) $data, (string) $dataMany);
 
         $data = (new $collection(
@@ -1216,7 +1216,35 @@ class CollectionTest extends TestCase
                 ['id' => 2, 'name' => 'a2'],
                 ['id' => 1, 'name' => 'a1'],
             ]
-        ))->sortBy(['name', 'asc'], SORT_NATURAL);
+        ))->sortBy([['name', 'asc']], SORT_NATURAL);
+        $this->assertEquals((string) $data, (string) $dataMany);
+
+        setlocale(LC_COLLATE, 'en_US.utf8');
+        $data = (new $collection(
+            [
+                ['id' => 5, 'name' => 'A'],
+                ['id' => 4, 'name' => 'a'],
+                ['id' => 3, 'name' => 'B'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'c'],
+            ]
+        ))->sortBy('name', SORT_LOCALE_STRING);
+        $this->assertEquals(json_encode([
+            1 => ['id' => 4, 'name' => 'a'],
+            0 => ['id' => 5, 'name' => 'A'],
+            3 => ['id' => 2, 'name' => 'b'],
+            2 => ['id' => 3, 'name' => 'B'],
+            4 => ['id' => 1, 'name' => 'c'],
+        ]), (string) $data);
+        $dataMany = (new $collection(
+            [
+                ['id' => 5, 'name' => 'A'],
+                ['id' => 4, 'name' => 'a'],
+                ['id' => 3, 'name' => 'B'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'c'],
+            ]
+        ))->sortBy([['name', 'asc']], SORT_LOCALE_STRING);
         $this->assertEquals((string) $data, (string) $dataMany);
 
         $data = (new $collection(

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -1104,40 +1104,39 @@ class CollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSortBy($collection)
     {
-
         $data = (new $collection(
             [
                 ['id' => 5, 'name' => 'e'],
                 ['id' => 4, 'name' => 'd'],
                 ['id' => 3, 'name' => 'c'],
                 ['id' => 2, 'name' => 'b'],
-                ['id' => 1, 'name' => 'a']
+                ['id' => 1, 'name' => 'a'],
             ]
         ))->sortBy('id');
-        $this->assertEquals([
+        $this->assertEquals(json_encode([
             4 => ['id' => 1, 'name' => 'a'],
             3 => ['id' => 2, 'name' => 'b'],
             2 => ['id' => 3, 'name' => 'c'],
             1 => ['id' => 4, 'name' => 'd'],
-            0 => ['id' => 5, 'name' => 'e']
-        ], $data->all());
-        $this->assertEquals([
+            0 => ['id' => 5, 'name' => 'e'],
+        ]), (string) $data);
+        $this->assertEquals(json_encode([
             ['id' => 1, 'name' => 'a'],
             ['id' => 2, 'name' => 'b'],
             ['id' => 3, 'name' => 'c'],
             ['id' => 4, 'name' => 'd'],
-            ['id' => 5, 'name' => 'e']
-        ], $data->values()->all());
+            ['id' => 5, 'name' => 'e'],
+        ]), (string) $data->values());
         $dataMany = (new $collection(
             [
                 ['id' => 5, 'name' => 'e'],
                 ['id' => 4, 'name' => 'd'],
                 ['id' => 3, 'name' => 'c'],
                 ['id' => 2, 'name' => 'b'],
-                ['id' => 1, 'name' => 'a']
+                ['id' => 1, 'name' => 'a'],
             ]
         ))->sortBy(['id', 'asc']);
-        $this->assertEquals($data->all(), $dataMany->all());
+        $this->assertEquals((string) $data, (string) $dataMany);
 
         $data = (new $collection(
             [
@@ -1145,32 +1144,32 @@ class CollectionTest extends TestCase
                 ['id' => 2, 'name' => 'b'],
                 ['id' => 3, 'name' => 'c'],
                 ['id' => 4, 'name' => 'd'],
-                ['id' => 5, 'name' => 'e']
+                ['id' => 5, 'name' => 'e'],
             ]
         ))->sortByDesc('id');
-        $this->assertEquals([
+        $this->assertEquals(json_encode([
             4 => ['id' => 5, 'name' => 'e'],
             3 => ['id' => 4, 'name' => 'd'],
             2 => ['id' => 3, 'name' => 'c'],
             1 => ['id' => 2, 'name' => 'b'],
-            0 => ['id' => 1, 'name' => 'a']
-        ], $data->all());
-        $this->assertEquals([
+            0 => ['id' => 1, 'name' => 'a'],
+        ]), (string) $data);
+        $this->assertEquals(json_encode([
             ['id' => 5, 'name' => 'e'],
             ['id' => 4, 'name' => 'd'],
             ['id' => 3, 'name' => 'c'],
             ['id' => 2, 'name' => 'b'],
-            ['id' => 1, 'name' => 'a']
-        ], $data->values()->all());
+            ['id' => 1, 'name' => 'a'],
+        ]), (string) $data->values());
         $dataMany = (new $collection(
             [
                 ['id' => 1, 'name' => 'a'],
                 ['id' => 2, 'name' => 'b'],
                 ['id' => 3, 'name' => 'c'],
                 ['id' => 4, 'name' => 'd'],
-                ['id' => 5, 'name' => 'e']
+                ['id' => 5, 'name' => 'e'],
             ]
         ))->sortByDesc(['id']);
-        $this->assertEquals($data->all(), $dataMany->all());
+        $this->assertEquals((string) $data, (string) $dataMany);
     }
 }

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -1140,6 +1140,87 @@ class CollectionTest extends TestCase
 
         $data = (new $collection(
             [
+                ['id' => 5, 'name' => '5a'],
+                ['id' => 4, 'name' => '4b'],
+                ['id' => 3, 'name' => '3c'],
+                ['id' => 2, 'name' => '2d'],
+                ['id' => 1, 'name' => '1e'],
+            ]
+        ))->sortBy('name', SORT_NUMERIC);
+        $this->assertEquals(json_encode([
+            4 => ['id' => 1, 'name' => '1e'],
+            3 => ['id' => 2, 'name' => '2d'],
+            2 => ['id' => 3, 'name' => '3c'],
+            1 => ['id' => 4, 'name' => '4b'],
+            0 => ['id' => 5, 'name' => '5a'],
+        ]), (string) $data);
+        $dataMany = (new $collection(
+            [
+                ['id' => 5, 'name' => '5a'],
+                ['id' => 4, 'name' => '4b'],
+                ['id' => 3, 'name' => '3c'],
+                ['id' => 2, 'name' => '2d'],
+                ['id' => 1, 'name' => '1e'],
+            ]
+        ))->sortBy(['name', 'asc'], SORT_NUMERIC);
+        $this->assertEquals((string) $data, (string) $dataMany);
+
+        $data = (new $collection(
+            [
+                ['id' => 5, 'name' => 'e'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'a'],
+            ]
+        ))->sortBy('name', SORT_STRING);
+        $this->assertEquals(json_encode([
+            4 => ['id' => 1, 'name' => 'a'],
+            3 => ['id' => 2, 'name' => 'b'],
+            2 => ['id' => 3, 'name' => 'c'],
+            1 => ['id' => 4, 'name' => 'd'],
+            0 => ['id' => 5, 'name' => 'e'],
+        ]), (string) $data);
+        $dataMany = (new $collection(
+            [
+                ['id' => 5, 'name' => 'e'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'a'],
+            ]
+        ))->sortBy(['name', 'asc'], SORT_STRING);
+        $this->assertEquals((string) $data, (string) $dataMany);
+
+        $data = (new $collection(
+            [
+                ['id' => 5, 'name' => 'a10'],
+                ['id' => 4, 'name' => 'a4'],
+                ['id' => 3, 'name' => 'a3'],
+                ['id' => 2, 'name' => 'a2'],
+                ['id' => 1, 'name' => 'a1'],
+            ]
+        ))->sortBy('name', SORT_NATURAL);
+        $this->assertEquals(json_encode([
+            4 => ['id' => 1, 'name' => 'a1'],
+            3 => ['id' => 2, 'name' => 'a2'],
+            2 => ['id' => 3, 'name' => 'a3'],
+            1 => ['id' => 4, 'name' => 'a4'],
+            0 => ['id' => 5, 'name' => 'a10'],
+        ]), (string) $data);
+        $dataMany = (new $collection(
+            [
+                ['id' => 5, 'name' => 'a10'],
+                ['id' => 4, 'name' => 'a4'],
+                ['id' => 3, 'name' => 'a3'],
+                ['id' => 2, 'name' => 'a2'],
+                ['id' => 1, 'name' => 'a1'],
+            ]
+        ))->sortBy(['name', 'asc'], SORT_NATURAL);
+        $this->assertEquals((string) $data, (string) $dataMany);
+
+        $data = (new $collection(
+            [
                 ['id' => 1, 'name' => 'a'],
                 ['id' => 2, 'name' => 'b'],
                 ['id' => 3, 'name' => 'c'],

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -1100,4 +1100,77 @@ class CollectionTest extends TestCase
         $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);
         $this->assertNull($c->after(5));
     }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testSortBy($collection)
+    {
+
+        $data = (new $collection(
+            [
+                ['id' => 5, 'name' => 'e'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'a']
+            ]
+        ))->sortBy('id');
+        $this->assertEquals([
+            4 => ['id' => 1, 'name' => 'a'],
+            3 => ['id' => 2, 'name' => 'b'],
+            2 => ['id' => 3, 'name' => 'c'],
+            1 => ['id' => 4, 'name' => 'd'],
+            0 => ['id' => 5, 'name' => 'e']
+        ], $data->all());
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'a'],
+            ['id' => 2, 'name' => 'b'],
+            ['id' => 3, 'name' => 'c'],
+            ['id' => 4, 'name' => 'd'],
+            ['id' => 5, 'name' => 'e']
+        ], $data->values()->all());
+        $dataMany = (new $collection(
+            [
+                ['id' => 5, 'name' => 'e'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 1, 'name' => 'a']
+            ]
+        ))->sortBy(['id', 'asc']);
+        $this->assertEquals($data->all(), $dataMany->all());
+
+        $data = (new $collection(
+            [
+                ['id' => 1, 'name' => 'a'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 5, 'name' => 'e']
+            ]
+        ))->sortByDesc('id');
+        $this->assertEquals([
+            4 => ['id' => 5, 'name' => 'e'],
+            3 => ['id' => 4, 'name' => 'd'],
+            2 => ['id' => 3, 'name' => 'c'],
+            1 => ['id' => 2, 'name' => 'b'],
+            0 => ['id' => 1, 'name' => 'a']
+        ], $data->all());
+        $this->assertEquals([
+            ['id' => 5, 'name' => 'e'],
+            ['id' => 4, 'name' => 'd'],
+            ['id' => 3, 'name' => 'c'],
+            ['id' => 2, 'name' => 'b'],
+            ['id' => 1, 'name' => 'a']
+        ], $data->values()->all());
+        $dataMany = (new $collection(
+            [
+                ['id' => 1, 'name' => 'a'],
+                ['id' => 2, 'name' => 'b'],
+                ['id' => 3, 'name' => 'c'],
+                ['id' => 4, 'name' => 'd'],
+                ['id' => 5, 'name' => 'e']
+            ]
+        ))->sortByDesc(['id']);
+        $this->assertEquals($data->all(), $dataMany->all());
+    }
 }


### PR DESCRIPTION
sortByMany 用的 usort 未保持索引关联
sortBy用的 asort/arsort  保持索引关联
sortBy('a') 与 sortBy(['a']) 返回结果经 json_encode后一个是数组，一个是对象（可能BC）
laravel用的是uasort 保持索引关联
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/Collection.php#L1506


sortByDesc 传数组时 不会按降序排序

