### PR TITLE
improve: split executeCommand from execute function for easy overriding in Command

### DIFF
--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -169,13 +169,11 @@ abstract class Command extends SymfonyCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->disableDispatcher($input);
-        $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
 
-        $callback = function () use ($method): int {
+        $callback = function (): int {
             try {
                 $this->eventDispatcher?->dispatch(new Event\BeforeHandle($this));
-                $statusCode = $this->{$method}();
-                if (is_int($statusCode)) {
+                if (is_int($statusCode = $this->executeCommand())) {
                     $this->exitCode = $statusCode;
                 }
                 $this->eventDispatcher?->dispatch(new Event\AfterHandle($this));
@@ -207,6 +205,13 @@ abstract class Command extends SymfonyCommand
         }
 
         return $this->exitCode >= 0 && $this->exitCode <= 255 ? $this->exitCode : self::INVALID;
+    }
+
+    protected function executeCommand()
+    {
+        $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
+
+        return $this->{$method}();
     }
 
     /**


### PR DESCRIPTION
將 Command 中執行 command function 的邏輯抽初成獨立的 function
方便 child class 要 override 執行時可以專注實現 command 執行邏輯，而不用覆寫整個 execute 方法