### PR TITLE
Optimized phpdoc & code 

### DIFF
--- a/src/command/src/ParameterParser.php
+++ b/src/command/src/ParameterParser.php
@@ -91,6 +91,24 @@ class ParameterParser
         return $this->extractedOptions($definitions);
     }
 
+    public function extractedOptions(array $definitions): array
+    {
+        $options = [];
+
+        foreach ($definitions as $definition) {
+            $type = $definition->getName();
+            if (! in_array($type, ['int', 'float', 'string', 'bool'])) {
+                continue;
+            }
+            $name = $definition->getMeta('name');
+            $mode = $definition->allowsNull() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
+            $default = $definition->getMeta('defaultValue');
+            $options[] = new InputOption($name, null, $mode, '', $default, []);
+        }
+
+        return $options;
+    }
+
     private function getInjections(array $definitions, string $callableName, array $arguments): array
     {
         $injections = [];
@@ -114,23 +132,5 @@ class ParameterParser
         }
 
         return $injections;
-    }
-
-    public function extractedOptions(array $definitions): array
-    {
-        $options = [];
-
-        foreach ($definitions as $definition) {
-            $type = $definition->getName();
-            if (! in_array($type, ['int', 'float', 'string', 'bool'])) {
-                continue;
-            }
-            $name = $definition->getMeta('name');
-            $mode = $definition->allowsNull() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
-            $default = $definition->getMeta('defaultValue');
-            $options[] = new InputOption($name, null, $mode, '', $default, []);
-        }
-
-        return $options;
     }
 }

--- a/src/command/src/ParameterParser.php
+++ b/src/command/src/ParameterParser.php
@@ -73,20 +73,8 @@ class ParameterParser
         }
 
         $definitions = $this->closureDefinitionCollector->getParameters($closure);
-        $options = [];
 
-        foreach ($definitions as $definition) {
-            $type = $definition->getName();
-            if (! in_array($type, ['int', 'float', 'string', 'bool'])) {
-                continue;
-            }
-            $name = $definition->getMeta('name');
-            $mode = $definition->allowsNull() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
-            $default = $definition->getMeta('defaultValue');
-            $options[] = new InputOption($name, null, $mode, '', $default, []);
-        }
-
-        return $options;
+        return $this->extractedOptions($definitions);
     }
 
     /**
@@ -99,20 +87,8 @@ class ParameterParser
         }
 
         $definitions = $this->methodDefinitionCollector->getParameters($class, $method);
-        $options = [];
 
-        foreach ($definitions as $definition) {
-            $type = $definition->getName();
-            if (! in_array($type, ['int', 'float', 'string', 'bool'])) {
-                continue;
-            }
-            $name = $definition->getMeta('name');
-            $mode = $definition->allowsNull() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
-            $default = $definition->getMeta('defaultValue');
-            $options[] = new InputOption($name, null, $mode, '', $default, []);
-        }
-
-        return $options;
+        return $this->extractedOptions($definitions);
     }
 
     private function getInjections(array $definitions, string $callableName, array $arguments): array
@@ -138,5 +114,23 @@ class ParameterParser
         }
 
         return $injections;
+    }
+
+    public function extractedOptions(array $definitions): array
+    {
+        $options = [];
+
+        foreach ($definitions as $definition) {
+            $type = $definition->getName();
+            if (! in_array($type, ['int', 'float', 'string', 'bool'])) {
+                continue;
+            }
+            $name = $definition->getMeta('name');
+            $mode = $definition->allowsNull() ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
+            $default = $definition->getMeta('defaultValue');
+            $options[] = new InputOption($name, null, $mode, '', $default, []);
+        }
+
+        return $options;
     }
 }

--- a/src/command/src/Parser.php
+++ b/src/command/src/Parser.php
@@ -78,14 +78,20 @@ class Parser
     {
         [$token, $description] = static::extractDescription($token);
 
-        return match (true) {
-            Str::endsWith($token, '?*') => new InputArgument(trim($token, '?*'), InputArgument::IS_ARRAY, $description),
-            Str::endsWith($token, '*') => new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description),
-            Str::endsWith($token, '?') => new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description),
-            preg_match('/(.+)=\*(.+)/', $token, $matches) => new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
-            preg_match('/(.+)=(.+)/', $token, $matches) => new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]),
-            default => new InputArgument($token, InputArgument::REQUIRED, $description),
-        };
+        switch (true) {
+            case Str::endsWith($token, '?*'):
+                return new InputArgument(trim($token, '?*'), InputArgument::IS_ARRAY, $description);
+            case Str::endsWith($token, '*'):
+                return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
+            case Str::endsWith($token, '?'):
+                return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
+                return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
+            case preg_match('/(.+)\=(.+)/', $token, $matches):
+                return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
+            default:
+                return new InputArgument($token, InputArgument::REQUIRED, $description);
+        }
     }
 
     /**
@@ -104,13 +110,18 @@ class Parser
             $shortcut = null;
         }
 
-        return match (true) {
-            Str::endsWith($token, '=') => new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description),
-            Str::endsWith($token, '=*') => new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description),
-            preg_match('/(.+)=\*(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
-            preg_match('/(.+)=(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]),
-            default => new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description),
-        };
+        switch (true) {
+            case Str::endsWith($token, '='):
+                return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
+            case Str::endsWith($token, '=*'):
+                return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
+            case preg_match('/(.+)\=(.+)/', $token, $matches):
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
+            default:
+                return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);
+        }
     }
 
     /**

--- a/src/command/src/Parser.php
+++ b/src/command/src/Parser.php
@@ -44,7 +44,7 @@ class Parser
      */
     protected static function name(string $expression): string
     {
-        if (! preg_match('/[^\s]+/', $expression, $matches)) {
+        if (! preg_match('/\S+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }
 
@@ -78,20 +78,14 @@ class Parser
     {
         [$token, $description] = static::extractDescription($token);
 
-        switch (true) {
-            case Str::endsWith($token, '?*'):
-                return new InputArgument(trim($token, '?*'), InputArgument::IS_ARRAY, $description);
-            case Str::endsWith($token, '*'):
-                return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
-            case Str::endsWith($token, '?'):
-                return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
-            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
-                return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)\=(.+)/', $token, $matches):
-                return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
-            default:
-                return new InputArgument($token, InputArgument::REQUIRED, $description);
-        }
+        return match (true) {
+            Str::endsWith($token, '?*') => new InputArgument(trim($token, '?*'), InputArgument::IS_ARRAY, $description),
+            Str::endsWith($token, '*') => new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description),
+            Str::endsWith($token, '?') => new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description),
+            preg_match('/(.+)=\*(.+)/', $token, $matches) => new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
+            preg_match('/(.+)=(.+)/', $token, $matches) => new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]),
+            default => new InputArgument($token, InputArgument::REQUIRED, $description),
+        };
     }
 
     /**
@@ -110,18 +104,13 @@ class Parser
             $shortcut = null;
         }
 
-        switch (true) {
-            case Str::endsWith($token, '='):
-                return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
-            case Str::endsWith($token, '=*'):
-                return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
-            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
-                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)\=(.+)/', $token, $matches):
-                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
-            default:
-                return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);
-        }
+        return match (true) {
+            Str::endsWith($token, '=') => new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description),
+            Str::endsWith($token, '=*') => new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description),
+            preg_match('/(.+)=\*(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2])),
+            preg_match('/(.+)=(.+)/', $token, $matches) => new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]),
+            default => new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description),
+        };
     }
 
     /**

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -1213,7 +1213,7 @@ class Connection implements ConnectionInterface
      * Fire an event for this connection.
      *
      * @param string $event
-     * @return null|array
+     * @return null|object
      */
     protected function fireConnectionEvent($event)
     {

--- a/src/db/src/ManagesTransactions.php
+++ b/src/db/src/ManagesTransactions.php
@@ -84,6 +84,8 @@ trait ManagesTransactions
 
     /**
      * Create a transaction within the database.
+     *
+     * @throws Throwable
      */
     protected function createTransaction(): void
     {
@@ -101,7 +103,7 @@ trait ManagesTransactions
     /**
      * Create a save point within the database.
      */
-    protected function createSavepoint()
+    protected function createSavepoint(): void
     {
         $this->exec(
             $this->compileSavepoint('trans' . ($this->transactions + 1))
@@ -113,7 +115,7 @@ trait ManagesTransactions
      *
      * @throws Throwable
      */
-    protected function handleBeginTransactionException(Throwable $e)
+    protected function handleBeginTransactionException(Throwable $e): void
     {
         if ($this->causedByLostConnection($e)) {
             $this->reconnect();
@@ -127,7 +129,7 @@ trait ManagesTransactions
     /**
      * Perform a rollback within the database.
      */
-    protected function performRollBack(int $toLevel)
+    protected function performRollBack(int $toLevel): void
     {
         if ($toLevel == 0) {
             $this->call('rollBack');

--- a/src/db/src/MySQLConnection.php
+++ b/src/db/src/MySQLConnection.php
@@ -207,7 +207,7 @@ class MySQLConnection extends AbstractConnection
     /**
      * Configure the connection character set and collation.
      */
-    protected function configureCharset(PDO $connection, array $config)
+    protected function configureCharset(PDO $connection, array $config): void
     {
         if (isset($config['charset'])) {
             $connection->prepare(sprintf("set names '%s'%s", $config['charset'], $this->getCollation($config)))->execute();

--- a/src/elasticsearch/src/ClientBuilderFactory.php
+++ b/src/elasticsearch/src/ClientBuilderFactory.php
@@ -18,7 +18,7 @@ use Hyperf\Guzzle\RingPHP\CoroutineHandler;
 
 class ClientBuilderFactory
 {
-    public function create()
+    public function create(): ClientBuilder
     {
         $builder = ClientBuilder::create();
         if (Coroutine::inCoroutine()) {


### PR DESCRIPTION
specify return types and update docblocks for consistency
refactor(command): extract option extraction from parameter parsing

- Add return type declarations for methods that were missing them, ensuring
  type consistency across the codebase.
- Update docblocks to reflect changes and correct any inconsistencies.
- Implement `void` return type for methods that do not return a value to enforce this behavior in the future.