### PR TITLE
Fixed bug that the mount code will break the main file with `declare` when using `phar:build`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.39 - TBD
 
+## Fixed
+
+- [#7034](https://github.com/hyperf/hyperf/pull/7034) Fixed bug that the mount code will break the main file with `declare` when using `phar:build`.
+
 ## Optimized
 
 - [#7033](https://github.com/hyperf/hyperf/pull/7033) Improved `ConsoleLogger` to support running in watcher.

--- a/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
+++ b/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
@@ -34,7 +34,7 @@ class UnshiftCodeStringVisitor extends NodeVisitorAbstract
         foreach ($nodes as $i => $node) {
             if ($node instanceof Node\Stmt\Declare_) {
                 array_splice($nodes, $i + 1, 0, $stmt);
-                $isUnshift = true;
+                return $nodes;
             }
         }
 
@@ -42,14 +42,12 @@ class UnshiftCodeStringVisitor extends NodeVisitorAbstract
             foreach ($nodes as $i => $node) {
                 if (! $node instanceof Node\Stmt\InlineHTML) {
                     array_splice($nodes, $i, 0, $stmt);
-                    $isUnshift = true;
+                    return $nodes;
                 }
             }
         }
 
-        if (! $isUnshift) {
-            array_unshift($nodes, $stmt[0]);
-        }
+        array_unshift($nodes, $stmt[0]);
 
         return $nodes;
     }

--- a/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
+++ b/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Phar\Ast\Visitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+class UnshiftCodeStringVisitor extends NodeVisitorAbstract
+{
+    private Parser $astParser;
+
+    public function __construct(public string $code)
+    {
+        $parserFactory = new ParserFactory();
+        $this->astParser = $parserFactory->create(ParserFactory::ONLY_PHP7);
+    }
+
+    public function beforeTraverse(array $nodes)
+    {
+        $stmt = $this->astParser->parse($this->code);
+        $isUnshift = false;
+        foreach ($nodes as $i => $node) {
+            if ($node instanceof Node\Stmt\Declare_) {
+                array_splice($nodes, $i + 1, 0, $stmt);
+                $isUnshift = true;
+            }
+        }
+
+        if (! $isUnshift) {
+            foreach ($nodes as $i => $node) {
+                if (! $node instanceof Node\Stmt\InlineHTML) {
+                    array_splice($nodes, $i, 0, $stmt);
+                    $isUnshift = true;
+                }
+            }
+        }
+
+        if (! $isUnshift) {
+            array_unshift($nodes, $stmt[0]);
+        }
+
+        return $nodes;
+    }
+}

--- a/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
+++ b/src/phar/src/Ast/Visitor/UnshiftCodeStringVisitor.php
@@ -30,7 +30,6 @@ class UnshiftCodeStringVisitor extends NodeVisitorAbstract
     public function beforeTraverse(array $nodes)
     {
         $stmt = $this->astParser->parse($this->code);
-        $isUnshift = false;
         foreach ($nodes as $i => $node) {
             if ($node instanceof Node\Stmt\Declare_) {
                 array_splice($nodes, $i + 1, 0, $stmt);
@@ -38,12 +37,10 @@ class UnshiftCodeStringVisitor extends NodeVisitorAbstract
             }
         }
 
-        if (! $isUnshift) {
-            foreach ($nodes as $i => $node) {
-                if (! $node instanceof Node\Stmt\InlineHTML) {
-                    array_splice($nodes, $i, 0, $stmt);
-                    return $nodes;
-                }
+        foreach ($nodes as $i => $node) {
+            if (! $node instanceof Node\Stmt\InlineHTML) {
+                array_splice($nodes, $i, 0, $stmt);
+                return $nodes;
             }
         }
 

--- a/src/phar/src/PharBuilder.php
+++ b/src/phar/src/PharBuilder.php
@@ -330,7 +330,7 @@ EOD;
         $this->replaceConfigFactoryReadPaths($targetPhar, $vendorPath);
 
         $this->logger->info('Adding main file "' . $main . '"');
-        $stubContents = file_get_contents($main);
+        $stubContents = preg_replace('/declare\s*\(\s*strict_types\s*=\s*1\s*\);/i', '', file_get_contents($main));
         $targetPhar->addFromString($main, strtr($stubContents, ['<?php' => $this->getMountLinkCode()]));
 
         $this->logger->info('Setting stub');

--- a/src/phar/src/PharBuilder.php
+++ b/src/phar/src/PharBuilder.php
@@ -17,6 +17,7 @@ use GlobIterator;
 use Hyperf\Phar\Ast\Ast;
 use Hyperf\Phar\Ast\Visitor\RewriteConfigFactoryVisitor;
 use Hyperf\Phar\Ast\Visitor\RewriteConfigVisitor;
+use Hyperf\Phar\Ast\Visitor\UnshiftCodeStringVisitor;
 use InvalidArgumentException;
 use JsonException;
 use Phar;
@@ -330,8 +331,7 @@ EOD;
         $this->replaceConfigFactoryReadPaths($targetPhar, $vendorPath);
 
         $this->logger->info('Adding main file "' . $main . '"');
-        $stubContents = preg_replace('/declare\s*\(\s*strict_types\s*=\s*1\s*\);/i', '', file_get_contents($main));
-        $targetPhar->addFromString($main, strtr($stubContents, ['<?php' => $this->getMountLinkCode()]));
+        $this->rewriteMainWithMountLinkCode($targetPhar, $main);
 
         $this->logger->info('Setting stub');
         // Add the default stub.
@@ -382,6 +382,13 @@ EOD;
         $code = file_get_contents($absPath);
         $code = (new Ast())->parse($code, [new RewriteConfigFactoryVisitor()]);
         $targetPhar->addFromString('vendor/' . $configPath, $code);
+    }
+
+    protected function rewriteMainWithMountLinkCode(TargetPhar $targetPhar, string $mainPath): void
+    {
+        $code = file_get_contents($mainPath);
+        $code = (new Ast())->parse($code, [new UnshiftCodeStringVisitor($this->getMountLinkCode())]);
+        $targetPhar->addFromString($mainPath, $code);
     }
 
     /**

--- a/src/phar/tests/VisitorTest.php
+++ b/src/phar/tests/VisitorTest.php
@@ -14,6 +14,7 @@ namespace HyperfTest\Phar;
 
 use Hyperf\Phar\Ast\Ast;
 use Hyperf\Phar\Ast\Visitor\RewriteConfigVisitor;
+use Hyperf\Phar\Ast\Visitor\UnshiftCodeStringVisitor;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
@@ -77,5 +78,45 @@ use Psr\\Log\\LogLevel;
 use function Hyperf\\Support\\env;
 \$result = ['app_name' => env('APP_NAME', 'skeleton'), 'app_env' => env('APP_ENV', 'dev'), 'scan_cacheable' => env('SCAN_CACHEABLE', false), StdoutLoggerInterface::class => ['log_level' => [LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::DEBUG, LogLevel::EMERGENCY, LogLevel::ERROR, LogLevel::INFO, LogLevel::NOTICE, LogLevel::WARNING]]];
 return array_replace(\$result, array('scan_cacheable' => true));", $code);
+    }
+
+    public function testRewriteMain()
+    {
+        $code = <<<'CODE'
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+echo "Hello Hyperf";
+CODE;
+        $unshiftCode = '<?php echo "Hello World";';
+        $code = (new Ast())->parse($code, [new UnshiftCodeStringVisitor($unshiftCode)]);
+        $this->assertSame('#!/usr/bin/env php
+<?php 
+declare (strict_types=1);
+echo "Hello World";
+echo "Hello Hyperf";', $code);
+
+        $code = <<<'CODE'
+<?php
+echo "Hello Hyperf";
+CODE;
+        $unshiftCode = '<?php echo "Hello World";';
+        $code = (new Ast())->parse($code, [new UnshiftCodeStringVisitor($unshiftCode)]);
+        $this->assertSame('<?php
+
+echo "Hello World";
+echo "Hello Hyperf";', $code);
+
+        $code = <<<'CODE'
+#!/usr/bin/env php
+<?php
+echo "Hello Hyperf";
+CODE;
+        $unshiftCode = '<?php echo "Hello World";';
+        $code = (new Ast())->parse($code, [new UnshiftCodeStringVisitor($unshiftCode)]);
+        $this->assertSame('#!/usr/bin/env php
+<?php 
+echo "Hello World";
+echo "Hello Hyperf";', $code);
     }
 }


### PR DESCRIPTION
由于框架是基于 cs-fix 格式化自动化处理，IDE 集成时经常出现自动格式化 ( 未成功加载到配置文件 )，会在文件头生成 declare(strict_types=1); ，打包为 phar 后会运行报错，而一次打包往往需要很长时间，希望可以在打包时自动做下处理。