### PR TITLE
Optimized the argument `table` like `database.table` for `gen:model` which can be used to generate another database models.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -9,6 +9,7 @@
 
 - [#7033](https://github.com/hyperf/hyperf/pull/7033) Improved `ConsoleLogger` to support running in watcher.
 - [#7040](https://github.com/hyperf/hyperf/pull/7040) Improved packaging speed for command `phar:build`. 
+- [#7044](https://github.com/hyperf/hyperf/pull/7044) Optimized the argument `table` like `database.table` for `gen:model` which can be used to generate another database models.
 
 ## Added
 

--- a/src/database-pgsql/src/Schema/PostgresBuilder.php
+++ b/src/database-pgsql/src/Schema/PostgresBuilder.php
@@ -216,11 +216,8 @@ class PostgresBuilder extends Builder
 
     /**
      * Get the column type listing for a given table.
-     *
-     * @param string $table
-     * @return array
      */
-    public function getColumnTypeListing($table)
+    public function getColumnTypeListing(string $table, ?string $database = null): array
     {
         [$schema, $table] = $this->parseSchemaAndTable($table);
 
@@ -228,7 +225,7 @@ class PostgresBuilder extends Builder
 
         $results = $this->connection->select(
             $this->grammar->compileColumnListing(),
-            [$this->connection->getDatabaseName(), $schema, $table]
+            [$database ?? $this->connection->getDatabaseName(), $schema, $table]
         );
 
         /** @var PostgresProcessor $processor */

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -156,7 +156,9 @@ class ModelCommand extends Command
     {
         $builder = $this->getSchemaBuilder($option->getPool());
         $table = Str::replaceFirst($option->getPrefix(), '', $table);
-        $columns = $this->formatColumns($builder->getColumnTypeListing($table));
+        $pureTable = Str::after($table, '.');
+        $databaseName = Str::contains($table, '.') ? Str::before($table, '.') : null;
+        $columns = $this->formatColumns($builder->getColumnTypeListing($pureTable, $databaseName));
         if (empty($columns)) {
             $this->output?->error(
                 sprintf('Query columns empty, maybe is table `%s` does not exist.You can check it in database.', $table)
@@ -164,7 +166,7 @@ class ModelCommand extends Command
         }
 
         $project = new Project();
-        $class = $option->getTableMapping()[$table] ?? Str::studly(Str::singular($table));
+        $class = $option->getTableMapping()[$table] ?? Str::studly(Str::singular($pureTable));
         $class = $project->namespace($option->getPath()) . $class;
         $path = BASE_PATH . '/' . $project->path($class);
 

--- a/src/database/src/Commands/ModelCommand.php
+++ b/src/database/src/Commands/ModelCommand.php
@@ -152,7 +152,7 @@ class ModelCommand extends Command
         return $table === $this->config->get('databases.migrations', 'migrations');
     }
 
-    protected function createModel(string $table, ModelOption $option)
+    protected function createModel(string $table, ModelOption $option): void
     {
         $builder = $this->getSchemaBuilder($option->getPool());
         $table = Str::replaceFirst($option->getPrefix(), '', $table);

--- a/src/database/src/Schema/MySqlBuilder.php
+++ b/src/database/src/Schema/MySqlBuilder.php
@@ -85,17 +85,14 @@ class MySqlBuilder extends Builder
 
     /**
      * Get the column type listing for a given table.
-     *
-     * @param string $table
-     * @return array
      */
-    public function getColumnTypeListing($table)
+    public function getColumnTypeListing(string $table, ?string $database = null): array
     {
         $table = $this->connection->getTablePrefix() . $table;
 
         $results = $this->connection->select(
             $this->grammar->compileColumnListing(),
-            [$this->connection->getDatabaseName(), $table]
+            [$database ?? $this->connection->getDatabaseName(), $table]
         );
 
         /** @var MySqlProcessor $processor */


### PR DESCRIPTION
### Context:
Multiple databases exist in the same database instance. But different database models cannot be generated over the same connection.
### After optimization：
php bin/hyperf.php gen:model --pool=default --with-comments **database_one.table_one**
