### PR TITLE
Optimized the instantiate of Producer

### DIFF
--- a/src/amqp/src/Listener/MainWorkerStartListener.php
+++ b/src/amqp/src/Listener/MainWorkerStartListener.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Hyperf\Amqp\Listener;
 
-use Doctrine\Instantiator\Instantiator;
 use Hyperf\Amqp\Annotation\Producer;
 use Hyperf\Amqp\DeclaredExchanges;
 use Hyperf\Amqp\Message\ProducerMessageInterface;
@@ -25,6 +24,8 @@ use Hyperf\Server\Event\MainCoroutineServerStart;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use Psr\Container\ContainerInterface;
 use Throwable;
+
+use function Hyperf\Support\make;
 
 class MainWorkerStartListener implements ListenerInterface
 {
@@ -57,13 +58,12 @@ class MainWorkerStartListener implements ListenerInterface
         $producerMessages = AnnotationCollector::getClassesByAnnotation(Producer::class);
         if ($producerMessages) {
             $producer = $this->container->get(\Hyperf\Amqp\Producer::class);
-            $instantiator = $this->container->get(Instantiator::class);
             /**
              * @var string $producerMessageClass
              * @var Producer $annotation
              */
             foreach ($producerMessages as $producerMessageClass => $annotation) {
-                $instance = $instantiator->instantiate($producerMessageClass);
+                $instance = make($producerMessageClass);
                 if (! $instance instanceof ProducerMessageInterface) {
                     continue;
                 }


### PR DESCRIPTION
使用instantiate实例化时，无法继承到生产者父类的构造函数，导致实例化出来的类缺少参数

而消费者却可以拿到父类的构造函数写入的内容，参考了下消费者的监听写法，发现消费者使用的是make进行实例化，可以继承到父类构造函数

![image](https://github.com/user-attachments/assets/bf24d678-a768-4c25-80a0-7ac9a7bf30cb)
