### PR TITLE
Fix the priority of the database parameter in the hyperf migrate command

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,7 +1,7 @@
 # v3.1.40 - TBD
 
 ## Fixed
-- [#7050](https://github.com/hyperf/hyperf/pull/7051) Fixed bug that `--database` option does not work for `migrate` command.
+- [#7051](https://github.com/hyperf/hyperf/pull/7051) Fixed bug that `--database` option does not work for `migrate` command.
 
 # v3.1.39 - 2024-09-05
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,6 +1,7 @@
 # v3.1.40 - TBD
 
 ## Fixed
+
 - [#7051](https://github.com/hyperf/hyperf/pull/7051) Fixed bug that `--database` option does not work for `migrate` command.
 
 # v3.1.39 - 2024-09-05

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,7 +1,7 @@
 # v3.1.40 - TBD
 
 ## Fixed
-- [#7050](https://github.com/hyperf/hyperf/pull/7050) Fixed bug that `--database` option does not work for `migrate` command.
+- [#7050](https://github.com/hyperf/hyperf/pull/7051) Fixed bug that `--database` option does not work for `migrate` command.
 
 # v3.1.39 - 2024-09-05
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,8 @@
 # v3.1.40 - TBD
 
+## Fixed
+- [#7050](https://github.com/hyperf/hyperf/pull/7050) Fixed bug that `--database` option does not work for `migrate` command.
+
 # v3.1.39 - 2024-09-05
 
 ## Fixed

--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -245,7 +245,7 @@ class Migrator
      */
     public function resolveConnection(string $connection)
     {
-        return $this->resolver->connection($connection ?: $this->connection);
+        return $this->resolver->connection($this->connection ?: $connection);
     }
 
     /**
@@ -457,7 +457,7 @@ class Migrator
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
                 $defaultConnection = $this->resolver->getDefaultConnection();
-                $this->resolver->setDefaultConnection($migration->getConnection() ?: $this->connection);
+                $this->resolver->setDefaultConnection($this->connection ?: $migration->getConnection());
 
                 $migration->{$method}();
 


### PR DESCRIPTION
When executing the `hyperf migrate` command with the `--database` parameter set to `sqlite`, the system still attempted to run migrations on the default database, resulting in an error.

This change modifies the execution order in the `Migrator`, ensuring that the specified database takes precedence over the connection configured in the migrations.

You can test this by running `hyperf migrate` without parameters and using `hyperf migrate --database=sqlite`, configuring a database in addition to the default.