### PR TITLE
Fixed bug that `data_get` cannot support `int` key. 

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.42 - TBD
 
+## Fixed
+
+- [#7081](https://github.com/hyperf/hyperf/pull/7081) Fixed bug that `data_get` cannot support `int` key. 
+
 # v3.1.41 - 2024-09-19
 
 ## Added

--- a/src/collection/src/Functions.php
+++ b/src/collection/src/Functions.php
@@ -55,7 +55,7 @@ function data_get($target, $key, $default = null)
         return $target;
     }
 
-    $key = is_array($key) ? $key : explode('.', $key);
+    $key = is_array($key) ? $key : explode('.', strval($key));
 
     foreach ($key as $i => $segment) {
         unset($key[$i]);

--- a/src/collection/src/Functions.php
+++ b/src/collection/src/Functions.php
@@ -55,7 +55,7 @@ function data_get($target, $key, $default = null)
         return $target;
     }
 
-    $key = is_array($key) ? $key : explode('.', strval($key));
+    $key = is_array($key) ? $key : explode('.', (string) $key);
 
     foreach ($key as $i => $segment) {
         unset($key[$i]);

--- a/src/collection/src/Functions.php
+++ b/src/collection/src/Functions.php
@@ -44,12 +44,9 @@ function data_fill(&$target, $key, $value)
 /**
  * Get an item from an array or object using "dot" notation.
  *
- * @param mixed $target
  * @param null|array|int|string $key
- * @param mixed $default
- * @return mixed
  */
-function data_get($target, $key, $default = null)
+function data_get(mixed $target, mixed $key, mixed $default = null): mixed
 {
     if (is_null($key)) {
         return $target;

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -383,6 +383,14 @@ class CollectionTest extends TestCase
         $this->assertEquals(['a', 'b', 'c'], $c->replace(null)->all());
     }
 
+    public function testDateGetWithInteger()
+    {
+        $data = ['id' => 1, 2 => 2];
+
+        $this->assertSame(1, \Hyperf\Collection\data_get($data, 'id'));
+        $this->assertSame(2, \Hyperf\Collection\data_get($data, 2));
+    }
+
     public function testReplaceArray(): void
     {
         $c = new Collection(['a', 'b', 'c']);


### PR DESCRIPTION
strval($key)