### PR TITLE
Improve NSQ connection pool heartbeat detection.

### DIFF
--- a/src/nsq/src/Pool/NsqConnection.php
+++ b/src/nsq/src/Pool/NsqConnection.php
@@ -73,7 +73,22 @@ class NsqConnection extends KeepaliveConnection
 
         return $socket;
     }
-
+    
+    protected function heartbeat(): void
+    {
+        $heartbeatSecounds = $this->getHeartbeatSeconds();
+        if ($heartbeatSecounds <= 0) {
+            return;
+        }
+        Timer::tick((int) $this->getHeartbeatSeconds() * 1000, function () {
+            if ($this->isTimeout()) {
+                $this->call(function ($connect) {
+                    $connect->send($this->builder->buildNop());
+                }, false);
+            }
+        });
+    }
+    
     /**
      * @param Socket $connection
      */


### PR DESCRIPTION
最近项目中也遇到了连接NSQ之后一段时间再发布消息，提示`PHP Fatal error:  Uncaught Hyperf\Pool\Exception\ConnectionException: Payload send failed, the errorCode is 32`的问题，
搜索了一下关于这个致命错误的issue有几个，随后我debug了一下并参考pr https://github.com/hyperf/hyperf/pull/1729 进行了简单的修改来处理这个问题，目前运行良好，没有再次出现这个报错。

相关issues:
https://github.com/hyperf/hyperf/issues/5516
https://github.com/hyperf/hyperf/issues/3546
