### PR TITLE
Replace `Monolog\Logger::DEBUG`  to `Monolog\Level::DEBUG`

### DIFF
--- a/src/logger/publish/logger.php
+++ b/src/logger/publish/logger.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
+use Monolog\Level;
 
 return [
     'default' => [
@@ -20,7 +20,7 @@ return [
                 'class' => StreamHandler::class,
                 'constructor' => [
                     'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-                    'level' => Logger::DEBUG,
+                    'level' => Level::DEBUG,
                 ],
                 'formatter' => [
                     'class' => LineFormatter::class,


### PR DESCRIPTION
`Monolog\Logger::DEBUG` is deprecated.