### PR TITLE
Replace `Monolog\Logger::DEBUG` to `Monolog\Level::DEBUG`

### DIFF
--- a/src/logger/publish/logger.php
+++ b/src/logger/publish/logger.php
@@ -16,7 +16,7 @@ return [
                 'class' => Monolog\Handler\StreamHandler::class,
                 'constructor' => [
                     'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-                    'level' => Monolog\Logger::DEBUG,
+                    'level' => Monolog\Level::DEBUG,
                 ],
                 'formatter' => [
                     'class' => Monolog\Formatter\LineFormatter::class,

--- a/src/logger/src/LoggerFactory.php
+++ b/src/logger/src/LoggerFactory.php
@@ -19,6 +19,7 @@ use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\FormattableHandlerInterface;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -76,7 +77,7 @@ class LoggerFactory
         $handlerClass = Arr::get($config, 'handler.class', StreamHandler::class);
         $handlerConstructor = Arr::get($config, 'handler.constructor', [
             'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-            'level' => Logger::DEBUG,
+            'level' => Level::DEBUG,
         ]);
 
         return [


### PR DESCRIPTION
Monolog\Logger::DEBUG is deprecated.