### PR TITLE
Removed `env_vars` to keep the child process environment variables consistent with the parent process

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - [#7082](https://github.com/hyperf/hyperf/pull/7082) Optimized the code of `Hyperf\Database\Query\Grammars\Grammar::compileUpdate()`.
 - [#7084](https://github.com/hyperf/hyperf/pull/7084) Optimized the code of `Hyperf\Watcher\Ast\RewriteClassNameVisitor::leaveNode()`.
+- [#7105](https://github.com/hyperf/hyperf/pull/7105) Removed `env_vars` to keep the child process environment variables consistent with the parent process.
 
 ## Added
 

--- a/src/watcher/src/Watcher.php
+++ b/src/watcher/src/Watcher.php
@@ -132,10 +132,9 @@ class Watcher
             ];
 
             proc_open(
-                $this->option->getBin() . ' ' . BASE_PATH . '/' . $this->option->getCommand(),
-                $descriptorSpec,
-                $pipes,
-                env_vars: $_ENV
+                command: $this->option->getBin() . ' ' . BASE_PATH . '/' . $this->option->getCommand(),
+                descriptor_spec: $descriptorSpec,
+                pipes: $pipes
             );
 
             $this->output->writeln('Stop server success.');


### PR DESCRIPTION
Fix #7033