### PR TITLE
Async Queue: make default channel name consistent with the Redis driver

### DIFF
--- a/src/async-queue/publish/async_queue.php
+++ b/src/async-queue/publish/async_queue.php
@@ -17,7 +17,7 @@ return [
         'redis' => [
             'pool' => 'default',
         ],
-        'channel' => '{queue}',
+        'channel' => 'queue',
         'timeout' => 2,
         'retry_seconds' => 5,
         'handle_timeout' => 10,


### PR DESCRIPTION
To make the default channel name consistent with [the one](https://github.com/hyperf/hyperf/blob/v3.1.42/src/async-queue/src/Driver/RedisDriver.php#L49) from the Redis driver.