### PR TITLE
fix: migration connection setting invalid

### DIFF
--- a/src/database/src/Migrations/Migration.php
+++ b/src/database/src/Migrations/Migration.php
@@ -22,7 +22,7 @@ abstract class Migration
     /**
      * The name of the database connection to use.
      */
-    protected string $connection = 'default';
+    protected string $connection = '';
 
     /**
      * Get the migration connection name.

--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -245,7 +245,7 @@ class Migrator
      */
     public function resolveConnection(string $connection)
     {
-        return $this->resolver->connection($this->connection ?: $connection);
+        return $this->resolver->connection($connection ?: $this->connection);
     }
 
     /**
@@ -457,7 +457,7 @@ class Migrator
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
                 $defaultConnection = $this->resolver->getDefaultConnection();
-                $this->resolver->setDefaultConnection($this->connection ?: $migration->getConnection());
+                $this->resolver->setDefaultConnection($migration->getConnection() ?: $this->connection);
 
                 $migration->{$method}();
 


### PR DESCRIPTION
https://github.com/hyperf/hyperf/pull/7051, 这个修复有点问题，简单的修改优先级会导致migration文件中的connection设置失效。要解决database参数无效的问题，不能是修改优先级，优先顺序还是和之前一样，只是修改Migration文件中$connection的默认值为空即可解决