### PR TITLE
Fix migration error

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.45 - TBD
 
+## Fixed
+
+- [#7133](https://github.com/hyperf/hyperf/pull/7133) Fixed bug that the connection of migrations cannot work excepted.
+
 # v3.1.44 - 2024-10-24
 
 ## Added

--- a/src/database/src/Migrations/Migration.php
+++ b/src/database/src/Migrations/Migration.php
@@ -22,7 +22,7 @@ abstract class Migration
     /**
      * The name of the database connection to use.
      */
-    protected string $connection = 'default';
+    protected string $connection = '';
 
     /**
      * Get the migration connection name.

--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -245,7 +245,7 @@ class Migrator
      */
     public function resolveConnection(string $connection)
     {
-        return $this->resolver->connection($this->connection ?: $connection);
+        return $this->resolver->connection($connection ?: $this->connection);
     }
 
     /**
@@ -457,7 +457,7 @@ class Migrator
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
                 $defaultConnection = $this->resolver->getDefaultConnection();
-                $this->resolver->setDefaultConnection($this->connection ?: $migration->getConnection());
+                $this->resolver->setDefaultConnection($migration->getConnection() ?: $this->connection);
 
                 $migration->{$method}();
 

--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -32,7 +32,7 @@ class Migrator
      *
      * @var string
      */
-    protected $connection;
+    protected $connection = 'default';
 
     /**
      * The paths to all of the migration files.


### PR DESCRIPTION
https://github.com/hyperf/hyperf/pull/7051, 这个修复database参数生效了，但是导致migrations中文件设置的connection无法生效。
1. 将优先级修改调回，通过修改类Migration中$connection默认为空，来使得database参数生效
2. Migrator中$connection添加default默认参数，通过testcases