### PR TITLE
Add entry point setup for Docker hot-reloading in Watcher doc

### DIFF
--- a/docs/en/watcher.md
+++ b/docs/en/watcher.md
@@ -75,6 +75,13 @@ Because of the directory structure, the start command has to be run in the root 
 php bin/hyperf.php server:watch
 ```
 
+## Startup with docker 
+When configuring a file watcher for hot-reloading in Docker, specify the entry point in the Dockerfile as follows:
+
+```bash
+ENTRYPOINT ["php", "/opt/www/bin/hyperf.php", "server:watch"]
+```
+
 ## Problems
 
 - For now, there is a slight problem in the Alpine Docker environment, which will be improved in the future version.


### PR DESCRIPTION
### Summary
This PR adds instructions for configuring hot-reload with Docker in the Watcher documentation.

### Details
- **Section Added**: Startup with Docker
- **Instructions**: Specifies the Docker `ENTRYPOINT` command to enable hot-reloading in development environments.

### Purpose
These changes help developers set up hot-reloading when running Hyperf in Docker, improving the development workflow without affecting other parts of the documentation.