### PR TITLE
Allow request IP retrieval during tests via server parameters

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Optimized
 
 - [#7194](https://github.com/hyperf/hyperf/pull/7194) Optimized the database exception to implement unique constraint error detection.
+- [#7187](https://github.com/hyperf/hyperf/pull/7187) Allow request IP retrieval during tests via server parameters.
 
 ## Fixed
 

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -290,16 +290,16 @@ class Client extends Server
     protected function getServerParams(string $method, string $uri): array
     {
         return [
-            "request_method" => $method,
-            "request_uri" => $uri,
-            "path_info" => $uri,
-            "request_time" => time(),
-            "request_time_float" => microtime(true),
-            "server_protocol" => "HTTP/1.1",
-            "server_port" => 9501,
-            "remote_port" => 40005,
-            "remote_addr" => "127.0.0.1",
-            "master_time" => time()
+            'request_method' => $method,
+            'request_uri' => $uri,
+            'path_info' => $uri,
+            'request_time' => time(),
+            'request_time_float' => microtime(true),
+            'server_protocol' => 'HTTP/1.1',
+            'server_port' => 9501,
+            'remote_port' => 40005,
+            'remote_addr' => '127.0.0.1',
+            'master_time' => time(),
         ];
     }
 }

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -192,6 +192,7 @@ class Client extends Server
         $body = new SwooleStream($content);
 
         $request = new Psr7Request($method, $uri, $headers, $body);
+        $request->setServerParams($this->getServerParams($method, $uri->getPath()));
 
         return $request->withQueryParams($query)
             ->withParsedBody($data)
@@ -284,5 +285,21 @@ class Client extends Server
         }
 
         return $stream;
+    }
+
+    protected function getServerParams(string $method, string $uri): array
+    {
+        return [
+            "request_method" => $method,
+            "request_uri" => $uri,
+            "path_info" => $uri,
+            "request_time" => time(),
+            "request_time_float" => microtime(true),
+            "server_protocol" => "HTTP/1.1",
+            "server_port" => 9501,
+            "remote_port" => 40005,
+            "remote_addr" => "127.0.0.1",
+            "master_time" => time()
+        ];
     }
 }


### PR DESCRIPTION
This update allows retrieving the request IP address while running tests by enabling access to the REMOTE_ADDR server parameter. This enhancement is particularly useful for scenarios where the application logic relies on the client’s IP address, ensuring consistent behavior in both runtime and testing environments. By leveraging mock server parameters, developers can validate IP-dependent functionality during automated tests with greater accuracy and flexibility.


Example:

```
class AuthController extends AbstractController
{

    function authenticate(): ResponseInterface
    {
        $ip = $this->request->server('remote_addr'); // actually returns null while running tests

        // do something...
    }
}
```