### PR TITLE
Optimized the database exception to implement unique constraint error detection.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.48 - TBD
 
+## Optimized
+
+- [#7194](https://github.com/hyperf/hyperf/pull/7194) Optimized the database exception to implement unique constraint error detection.
+
 ## Fixed
 
 - [#7188](https://github.com/hyperf/hyperf/pull/7188) Fixed bug that `Hyperf\HttpMessage\Server\ResponsePlusProxy` cannot support another responses without `getCookies`.

--- a/src/database-pgsql/src/PostgreSqlConnection.php
+++ b/src/database-pgsql/src/PostgreSqlConnection.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Hyperf\Database\PgSQL;
 
+use Exception;
 use Hyperf\Database\Connection;
 use Hyperf\Database\PgSQL\DBAL\PostgresDriver;
 use Hyperf\Database\PgSQL\Query\Grammars\PostgresGrammar as QueryGrammar;
@@ -46,6 +47,16 @@ class PostgreSqlConnection extends Connection
                 $value
             );
         }
+    }
+
+    /**
+     * Determine if the given database exception was caused by a unique constraint violation.
+     *
+     * @return bool
+     */
+    protected function isUniqueConstraintError(Exception $exception)
+    {
+        return $exception->getCode() === '23505';
     }
 
     /**

--- a/src/database-sqlite/src/SQLiteConnection.php
+++ b/src/database-sqlite/src/SQLiteConnection.php
@@ -15,6 +15,7 @@ namespace Hyperf\Database\SQLite;
 use Closure;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver as DoctrineDriver;
+use Exception;
 use Hyperf\Database\Connection;
 use Hyperf\Database\Query\Grammars\Grammar as HyperfQueryGrammar;
 use Hyperf\Database\Query\Processors\Processor;
@@ -63,6 +64,16 @@ class SQLiteConnection extends Connection
         }
 
         return new SQLiteBuilder($this);
+    }
+
+    /**
+     * Determine if the given database exception was caused by a unique constraint violation.
+     *
+     * @return bool
+     */
+    protected function isUniqueConstraintError(Exception $exception)
+    {
+        return boolval(preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
     }
 
     /**

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -1099,6 +1099,7 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement and log its execution context.
      *
+     * @throws UniqueConstraintViolationException
      * @throws QueryException
      */
     protected function run(string $query, array $bindings, Closure $callback)
@@ -1141,6 +1142,7 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement.
      *
+     * @throws UniqueConstraintViolationException
      * @throws QueryException
      */
     protected function runQueryCallback(string $query, array $bindings, Closure $callback)
@@ -1207,6 +1209,7 @@ class Connection implements ConnectionInterface
     /**
      * Handle a query exception that occurred during query execution.
      *
+     * @throws UniqueConstraintViolationException
      * @throws QueryException
      */
     protected function tryAgainIfCausedByLostConnection(QueryException $e, string $query, array $bindings, Closure $callback)

--- a/src/database/src/Exception/UniqueConstraintViolationException.php
+++ b/src/database/src/Exception/UniqueConstraintViolationException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Database\Exception;
+
+class UniqueConstraintViolationException extends QueryException
+{
+}

--- a/src/database/src/MySqlConnection.php
+++ b/src/database/src/MySqlConnection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Database;
 
 use Doctrine\DBAL\Driver\PDO\MySQL\Driver;
+use Exception;
 use Hyperf\Database\DBAL\MySqlDriver;
 use Hyperf\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Hyperf\Database\Query\Processors\MySqlProcessor;
@@ -45,6 +46,16 @@ class MySqlConnection extends Connection
                 $value
             );
         }
+    }
+
+    /**
+     * Determine if the given database exception was caused by a unique constraint violation.
+     *
+     * @return bool
+     */
+    protected function isUniqueConstraintError(Exception $exception)
+    {
+        return boolval(preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage()));
     }
 
     /**

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -425,7 +425,9 @@ class ModelRealBuilderTest extends TestCase
         try {
             $res = TestModel::query()->insert(['user_id' => 1, 'uid' => 1]);
         } catch (UniqueConstraintViolationException $exception) {
-            $this->assertTrue(true);
+            // check if the exception is instance of QueryException
+            $this->assertInstanceOf(QueryException::class, $exception);
+            $this->assertSame('Duplicate entry 1 for key \'user_id\'', $exception->getMessage());
         }
 
         $model = TestModel::query()->find(1);

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -427,7 +427,7 @@ class ModelRealBuilderTest extends TestCase
         } catch (UniqueConstraintViolationException $exception) {
             // check if the exception is instance of QueryException
             $this->assertInstanceOf(QueryException::class, $exception);
-            $this->assertStringContainsString('Duplicate entry \'1\' for key \'user_id\'', $exception->getMessage());
+            $this->assertStringContainsString('Duplicate entry \'1\' for key', $exception->getMessage());
         }
 
         $model = TestModel::query()->find(1);

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -427,7 +427,7 @@ class ModelRealBuilderTest extends TestCase
         } catch (UniqueConstraintViolationException $exception) {
             // check if the exception is instance of QueryException
             $this->assertInstanceOf(QueryException::class, $exception);
-            $this->assertSame('Duplicate entry 1 for key \'user_id\'', $exception->getMessage());
+            $this->assertStringContainsString('Duplicate entry \'1\' for key \'user_id\'', $exception->getMessage());
         }
 
         $model = TestModel::query()->find(1);

--- a/src/database/tests/ModelRealBuilderTest.php
+++ b/src/database/tests/ModelRealBuilderTest.php
@@ -26,6 +26,7 @@ use Hyperf\Database\Connectors\ConnectionFactory;
 use Hyperf\Database\Connectors\MySqlConnector;
 use Hyperf\Database\Events\QueryExecuted;
 use Hyperf\Database\Exception\QueryException;
+use Hyperf\Database\Exception\UniqueConstraintViolationException;
 use Hyperf\Database\Model\EnumCollector;
 use Hyperf\Database\Model\Events\Saved;
 use Hyperf\Database\Model\Model;
@@ -420,6 +421,12 @@ class ModelRealBuilderTest extends TestCase
 
         $res = TestModel::query()->insert(['user_id' => 1, 'uid' => 1]);
         $this->assertTrue($res);
+
+        try {
+            $res = TestModel::query()->insert(['user_id' => 1, 'uid' => 1]);
+        } catch (UniqueConstraintViolationException $exception) {
+            $this->assertTrue(true);
+        }
 
         $model = TestModel::query()->find(1);
         $this->assertSame(1, $model->uid);


### PR DESCRIPTION
…

Add isUniqueConstraintError method implementations for:
- MySQL: Check for error code 1062 in message
- PostgreSQL: Check for error code 23505
- SQLite: Check for unique constraint failure messages

This allows proper detection of unique constraint violations across different database systems.