### PR TITLE
refactor(paginator): optimize collection usage in getUrlRange method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ '8.1' ]
-        swoole: [ 'swoole']
+        swoole: [ 'swoole' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.3', '8.2', '8.1' ]
-        sw-version: [ 'v5.0.3', 'v5.1.6', 'v6.0.0-rc1', 'master' ]
+        sw-version: [ 'v5.0.3', 'v5.1.6', 'v6.0.0', 'master' ]
         exclude:
           - php-version: '8.3'
             sw-version: 'v5.0.3'

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.48 - TBD
 
+## Optimized
+
+- [#7209](https://github.com/hyperf/hyperf/pull/7209) Optimized collection usage in `getUrlRange` method.
+
 # v3.1.48 - 2024-12-12
 
 ## Optimized

--- a/src/paginator/src/AbstractPaginator.php
+++ b/src/paginator/src/AbstractPaginator.php
@@ -22,8 +22,6 @@ use Hyperf\Stringable\Str;
 use Hyperf\Support\Traits\ForwardsCalls;
 use Stringable;
 
-use function Hyperf\Collection\collect;
-
 abstract class AbstractPaginator implements PaginatorInterface, ArrayAccess, Stringable
 {
     use ForwardsCalls;
@@ -120,9 +118,9 @@ abstract class AbstractPaginator implements PaginatorInterface, ArrayAccess, Str
      */
     public function getUrlRange(int $start, int $end): array
     {
-        return collect(range($start, $end))->mapWithKeys(function ($page) {
-            return [$page => $this->url($page)];
-        })->all();
+        return Collection::range($start, $end)
+            ->mapWithKeys(fn ($page) => [$page => $this->url($page)])
+            ->all();
     }
 
     /**


### PR DESCRIPTION
- Replace collect() helper with Collection::range()
- Use arrow function for better readability
- Remove unused function import