### PR TITLE
fix:修复注解方式会在非消费环境下自动投递消息到队列问题

### DIFF
--- a/src/async-queue/src/Aspect/AsyncQueueAspect.php
+++ b/src/async-queue/src/Aspect/AsyncQueueAspect.php
@@ -36,6 +36,7 @@ class AsyncQueueAspect extends AbstractAspect
     {
         $env = $this->container->get(Environment::class);
         if ($env->isAsyncQueue()) {
+            $env->setAsyncQueue(false);
             $proceedingJoinPoint->process();
             return;
         }


### PR DESCRIPTION
翻了下代码
是AnnotationJob调用之前在当前上下文写入了个bool值区别是否AnnotationJob环境
判断之后把bool值改回去可以解决重新投递的延迟任务立即执行问题
