### PR TITLE
Upgrade nesbot/carbon ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "mockery/mockery": "^1.0",
         "monolog/monolog": "^2.7 || ^3.1",
         "multiplex/socket": "^1.0",
-        "nesbot/carbon": "^2.0",
+        "nesbot/carbon": "^3.0",
         "nikic/fast-route": "^1.3",
         "nikic/php-parser": "^4.1",
         "opentracing/opentracing": "^1.0",

--- a/src/carbon/composer.json
+++ b/src/carbon/composer.json
@@ -13,7 +13,7 @@
         "hyperf/contract": "~3.1.0",
         "hyperf/event": "~3.1.0",
         "hyperf/framework": "~3.1.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^3.0"
     },
     "suggest": {
         "ramsey/uuid": "Required to use \\Ramsey\\Uuid\\Uuid (^4.7).",

--- a/src/crontab/composer.json
+++ b/src/crontab/composer.json
@@ -22,7 +22,7 @@
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
         "hyperf/utils": "~3.1.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^3.0"
     },
     "suggest": {
         "hyperf/command": "Required to use command trigger.",

--- a/src/crontab/src/Strategy/Executor.php
+++ b/src/crontab/src/Strategy/Executor.php
@@ -64,7 +64,7 @@ class Executor
     public function execute(Crontab $crontab)
     {
         try {
-            $diff = Carbon::now()->diffInRealSeconds($crontab->getExecuteTime(), false);
+            $diff = Carbon::now()->diffInSeconds($crontab->getExecuteTime(), false);
             $runnable = null;
 
             switch ($crontab->getType()) {

--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -23,7 +23,7 @@
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
         "hyperf/utils": "~3.1.0",
-        "nesbot/carbon": "^2.0",
+        "nesbot/carbon": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0"
     },

--- a/src/support/composer.json
+++ b/src/support/composer.json
@@ -25,7 +25,7 @@
         "hyperf/stringable": "~3.1.0"
     },
     "suggest": {
-        "nesbot/carbon": "Use Carbon as DateTime object.(^2.0)"
+        "nesbot/carbon": "Use Carbon as DateTime object.(^3.0)"
     },
     "autoload": {
         "psr-4": {

--- a/src/validation/composer.json
+++ b/src/validation/composer.json
@@ -21,7 +21,7 @@
         "hyperf/tappable": "~3.1.0",
         "hyperf/translation": "~3.1.0",
         "hyperf/utils": "~3.1.0",
-        "nesbot/carbon": "^2.21",
+        "nesbot/carbon": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-message": "^1.0 || ^2.0"


### PR DESCRIPTION
nesbot/carbon version 2 under PHP 8.4 throws: `Fatal error: During class fetch: Uncaught ErrorException: Carbon\Traits\Date::getDaysFromStartOfWeek(): Implicitly marking parameter $weekStartsAt as nullable is deprecated, the explicit nullable type must be used instead in vendor/nesbot/carbon/src/Carbon/Traits/Date.php:1394`
Would be solved by upgrading to at least ^3.0

Maybe could even upgrade all the way to latest ^3.8 ?...

This is also needed to support [similar Carbon upgrade for swooletw/laravel-hyperf](https://github.com/swooletw/hyperf-packages/pull/45) dependent on:

- hyperf/validation
- hyperf/crontab
- hyperf/database