### PR TITLE
Fix fatal exception "Object of class ... could not be converted to string"

### DIFF
--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -202,7 +202,7 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
         $instance = $this->container->get($fdObj->class);
 
         if (! $instance instanceof OnMessageInterface) {
-            $this->logger->warning("{$instance} is not instanceof " . OnMessageInterface::class);
+            $this->logger->warning(get_class($instance)." is not instanceof " . OnMessageInterface::class);
             return;
         }
 

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -202,7 +202,7 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
         $instance = $this->container->get($fdObj->class);
 
         if (! $instance instanceof OnMessageInterface) {
-            $this->logger->warning(get_class($instance)." is not instanceof " . OnMessageInterface::class);
+            $this->logger->warning($instance::class . " is not instanceof " . OnMessageInterface::class);
             return;
         }
 

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -202,7 +202,7 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
         $instance = $this->container->get($fdObj->class);
 
         if (! $instance instanceof OnMessageInterface) {
-            $this->logger->warning($instance::class . " is not instanceof " . OnMessageInterface::class);
+            $this->logger->warning($instance::class . ' is not instanceof ' . OnMessageInterface::class);
             return;
         }
 


### PR DESCRIPTION
Fix erroneous outputting of an error message using object instance as part of error string

Reproduce: Configure websocket server without implementing `OnMessageInterface` so that it will fail the `$instance instanceof OnMessageInterface` check

```
Fatal error: Uncaught Error: Object of class App\Http\Controllers\IndexController could not be converted to string in vendor/hyperf/websocket-server/src/Server.php:205
Stack trace:
#0 [internal function]: Hyperf\WebSocketServer\Server->onMessage(Object(Swoole\WebSocket\Server), Object(Swoole\WebSocket\Frame))
#1 {main}
  thrown in vendor/hyperf/websocket-server/src/Server.php on line 205
ERROR   php_swoole_server_rshutdown() (ERRNO 503): Fatal error: Uncaught Error: Object of class App\Http\Controllers\IndexController could not be converted to string in vendor/hyperf/websocket-server/src/Server.php:205
Stack trace:
#0 [internal function]: Hyperf\WebSocketServer\Server->onMessage(Object(Swoole\WebSocket\Server), Object(Swoole\WebSocket\Frame))
#1 {main}
  thrown in vendor/hyperf/websocket-server/src/Server.php on line 205
WARNING Worker::report_error(): worker(pid=28, id=3) abnormal exit, status=255, signal=0
```