### PR TITLE
feat(database): add existsOr and doesntExistOr methods to Builder

### DIFF
--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -2462,6 +2462,22 @@ class Builder
     }
 
     /**
+     * Execute the given callback if no rows exist for the current query.
+     */
+    public function existsOr(Closure $callback): mixed
+    {
+        return $this->exists() ? true : $callback();
+    }
+
+    /**
+     * Execute the given callback if rows exist for the current query.
+     */
+    public function doesntExistOr(Closure $callback): mixed
+    {
+        return $this->doesntExist() ? true : $callback();
+    }
+
+    /**
      * Retrieve the "count" result of the query.
      *
      * @param string $columns

--- a/src/database/tests/QueryBuilderTest.php
+++ b/src/database/tests/QueryBuilderTest.php
@@ -3125,6 +3125,38 @@ class QueryBuilderTest extends TestCase
         $this->assertTrue(call_user_func($call, '!'));
     }
 
+    public function testExistsOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->doesntExistOr(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->doesntExistOr(function () {
+            throw new RuntimeException();
+        });
+        $this->assertTrue($results);
+    }
+
+    public function testDoesntExistsOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->existsOr(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->existsOr(function () {
+            throw new RuntimeException();
+        });
+        $this->assertTrue($results);
+    }
+
     protected function getBuilderWithProcessor(): Builder
     {
         return new Builder(Mockery::mock(ConnectionInterface::class), new Grammar(), new Processor());


### PR DESCRIPTION
- Add existsOr method to execute callback if no rows exist for the query
- Add doesntExistOr method to execute callback if rows exist for the query
- Update Builder class with new methods
- Add unit tests for new methods in QueryBuilderTest