### PR TITLE
Replaced `get_called_class` with `static::class`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -16,6 +16,7 @@
 ## Optimized
 
 - [#7258](https://github.com/hyperf/hyperf/pull/7258) Optimized code for reading package data from `composer.lock`.
+- [#7276](https://github.com/hyperf/hyperf/pull/7276) Replaced `get_called_class` with `static::class`.
 
 # v3.1.50 - 2025-01-09
 

--- a/src/model-cache/src/Cacheable.php
+++ b/src/model-cache/src/Cacheable.php
@@ -56,7 +56,7 @@ trait Cacheable
     {
         $manager = $this->getContainer()->get(Manager::class);
 
-        return $manager->destroy([$this->getKey()], get_called_class());
+        return $manager->destroy([$this->getKey()], static::class);
     }
 
     /**
@@ -83,7 +83,7 @@ trait Cacheable
                 // Only increment a column's value.
                 /** @var Manager $manager */
                 $manager = $this->getContainer()->get(Manager::class);
-                $manager->increment($this->getKey(), $column, $amount, get_called_class());
+                $manager->increment($this->getKey(), $column, $amount, static::class);
             } else {
                 // Update other columns, when increment a column's value.
                 $this->deleteCache();
@@ -108,7 +108,7 @@ trait Cacheable
                 // Only decrement a column's value.
                 /** @var Manager $manager */
                 $manager = $this->getContainer()->get(Manager::class);
-                $manager->increment($this->getKey(), $column, -$amount, get_called_class());
+                $manager->increment($this->getKey(), $column, -$amount, static::class);
             } else {
                 // Update other columns, when decrement a column's value.
                 $this->deleteCache();

--- a/src/scout/src/Searchable.php
+++ b/src/scout/src/Searchable.php
@@ -174,7 +174,7 @@ trait Searchable
      */
     public static function enableSearchSyncing(): void
     {
-        ModelObserver::enableSyncingFor(get_called_class());
+        ModelObserver::enableSyncingFor(static::class);
     }
 
     /**
@@ -182,7 +182,7 @@ trait Searchable
      */
     public static function disableSearchSyncing(): void
     {
-        ModelObserver::disableSyncingFor(get_called_class());
+        ModelObserver::disableSyncingFor(static::class);
     }
 
     /**
@@ -308,6 +308,6 @@ trait Searchable
      */
     protected static function usesSoftDelete(): bool
     {
-        return in_array(SoftDeletes::class, class_uses_recursive(get_called_class()));
+        return in_array(SoftDeletes::class, class_uses_recursive(static::class));
     }
 }

--- a/src/support/src/Traits/StaticInstance.php
+++ b/src/support/src/Traits/StaticInstance.php
@@ -18,8 +18,9 @@ trait StaticInstance
 {
     public static function instance(array $params = [], bool $refresh = false, string $suffix = ''): static
     {
-        $key = get_called_class() . $suffix;
+        $key = static::class . $suffix;
         $instance = null;
+
         if (Context::has($key)) {
             $instance = Context::get($key);
         }


### PR DESCRIPTION
As of PHP 5.5 you can also use "static::class" to get the name of the called class.

https://www.php.net/manual/zh/function.get-called-class.php#115790