### PR TITLE
Fixed Test for Filesystem 2.x

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Setup Flysystem(v1.0) Adapters
         if: ${{ matrix.version == '^1.0' }}
         run: |
+          composer require aws/aws-sdk-php:3.337.3
           composer require xxtime/flysystem-aliyun-oss -W
           composer require "overtrue/flysystem-cos:^3.0" -W
           composer require "overtrue/flysystem-qiniu:^1.0" -W

--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -85,13 +85,13 @@ jobs:
       - name: Setup Flysystem(v1.0) Adapters
         if: ${{ matrix.version == '^1.0' }}
         run: |
-          composer require aws/aws-sdk-php:3.337.3 -W
           composer require xxtime/flysystem-aliyun-oss -W
           composer require "overtrue/flysystem-cos:^3.0" -W
           composer require "overtrue/flysystem-qiniu:^1.0" -W
       - name: Setup Flysystem(v2.0) Adapters
         if: ${{ matrix.version == '^2.0' }}
         run: |
+          composer require aws/aws-sdk-php:3.337.3 -W
           composer require hyperf/flysystem-oss -W
           composer require "league/flysystem-ftp:^3.0" -W
           composer require "overtrue/flysystem-cos:^4.0" -W

--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Flysystem(v1.0) Adapters
         if: ${{ matrix.version == '^1.0' }}
         run: |
-          composer require aws/aws-sdk-php:3.337.3
+          composer require aws/aws-sdk-php:3.337.3 -W
           composer require xxtime/flysystem-aliyun-oss -W
           composer require "overtrue/flysystem-cos:^3.0" -W
           composer require "overtrue/flysystem-qiniu:^1.0" -W


### PR DESCRIPTION
aws/aws-sdk-php 3.338.0 之后移除了 psr/http-message 1.0 依赖，与 qcloud-cos-client 4.x 依赖冲突了。

提PR给 qcloud-cos-client 了，看是不是可以支持2.0 https://github.com/overtrue/qcloud-cos-client/pull/16