### PR TITLE
Fixed bug that testing client cannot support json without `POST`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.53 - TBD
 
+## Fixed
+
+- [#7309](https://github.com/hyperf/hyperf/pull/7309) Fixed bug that testing client cannot support json without `POST`.
+
 # v3.1.52 - 2025-02-27
 
 ## Added

--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -184,7 +184,7 @@ class Client extends Server
         $uri = (new Uri($this->baseUri . ltrim($path, '/')))->withQuery(http_build_query($query));
 
         $content = http_build_query($params);
-        if ($method == 'POST' && data_get($headers, 'Content-Type') == 'application/json') {
+        if (data_get($headers, 'Content-Type') == 'application/json' && ! empty($json)) {
             $content = json_encode($json, JSON_UNESCAPED_UNICODE);
             $data = $json;
         }


### PR DESCRIPTION
fix:修复 \Hyperf\Testing\Client::initRequest 方法中，如果请求头传了 application/json 只有 POST 的情况下才会生效的问题