### PR TITLE
Added validation rules `contains`, `extensions` and `hex_color`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -8,6 +8,7 @@
 ## Added
 
 - [#7311](https://github.com/hyperf/hyperf/pull/7311) Added `Hyperf\Redis\Event\CommandExecuted::getFormatCommand()`.
+- [#7313](https://github.com/hyperf/hyperf/pull/7313) Added validation rules `contains`, `extensions` and `hex_color`.
 - [#7314](https://github.com/hyperf/hyperf/pull/7314) Enable `schema` Configuration for `hyperf/db` with `pgsql`.
 
 # v3.1.52 - 2025-02-27

--- a/src/validation/publish/en/validation.php
+++ b/src/validation/publish/en/validation.php
@@ -41,6 +41,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'confirmed' => 'The :attribute confirmation does not match.',
+    'contains' => 'The :attribute is missing a required value.',
     'date' => 'The :attribute is not a valid date.',
     'date_equals' => 'The :attribute must be a date equal to :date.',
     'date_format' => 'The :attribute does not match the format :format.',
@@ -56,7 +57,9 @@ return [
     'doesnt_start_with' => 'The :attribute must not start with one of the following: :values.',
     'email' => 'The :attribute must be a valid email address.',
     'ends_with' => 'The :attribute must end with one of the following: :values.',
+    'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',
+    'extensions' => 'The :attribute must have one of the following extensions: :values.',
     'file' => 'The :attribute must be a file.',
     'filled' => 'The :attribute field is required.',
     'gt' => [
@@ -71,6 +74,7 @@ return [
         'string' => 'The :attribute must be great than or equal to :value characters',
         'array' => 'The :attribute must be great than or equal to :value items',
     ],
+    'hex_color' => 'The :attribute must be a valid hexadecimal color.',
     'image' => 'The :attribute must be an image.',
     'in' => 'The selected :attribute is invalid.',
     'in_array' => 'The :attribute field does not exist in :other.',
@@ -93,6 +97,7 @@ return [
         'string' => 'The :attribute must be less than or equal to :value characters',
         'array' => 'The :attribute must be less than or equal to :value items',
     ],
+    'mac_address' => 'The :attribute must be a valid MAC address.',
     'max' => [
         'numeric' => 'The :attribute may not be greater than :max.',
         'file' => 'The :attribute may not be greater than :max kilobytes.',

--- a/src/validation/src/Concerns/ReplacesAttributes.php
+++ b/src/validation/src/Concerns/ReplacesAttributes.php
@@ -95,6 +95,14 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the extensions rule.
+     */
+    protected function replaceExtensions(string $message, string $attribute, string $rule, array $parameters): string
+    {
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the min rule.
      */
     protected function replaceMin(string $message, string $attribute, string $rule, array $parameters): string

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -323,6 +323,27 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute contains a list of values.
+     *
+     * @param mixed $value
+     * @param array<int, int|string> $parameters
+     */
+    public function validateContains(string $attribute, $value, array $parameters): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (! in_array($parameter, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is a valid date.
      *
      * @param mixed $value
@@ -636,6 +657,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the extension of a file upload attribute is in a set of defined extensions.
+     *
+     * @param mixed $value
+     * @param array<int, int|string>  $parameters
+     */
+    public function validateExtensions(string $attribute, $value, array $parameters): bool
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
+        return in_array(strtolower($value->getClientOriginalExtension()), $parameters);
+    }
+
+    /**
      * Validate the given value is a valid file.
      *
      * @param mixed $value
@@ -789,6 +829,16 @@ trait ValidatesAttributes
     public function validateUppercase(string $attribute, mixed $value, array $parameters): bool
     {
         return Str::upper($value) === $value;
+    }
+
+    /**
+     * Validate that an attribute is a valid HEX color.
+     *
+     * @param mixed $value
+     */
+    public function validateHexColor(string $attribute, $value): bool
+    {
+        return preg_match('/^#(?:(?:[0-9a-f]{3}){1,2}|(?:[0-9a-f]{4}){1,2})$/i', $value) === 1;
     }
 
     /**

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -672,7 +672,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return in_array(strtolower($value->getClientOriginalExtension()), $parameters);
+        return in_array(strtolower($value->getExtension()), $parameters);
     }
 
     /**

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -660,7 +660,7 @@ trait ValidatesAttributes
      * Validate the extension of a file upload attribute is in a set of defined extensions.
      *
      * @param mixed $value
-     * @param array<int, int|string>  $parameters
+     * @param array<int, int|string> $parameters
      */
     public function validateExtensions(string $attribute, $value, array $parameters): bool
     {

--- a/src/validation/src/Rules/File.php
+++ b/src/validation/src/Rules/File.php
@@ -44,6 +44,13 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected array $allowedMimetypes = [];
 
     /**
+     * The extensions that the given file should match.
+     *
+     * @var array
+     */
+    protected $allowedExtensions = [];
+
+    /**
      * The minimum size in kilobytes that the file can be.
      */
     protected ?int $minimumFileSize = null;
@@ -122,6 +129,19 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     public static function types(array|string $mimetypes): static
     {
         return \Hyperf\Tappable\tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+    }
+
+    /**
+     * Limit the uploaded file to the given file extensions.
+     *
+     * @param array<int, string>|string $extensions
+     * @return $this
+     */
+    public function extensions($extensions): static
+    {
+        $this->allowedExtensions = (array) $extensions;
+
+        return $this;
     }
 
     /**
@@ -275,6 +295,10 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         $rules = ['file'];
 
         $rules = array_merge($rules, $this->buildMimetypes());
+
+        if (! empty($this->allowedExtensions)) {
+            $rules[] = 'extensions:' . implode(',', array_map('strtolower', $this->allowedExtensions));
+        }
 
         $rules[] = match (true) {
             is_null($this->minimumFileSize) && is_null($this->maximumFileSize) => null,

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -128,8 +128,8 @@ class Validator implements ValidatorContract
      * The validation rules that may be applied to files.
      */
     protected array $fileRules = [
-        'File', 'Image', 'Mimes', 'Mimetypes', 'Min',
-        'Max', 'Size', 'Between', 'Dimensions',
+        'Between', 'Dimensions', 'Extensions', 'File', 'Image',
+        'Max', 'Mimes', 'Mimetypes', 'Min', 'Size',
     ];
 
     /**

--- a/src/validation/tests/Cases/ValidationFileRuleTest.php
+++ b/src/validation/tests/Cases/ValidationFileRuleTest.php
@@ -133,6 +133,52 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testSingleExtension()
+    {
+        $this->fails(
+            File::default()->extensions('png'),
+            (new FileFactory())->createWithContent('foo', file_get_contents(__DIR__ . '/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->fails(
+            File::default()->extensions('png'),
+            (new FileFactory())->createWithContent('foo.jpg', file_get_contents(__DIR__ . '/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->fails(
+            File::default()->extensions('jpeg'),
+            (new FileFactory())->createWithContent('foo.jpg', file_get_contents(__DIR__ . '/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->passes(
+            File::default()->extensions('png'),
+            (new FileFactory())->createWithContent('foo.png', file_get_contents(__DIR__ . '/fixtures/image.png')),
+        );
+    }
+
+    public function testMultipleExtensions()
+    {
+        $this->fails(
+            File::default()->extensions(['png', 'jpeg', 'jpg']),
+            (new FileFactory())->createWithContent('foo', file_get_contents(__DIR__ . '/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->fails(
+            File::default()->extensions(['png', 'jpeg']),
+            (new FileFactory())->createWithContent('foo.jpg', file_get_contents(__DIR__ . '/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->passes(
+            File::default()->extensions(['png', 'jpeg', 'jpg']),
+            (new FileFactory())->createWithContent('foo.png', file_get_contents(__DIR__ . '/fixtures/image.png')),
+        );
+    }
+
     public function testImage()
     {
         $this->fails(

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -3348,32 +3348,30 @@ class ValidationValidatorTest extends TestCase
     public function testValidateExtension()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $uploadedFile = [__FILE__, '', null, null, true];
+        $uploadedFile = [__FILE__, 0, 0];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getExtension')->willReturn('pdf');
+        $file->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:pdf']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpg']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg,jpg']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg']);
-        $this->assertFalse($v->passes());
-
-        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
-        $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg|extensions:jpg']);
         $this->assertFalse($v->passes());
     }
 

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -1069,6 +1069,49 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
     }
 
+    public function testValidateHexColor()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['color' => '#FFF'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#FFFF'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#FFFFFF'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#FF000080'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#FF000080'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#00FF0080'], ['color' => 'hex_color']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['color' => '#GGG'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#GGGG'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#123AB'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#GGGGGG'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#GGGGGGG'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#FFGG00FF'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['color' => '#00FF008X'], ['color' => 'hex_color']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateConfirmed()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -1308,6 +1351,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => 'off'], ['foo' => 'Accepted']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => null], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
@@ -1315,6 +1361,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Accepted']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => false], ['foo' => 'Accepted']);
@@ -2444,6 +2493,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(2, $v->messages()->first('items'));
     }
 
+    public function testValidateContains()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['name' => 0], ['name' => 'contains:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:baz,buzz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo,buzz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo,bar']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateIn()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -2730,6 +2802,49 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['ip' => '::1'], ['ip' => 'Ipv4']);
         $this->assertTrue($v->fails());
+    }
+
+    public function testValidateMacAddress()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => 'foo'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-AB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-aB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:AB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45-67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => 'xx:23:45:67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '0123.4567.89ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateEmail()
@@ -3227,6 +3342,38 @@ class ValidationValidatorTest extends TestCase
         $file->expects($this->any())->method('getMimeType')->will($this->returnValue('pdf'));
         $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateExtension()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $uploadedFile = [__FILE__, '', null, null, true];
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:pdf']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpg']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg,jpg']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg|extensions:jpg']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
- Added validation methods `contains`, `extensions` and `hex_color` to `validation` package.
- Including the `enum` method in validation messages, incorporated in https://github.com/hyperf/hyperf/pull/6749.
- Including the `mac_address` method in validation messages, incorporated in https://github.com/hyperf/hyperf/pull/6106.