### PR TITLE
Support to rewrite function `paginationInformation` for `resource`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,10 @@
 
 - [#7309](https://github.com/hyperf/hyperf/pull/7309) Fixed bug that testing client cannot support json without `POST`.
 
+## Added
+
+- [#7316](https://github.com/hyperf/hyperf/pull/7316) Support to rewrite function `paginationInformation` for `resource`.
+
 # v3.1.52 - 2025-02-27
 
 ## Added

--- a/src/resource/src/Response/PaginatedResponse.php
+++ b/src/resource/src/Response/PaginatedResponse.php
@@ -41,10 +41,16 @@ class PaginatedResponse extends Response
     {
         $paginated = $this->resource->resource->toArray();
 
-        return [
+        $default = [
             'links' => $this->paginationLinks($paginated),
             'meta' => $this->meta($paginated),
         ];
+
+        if (method_exists($this->resource, 'paginationInformation')) {
+            return $this->resource->paginationInformation($paginated, $default);
+        }
+
+        return $default;
     }
 
     /**

--- a/src/resource/src/Response/PaginatedResponse.php
+++ b/src/resource/src/Response/PaginatedResponse.php
@@ -46,7 +46,7 @@ class PaginatedResponse extends Response
             'meta' => $this->meta($paginated),
         ];
 
-        if (method_exists($this->resource, 'paginationInformation')) {
+        if ($this->resource instanceof PaginationInformationInterface) {
             return $this->resource->paginationInformation($paginated, $default);
         }
 

--- a/src/resource/src/Response/PaginationInformationInterface.php
+++ b/src/resource/src/Response/PaginationInformationInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Resource\Response;
+
+interface PaginationInformationInterface
+{
+    public function paginationInformation(array $paginated, array $default);
+}

--- a/src/resource/tests/ResourceTest.php
+++ b/src/resource/tests/ResourceTest.php
@@ -23,6 +23,7 @@ use HyperfTest\Resource\Stubs\Models\Post;
 use HyperfTest\Resource\Stubs\Models\Subscription;
 use HyperfTest\Resource\Stubs\Resources\AuthorResourceWithOptionalRelationship;
 use HyperfTest\Resource\Stubs\Resources\ObjectResource;
+use HyperfTest\Resource\Stubs\Resources\PaginationCollection;
 use HyperfTest\Resource\Stubs\Resources\PostCollectionResource;
 use HyperfTest\Resource\Stubs\Resources\PostResource;
 use HyperfTest\Resource\Stubs\Resources\PostResourceWithExtraData;
@@ -731,6 +732,27 @@ class ResourceTest extends TestCase
             1 => 20,
             'total' => 30,
         ], ['data' => [0 => 10, 1 => 20, 'total' => 30]]);
+    }
+
+    public function testResourceCollectionPagination()
+    {
+        $this->http(function () {
+            $paginator = new LengthAwarePaginator(
+                collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
+                10,
+                15,
+                1
+            );
+
+            return new PaginationCollection($paginator);
+        })->assertJson([
+            'data' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
+        ]);
     }
 
     private function assertJsonResourceResponse($data, $expectedJson)

--- a/src/resource/tests/Stubs/Resources/PaginationCollection.php
+++ b/src/resource/tests/Stubs/Resources/PaginationCollection.php
@@ -16,7 +16,7 @@ use Hyperf\Resource\Json\ResourceCollection;
 
 class PaginationCollection extends ResourceCollection
 {
-    public function paginationInformation(): array
+    public function paginationInformation(array $paginated, array $default): array
     {
         return [];
     }

--- a/src/resource/tests/Stubs/Resources/PaginationCollection.php
+++ b/src/resource/tests/Stubs/Resources/PaginationCollection.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 namespace HyperfTest\Resource\Stubs\Resources;
 
 use Hyperf\Resource\Json\ResourceCollection;
+use Hyperf\Resource\Response\PaginationInformationInterface;
 
-class PaginationCollection extends ResourceCollection
+class PaginationCollection extends ResourceCollection implements PaginationInformationInterface
 {
     public function paginationInformation(array $paginated, array $default): array
     {

--- a/src/resource/tests/Stubs/Resources/PaginationCollection.php
+++ b/src/resource/tests/Stubs/Resources/PaginationCollection.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Resource\Stubs\Resources;
+
+use Hyperf\Resource\Json\ResourceCollection;
+
+class PaginationCollection extends ResourceCollection
+{
+    public function paginationInformation(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
不想用默认的links和mate分页格式，paginationInformation方法可以支持隐藏或者自定义格式
![image](https://github.com/user-attachments/assets/1ed1b195-c87a-44c1-889c-5beff01f02b1)
