### PR TITLE
Update S3AdapterFactory.php

### DIFF
--- a/src/filesystem/src/Adapter/S3AdapterFactory.php
+++ b/src/filesystem/src/Adapter/S3AdapterFactory.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Hyperf\Filesystem\Adapter;
 
-use Aws\Handler\GuzzleV6\GuzzleHandler;
+use Aws\Handler\Guzzle\GuzzleHandler;
 use Aws\S3\S3Client;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;


### PR DESCRIPTION
flysystem-aws-s3-v3 reliant aws-sdk-php [Version 3.342.6](https://github.com/aws/aws-sdk-php/releases/tag/3.342.6) Aws\Handler - Remove code for unsupported version v6 of Guzzle and moved Aws\Handler\GuzzleV6\GuzzleHandler to an unversioned Aws\Handler\Guzzle\GuzzleHandler.
