### PR TITLE
Add exists method to LockManager

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -12,6 +12,7 @@
 - [#7313](https://github.com/hyperf/hyperf/pull/7313) Added validation rules `contains`, `extensions` and `hex_color`.
 - [#7314](https://github.com/hyperf/hyperf/pull/7314) Enable `schema` Configuration for `hyperf/db` with `pgsql`.
 - [#7325](https://github.com/hyperf/hyperf/pull/7325) Added metadata `attributes` into `Hyperf\Di\ReflectionType`.
+- [#7332](https://github.com/hyperf/hyperf/pull/7332) Added `Hyperf\Memory\LockManager::exists()`.
 
 # v3.1.52 - 2025-02-27
 

--- a/src/memory/src/LockManager.php
+++ b/src/memory/src/LockManager.php
@@ -45,6 +45,14 @@ class LockManager
     }
 
     /**
+     * Check if a lock with the given identifier exists in the container.
+     */
+    public static function exists(string $identifier): bool
+    {
+        return isset(static::$container[$identifier]);
+    }
+
+    /**
      * Remove the Lock by the identifier from container after used,
      * otherwise will occur memory leaks.
      */


### PR DESCRIPTION
Adds an `exists()` method to `LockManager` to make it easier to check for existing locks