### PR TITLE
Fixed bug that kafka producer cannot reconnect to server when the internet broken.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,11 +2,13 @@
 
 ## Added
 
+- [#7316](https://github.com/hyperf/hyperf/pull/7316) Support to rewrite function `paginationInformation` for `resource`.
 - [#7343](https://github.com/hyperf/hyperf/pull/7343) Added `Hyperf\Coroutine\Barrier`.
 
 ## Fixed
 
 - [#7328](https://github.com/hyperf/hyperf/pull/7328) Fix primary key creation for MySQL with sql_require_primary_key enabled.
+- [#7334](https://github.com/hyperf/hyperf/pull/7334) Fixed bug that kafka producer cannot reconnect to server when the internet broken.
 
 # v3.1.53 - 2025-04-03
 
@@ -23,10 +25,6 @@
 - [#7314](https://github.com/hyperf/hyperf/pull/7314) Enable `schema` Configuration for `hyperf/db` with `pgsql`.
 - [#7325](https://github.com/hyperf/hyperf/pull/7325) Added metadata `attributes` into `Hyperf\Di\ReflectionType`.
 - [#7332](https://github.com/hyperf/hyperf/pull/7332) Added `Hyperf\Memory\LockManager::exists()`.
-
-## Added
-
-- [#7316](https://github.com/hyperf/hyperf/pull/7316) Support to rewrite function `paginationInformation` for `resource`.
 
 # v3.1.52 - 2025-02-27
 

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -39,7 +39,12 @@ class Producer
 
     public function send(string $topic, ?string $value, ?string $key = null, array $headers = [], ?int $partitionIndex = null): void
     {
-        $this->sendAsync($topic, $value, $key, $headers, $partitionIndex)->wait();
+        try {
+            $this->sendAsync($topic, $value, $key, $headers, $partitionIndex)->wait();
+        } catch (Throwable $e) {
+            $this->close();
+            throw $e;
+        }
     }
 
     public function sendAsync(string $topic, ?string $value, ?string $key = null, array $headers = [], ?int $partitionIndex = null): Promise
@@ -64,7 +69,13 @@ class Producer
 
     public function sendBatch(array $messages): void
     {
-        $this->sendBatchAsync($messages)->wait();
+        try {
+            $this->sendBatchAsync($messages)->wait();
+        } catch (Throwable $e) {
+            $this->close();
+            throw $e;
+        }
+
     }
 
     /**
@@ -93,6 +104,7 @@ class Producer
     public function close(): void
     {
         $this->chan?->close();
+        $this->chan = null;
         $this->producer?->close();
     }
 

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -18,6 +18,7 @@ use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Coroutine\Coroutine;
 use Hyperf\Engine\Channel;
 use Hyperf\Kafka\Exception\ConnectionClosedException;
+use Hyperf\Kafka\Exception\TimeoutException;
 use longlang\phpkafka\Broker;
 use longlang\phpkafka\Producer\ProduceMessage;
 use longlang\phpkafka\Producer\Producer as LongLangProducer;
@@ -41,7 +42,7 @@ class Producer
     {
         try {
             $this->sendAsync($topic, $value, $key, $headers, $partitionIndex)->wait();
-        } catch (Throwable $e) {
+        } catch (TimeoutException $e) {
             $this->close();
             throw $e;
         }
@@ -71,7 +72,7 @@ class Producer
     {
         try {
             $this->sendBatchAsync($messages)->wait();
-        } catch (Throwable $e) {
+        } catch (TimeoutException $e) {
             $this->close();
             throw $e;
         }

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -76,7 +76,6 @@ class Producer
             $this->close();
             throw $e;
         }
-
     }
 
     /**


### PR DESCRIPTION
复现步骤
1. 网络正常
2. 启动框架
3. 断网
4. 发送kafka
```
    public function send(Producer $producer)
    {
        $headers = ['test-h' => 'goods-info', 'name' => 'goods-01'];
        $producer->send('hyperf', 'value:'.date('Y-m-d H:i:s'), 'key', $headers);
        return 1;
    }
```
5. 报错 `Hyperf\Kafka\Exception\TimeoutException: Kafka send timeout`
6. 恢复网络会一直报错` Kafka send timeout`


修改后, 恢复网络后正常请求
