### PR TITLE
Support callable config type for `logger`

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-- []() Support callable config type for `logger` . 
+- [#7365](https://github.com/hyperf/hyperf/pull/7365) Support callable config type for `logger` . 
 
 # v3.1.54 - 2025-04-27
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-- [#7365](https://github.com/hyperf/hyperf/pull/7365) Support callable config type for `logger` . 
+- [#7365](https://github.com/hyperf/hyperf/pull/7365) Support callable config type for `hyperf/logger`. 
 
 ## Fixed
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.55 - TBD
 
+## Added
+
+- []() Support callable config type for `logger` . 
+
 # v3.1.54 - 2025-04-27
 
 ## Added

--- a/src/logger/src/LoggerFactory.php
+++ b/src/logger/src/LoggerFactory.php
@@ -44,6 +44,9 @@ class LoggerFactory
         }
 
         $config = $config[$group];
+        if (is_callable($config)) {
+            $config = $config($name);
+        }
         $handlers = $this->handlers($config);
         $processors = $this->processors($config);
 


### PR DESCRIPTION
使用场景，相同业务类型，根据业务 ID 分割日志存储，无需定义多份 config

```php
di(LoggerFactory::class)->get('1001', 'room')->debug('房间 1001 日志')
di(LoggerFactory::class)->get('1002', 'room')->debug('房间 1002 日志')
```

```php

    'room' => function (string $name) {
        return [
            'handler' => [
                'class' => Monolog\Handler\StreamHandler::class,
                'constructor' => [
                    'stream' => BASE_PATH . '/runtime/logs/room_' . $name,
                    'level' => Monolog\Level::Debug,
                ],
            ],
            'formatter' => [
                'class' => Monolog\Formatter\LineFormatter::class,
                'constructor' => [
                    'format' => null,
                    'dateFormat' => null,
                    'allowInlineLineBreaks' => true,
                ],
            ],
        ];
    },
```