### PR TITLE
Fixed bug that pdo connector with pgsql cannot work when using migration.

### DIFF
--- a/src/database-pgsql/src/DBAL/PostgresDriver.php
+++ b/src/database-pgsql/src/DBAL/PostgresDriver.php
@@ -12,9 +12,20 @@ declare(strict_types=1);
 namespace Hyperf\Database\PgSQL\DBAL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use Hyperf\Database\DBAL\Concerns\ConnectsToDatabase;
+use InvalidArgumentException;
+use Swoole\Coroutine\PostgreSQL;
 
 class PostgresDriver extends AbstractPostgreSQLDriver
 {
-    use ConnectsToDatabase;
+    /**
+     * Create a new database connection.
+     */
+    public function connect(array $params)
+    {
+        if (! isset($params['pdo']) || ! $params['pdo'] instanceof PostgreSQL) {
+            throw new InvalidArgumentException('The "pdo" property must be required.');
+        }
+
+        return new Connection($params['pdo']);
+    }
 }

--- a/src/database-pgsql/src/DBAL/PostgresDriver.php
+++ b/src/database-pgsql/src/DBAL/PostgresDriver.php
@@ -12,20 +12,9 @@ declare(strict_types=1);
 namespace Hyperf\Database\PgSQL\DBAL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use InvalidArgumentException;
-use Swoole\Coroutine\PostgreSQL;
+use Hyperf\Database\DBAL\Concerns\ConnectsToDatabase;
 
 class PostgresDriver extends AbstractPostgreSQLDriver
 {
-    /**
-     * Create a new database connection.
-     */
-    public function connect(array $params)
-    {
-        if (! isset($params['pdo']) || ! $params['pdo'] instanceof PostgreSQL) {
-            throw new InvalidArgumentException('The "pdo" property must be required.');
-        }
-
-        return new Connection($params['pdo']);
-    }
+    use ConnectsToDatabase;
 }

--- a/src/database-pgsql/src/DBAL/PostgresPdoDriver.php
+++ b/src/database-pgsql/src/DBAL/PostgresPdoDriver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Hyperf\Database\PgSQL\DBAL;
+
+class PostgresPdoDriver
+{
+
+}
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Database\PgSQL\DBAL;
+
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Hyperf\Database\DBAL\Concerns\ConnectsToDatabase;
+
+class PostgresPdoDriver extends AbstractPostgreSQLDriver
+{
+    use ConnectsToDatabase;
+}

--- a/src/database-pgsql/src/DBAL/PostgresPdoDriver.php
+++ b/src/database-pgsql/src/DBAL/PostgresPdoDriver.php
@@ -1,12 +1,5 @@
 <?php
 
-namespace Hyperf\Database\PgSQL\DBAL;
-
-class PostgresPdoDriver
-{
-
-}
-
 declare(strict_types=1);
 /**
  * This file is part of Hyperf.

--- a/src/database-pgsql/src/PostgreSqlConnection.php
+++ b/src/database-pgsql/src/PostgreSqlConnection.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Hyperf\Database\PgSQL;
 
 use Hyperf\Database\Connection;
-use Hyperf\Database\PgSQL\DBAL\PostgresDriver;
+use Hyperf\Database\PgSQL\DBAL\PostgresPdoDriver;
 use Hyperf\Database\PgSQL\Query\Grammars\PostgresGrammar as QueryGrammar;
 use Hyperf\Database\PgSQL\Query\Processors\PostgresProcessor;
 use Hyperf\Database\PgSQL\Schema\Grammars\PostgresGrammar as SchemaGrammar;
@@ -76,8 +76,8 @@ class PostgreSqlConnection extends Connection
     /**
      * Get the Doctrine DBAL driver.
      */
-    protected function getDoctrineDriver(): PostgresDriver
+    protected function getDoctrineDriver(): PostgresPdoDriver
     {
-        return new PostgresDriver();
+        return new PostgresPdoDriver();
     }
 }


### PR DESCRIPTION
fix: connect方法校验的类型必须是PostgreSQL，然而在之前hyperf/database处理时出来的pdo类型是PDO，导致migration时变更（change）字段时出现报错。 只有变更字段时会直接调用“doctrine/dbal”获得SQL语句，create table等migration动作时都是本仓库完成的，所以直接修改为按照hyperf/database的mysql一样返回PDO类型。经测试，能正常使用。