### PR TITLE
Support `compileJsonOverlaps`

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Added
 
 - [#7365](https://github.com/hyperf/hyperf/pull/7365) Support callable config type for `hyperf/logger`. 
+- [#7381](https://github.com/hyperf/hyperf/pull/7381) Added `Hyperf\Database\PgSQL\Query\Grammars\PostgresGrammar\compileJsonOverlaps`.
 
 ## Fixed
 

--- a/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database-pgsql/src/Query/Grammars/PostgresGrammar.php
@@ -336,6 +336,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON overlaps" statement into SQL.
+     */
+    protected function compileJsonOverlaps(string $column, string $value): string
+    {
+        $column = str_replace('->>', '->', $this->wrap($column));
+
+        return 'EXISTS ( SELECT 1 FROM jsonb_array_elements((' . $column . ')::jsonb) AS elem1, jsonb_array_elements(' . $value . '::jsonb) AS elem2 WHERE elem1 = elem2)';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param string $column


### PR DESCRIPTION
MySQL already supports compileJsonOverlaps, and now Postgres supports it.