### PR TITLE
Db::setDefaultConnection('mydb') throwing exception

### DIFF
--- a/src/db-connection/src/ConnectionResolver.php
+++ b/src/db-connection/src/ConnectionResolver.php
@@ -82,14 +82,14 @@ class ConnectionResolver implements ConnectionResolverInterface
     /**
      * Set the default connection name.
      */
-    public function setDefaultConnection(string $name): void
+    public function setDefaultConnection(string $name, bool $scopeCoroutine = false): void
     {
-        $this->default = $name;
-    }
+        if ($scopeCoroutine) {
+            Context::set($this->getDefaultConnectionContextKey(), $name);
+            return;
+        }
 
-    public function setDefaultConnectionForCoroutine(string $name): void
-    {
-        Context::set($this->getDefaultConnectionContextKey(), $name);
+        $this->default = $name;
     }
 
     /**

--- a/src/db-connection/src/ConnectionResolver.php
+++ b/src/db-connection/src/ConnectionResolver.php
@@ -103,6 +103,6 @@ class ConnectionResolver implements ConnectionResolverInterface
 
     private function getDefaultConnectionContextKey(): string
     {
-        return 'database.connection.default';
+        return 'database.connection.default.key';
     }
 }

--- a/src/db-connection/src/ConnectionResolver.php
+++ b/src/db-connection/src/ConnectionResolver.php
@@ -76,7 +76,7 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     public function getDefaultConnection(): string
     {
-        return $this->default;
+        return Context::get($this->getDefaultConnectionContextKey()) ?? $this->default;
     }
 
     /**
@@ -87,6 +87,11 @@ class ConnectionResolver implements ConnectionResolverInterface
         $this->default = $name;
     }
 
+    public function setDefaultConnectionForCoroutine(string $name): void
+    {
+        Context::set($this->getDefaultConnectionContextKey(), $name);
+    }
+
     /**
      * The key to identify the connection object in coroutine context.
      * @param mixed $name
@@ -94,5 +99,10 @@ class ConnectionResolver implements ConnectionResolverInterface
     private function getContextKey($name): string
     {
         return sprintf('database.connection.%s', $name);
+    }
+
+    private function getDefaultConnectionContextKey(): string
+    {
+        return 'database.connection.default';
     }
 }

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -52,7 +52,7 @@ class Db
 
     public function __call($name, $arguments)
     {
-        if ($name === 'connection') {
+        if ($name === 'connection' || $name === 'setDefaultConnection') {
             return $this->__connection(...$arguments);
         }
         return $this->__connection()->{$name}(...$arguments);

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -43,7 +43,7 @@ use Psr\Container\ContainerInterface;
  * @method static int transactionLevel()
  * @method static array pretend(Closure $callback)
  * @method static ConnectionInterface connection(?string $pool = null)
- * @method static void setDefaultConnectionForCoroutine(string $name)
+ * @method static void setDefaultConnection(string $name, bool $scopeCoroutine = false)
  */
 class Db
 {
@@ -56,8 +56,8 @@ class Db
         if ($name === 'connection') {
             return $this->__connection(...$arguments);
         }
-        if ($name === 'setDefaultConnectionForCoroutine') {
-            $this->__setDefaultConnectionForCoroutine(...$arguments);
+        if ($name === 'setDefaultConnection') {
+            $this->__setDefaultConnection(...$arguments);
             return;
         }
         return $this->__connection()->{$name}(...$arguments);
@@ -69,8 +69,8 @@ class Db
         if ($name === 'connection') {
             return $db->__connection(...$arguments);
         }
-        if ($name === 'setDefaultConnectionForCoroutine') {
-            $db->__setDefaultConnectionForCoroutine(...$arguments);
+        if ($name === 'setDefaultConnection') {
+            $db->__setDefaultConnection(...$arguments);
             return;
         }
         return $db->__connection()->{$name}(...$arguments);
@@ -82,10 +82,10 @@ class Db
         return $resolver->connection($name);
     }
 
-    private function __setDefaultConnectionForCoroutine(?string $name = null): void
+    private function __setDefaultConnection(string $name, bool $scopeCoroutine = false): void
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
-        $resolver->setDefaultConnectionForCoroutine($name); // @phpstan-ignore method.notFound
+        $resolver->setDefaultConnection($name, $scopeCoroutine);
     }
 
     public static function beforeExecuting(Closure $closure): void

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -56,6 +56,7 @@ class Db
             return $this->__connection(...$arguments);
         } else if ($name === 'setDefaultConnection') {
             $this->__setDefaultConnection(...$arguments);
+            return;
         }
         return $this->__connection()->{$name}(...$arguments);
     }
@@ -67,6 +68,7 @@ class Db
             return $db->__connection(...$arguments);
         } else if ($name === 'setDefaultConnection') {
             $db->__setDefaultConnection(...$arguments);
+            return;
         }
         return $db->__connection()->{$name}(...$arguments);
     }

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -52,8 +52,10 @@ class Db
 
     public function __call($name, $arguments)
     {
-        if ($name === 'connection' || $name === 'setDefaultConnection') {
+        if ($name === 'connection') {
             return $this->__connection(...$arguments);
+        } else if ($name === 'setDefaultConnection') {
+            return $this->__setDefaultConnection(...$arguments);
         }
         return $this->__connection()->{$name}(...$arguments);
     }
@@ -63,6 +65,8 @@ class Db
         $db = ApplicationContext::getContainer()->get(Db::class);
         if ($name === 'connection') {
             return $db->__connection(...$arguments);
+        } else if ($name === 'setDefaultConnection') {
+            return $db->__setDefaultConnection(...$arguments);
         }
         return $db->__connection()->{$name}(...$arguments);
     }
@@ -71,6 +75,12 @@ class Db
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
         return $resolver->connection($name);
+    }
+
+    private function __setDefaultConnection(?string $name = null): ConnectionInterface
+    {
+        $resolver = $this->container->get(ConnectionResolverInterface::class);
+        return $resolver->setDefaultConnection($name);
     }
 
     public static function beforeExecuting(Closure $closure): void

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -55,7 +55,7 @@ class Db
         if ($name === 'connection') {
             return $this->__connection(...$arguments);
         } else if ($name === 'setDefaultConnection') {
-            return $this->__setDefaultConnection(...$arguments);
+            $this->__setDefaultConnection(...$arguments);
         }
         return $this->__connection()->{$name}(...$arguments);
     }
@@ -66,7 +66,7 @@ class Db
         if ($name === 'connection') {
             return $db->__connection(...$arguments);
         } else if ($name === 'setDefaultConnection') {
-            return $db->__setDefaultConnection(...$arguments);
+            $db->__setDefaultConnection(...$arguments);
         }
         return $db->__connection()->{$name}(...$arguments);
     }

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -43,6 +43,7 @@ use Psr\Container\ContainerInterface;
  * @method static int transactionLevel()
  * @method static array pretend(Closure $callback)
  * @method static ConnectionInterface connection(?string $pool = null)
+ * @method static void setDefaultConnectionForCoroutine(string $name)
  */
 class Db
 {
@@ -54,8 +55,9 @@ class Db
     {
         if ($name === 'connection') {
             return $this->__connection(...$arguments);
-        } else if ($name === 'setDefaultConnection') {
-            $this->__setDefaultConnection(...$arguments);
+        }
+        if ($name === 'setDefaultConnectionForCoroutine') {
+            $this->__setDefaultConnectionForCoroutine(...$arguments);
             return;
         }
         return $this->__connection()->{$name}(...$arguments);
@@ -66,8 +68,9 @@ class Db
         $db = ApplicationContext::getContainer()->get(Db::class);
         if ($name === 'connection') {
             return $db->__connection(...$arguments);
-        } else if ($name === 'setDefaultConnection') {
-            $db->__setDefaultConnection(...$arguments);
+        }
+        if ($name === 'setDefaultConnectionForCoroutine') {
+            $db->__setDefaultConnectionForCoroutine(...$arguments);
             return;
         }
         return $db->__connection()->{$name}(...$arguments);
@@ -79,10 +82,10 @@ class Db
         return $resolver->connection($name);
     }
 
-    private function __setDefaultConnection(?string $name = null): void
+    private function __setDefaultConnectionForCoroutine(?string $name = null): void
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
-        $resolver->setDefaultConnection($name);
+        $resolver->setDefaultConnectionForCoroutine($name); // @phpstan-ignore method.notFound
     }
 
     public static function beforeExecuting(Closure $closure): void

--- a/src/db-connection/src/Db.php
+++ b/src/db-connection/src/Db.php
@@ -77,10 +77,10 @@ class Db
         return $resolver->connection($name);
     }
 
-    private function __setDefaultConnection(?string $name = null): ConnectionInterface
+    private function __setDefaultConnection(?string $name = null): void
     {
         $resolver = $this->container->get(ConnectionResolverInterface::class);
-        return $resolver->setDefaultConnection($name);
+        $resolver->setDefaultConnection($name);
     }
 
     public static function beforeExecuting(Closure $closure): void


### PR DESCRIPTION
```php
// config/database.php
return [
    // i disable the default database connection
    'default' => '' , // force the codebase to expressly specify a database connection
    // ...
];
```

```php
// app/Services/SomethingService.php

namespace App\Services;

use Hypervel\Support\Facades\DB;

class SomethingService
{
    function somefunc()
    {
        // expressly set database connection
        DB::setDefaultConnection('mydb'); // THROWS EXCEPTION
    }
}
```

```
[2025-05-21 16:32:13 $641.0] WARNING Worker::report_error(): worker(pid=10404, id=1) abnormal exit, status=255, signal=0
Fatal error: Uncaught InvalidArgumentException: config[databases.] is not exist! in /var/www/app/vendor/hyperf/db-connection/src/Pool/DbPool.php:35
Stack trace:
#0 /var/www/app/vendor/hyperf/di/src/Resolver/ObjectResolver.php(85): Hyperf\DbConnection\Pool\DbPool->__construct(Object(Hypervel\Foundation\Application), '')
#1 /var/www/app/vendor/hyperf/di/src/Resolver/ObjectResolver.php(52): Hyperf\Di\Resolver\ObjectResolver->createInstance(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#2 /var/www/app/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(51): Hyperf\Di\Resolver\ObjectResolver->resolve(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#3 /var/www/app/vendor/hyperf/di/src/Resolver/DepthGuard.php(68): Hyperf\Di\Resolver\ResolverDispatcher->{closure:Hyperf\Di\Resolver\ResolverDispatcher::resolve():51}()
#4 /var/www/app/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(49): Hyperf\Di\Resolver\DepthGuard->call('Hyperf\\DbConnec...', Object(Closure))
#5 /var/www/app/vendor/hyperf/di/src/Container.php(161): Hyperf\Di\Resolver\ResolverDispatcher->resolve(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#6 /var/www/app/vendor/hyperf/di/src/Container.php(62): Hyperf\Di\Container->resolveDefinition(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#7 /var/www/app/vendor/hypervel/container/src/Container.php(120): Hyperf\Di\Container->make('Hyperf\\DbConnec...', Array)
#8 /var/www/app/vendor/hyperf/db-connection/src/Pool/PoolFactory.php(36): Hypervel\Container\Container->make('Hyperf\\DbConnec...', Array)
#9 /var/www/app/vendor/hyperf/db-connection/src/ConnectionResolver.php(54): Hyperf\DbConnection\Pool\PoolFactory->getPool('')
#10 /var/www/app/vendor/hyperf/db-connection/src/Db.php(73): Hyperf\DbConnection\ConnectionResolver->connection('')
#11 /var/www/app/vendor/hyperf/db-connection/src/Db.php(58): Hyperf\DbConnection\Db->__connection()
#12 /var/www/app/vendor/hypervel/support/src/Facades/Facade.php(151): Hyperf\DbConnection\Db->__call('setDefaultConne...', Array)
#13 /var/www/app/vendor/custom/app-foobar/app/Services/PlaidPropwareSyncService.php(21): Hypervel\Support\Facades\Facade::__callStatic('setDefaultConne...', Array)
#14 /var/www/app/vendor/hyperf/di/src/Resolver/ObjectResolver.php(85): Custom\Foobar\Services\PlaidPropwareSyncService->__construct(Object(Hyperf\Server\ServerFactory))
#15 /var/www/app/vendor/hyperf/di/src/Resolver/ObjectResolver.php(52): Hyperf\Di\Resolver\ObjectResolver->createInstance(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#16 /var/www/app/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(51): Hyperf\Di\Resolver\ObjectResolver->resolve(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#17 /var/www/app/vendor/hyperf/di/src/Resolver/DepthGuard.php(68): Hyperf\Di\Resolver\ResolverDispatcher->{closure:Hyperf\Di\Resolver\ResolverDispatcher::resolve():51}()
#18 /var/www/app/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(49): Hyperf\Di\Resolver\DepthGuard->call('Custom\\Fooba...', Object(Closure))
#19 /var/www/app/vendor/hyperf/di/src/Container.php(161): Hyperf\Di\Resolver\ResolverDispatcher->resolve(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#20 /var/www/app/vendor/hyperf/di/src/Container.php(62): Hyperf\Di\Container->resolveDefinition(Object(Hyperf\Di\Definition\ObjectDefinition), Array)
#21 /var/www/app/vendor/hypervel/container/src/Container.php(120): Hyperf\Di\Container->make('Custom\\Fooba...', Array)
#22 /var/www/app/vendor/hyperf/di/src/Container.php(103): Hypervel\Container\Container->make('Custom\\Fooba...')
#23 /var/www/app/vendor/hypervel/container/src/Container.php(145): Hyperf\Di\Container->get('Custom\\Fooba...')
#24 /var/www/app/vendor/hypervel/foundation/src/helpers.php(331): Hypervel\Container\Container->get('Custom\\Fooba...')
#25 /var/www/app/vendor/custom/app-foobar/app/Listeners/StartupListener.php(45): app('Custom\\Fooba...')
#26 /var/www/app/vendor/hypervel/event/src/EventDispatcher.php(241): Custom\Foobar\Listeners\StartupListener->process(Object(Hyperf\Framework\Event\OtherWorkerStart))
#27 /var/www/app/vendor/hypervel/event/src/EventDispatcher.php(152): Hypervel\Event\EventDispatcher->{closure:Hypervel\Event\EventDispatcher::createClassListener():237}(Object(Hyperf\Framework\Event\OtherWorkerStart), Array)
#28 /var/www/app/vendor/hypervel/event/src/EventDispatcher.php(75): Hypervel\Event\EventDispatcher->invokeListeners(Object(Hyperf\Framework\Event\OtherWorkerStart), Array, false)
#29 /var/www/app/vendor/hyperf/framework/src/Bootstrap/WorkerStartCallback.php(41): Hypervel\Event\EventDispatcher->dispatch(Object(Hyperf\Framework\Event\OtherWorkerStart))
#30 [internal function]: Hyperf\Framework\Bootstrap\WorkerStartCallback->onWorkerStart(Object(Swoole\WebSocket\Server), 1)
#31 {main}
  thrown in /var/www/app/vendor/hyperf/db-connection/src/Pool/DbPool.php on line 35
[2025-05-21 16:32:13 ^10406.1]       ERROR   php_swoole_server_rshutdown() (ERRNO 503): Fatal error: Uncaught InvalidArgumentException: config[databases.] is not exist! in /var/www/app/vendor/hyperf/db-connection/src/Pool/DbPool.php:35
```