### PR TITLE
fix: Correctly pass individual value in setMultiple

### DIFF
--- a/src/cache/src/Driver/CoroutineMemoryDriver.php
+++ b/src/cache/src/Driver/CoroutineMemoryDriver.php
@@ -53,7 +53,7 @@ class CoroutineMemoryDriver extends Driver implements KeyCollectorInterface
     public function setMultiple($values, $ttl = null): bool
     {
         foreach ($values as $key => $value) {
-            $this->set($key, $values, $ttl);
+            $this->set($key, $value, $ttl);
         }
 
         return true;


### PR DESCRIPTION
The previous implementation of `setMultiple` was incorrectly passing the entire `$values` array as the value to the `set` method for each key, instead of the individual `$value` associated with that `$key`.

This commit corrects the arguments passed to `$this->set()` within the loop to use `$value` instead of `$values`, ensuring each key is associated with its intended individual value.