### PR TITLE
Fixed bug that sqlite migration does not work.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.57 - TBD
 
+## Fixed
+
+- [#7414](https://github.com/hyperf/hyperf/pull/7414) Fixed bug that sqlite migration does not work.
+
 ## Optimized
 
 - [#7411](https://github.com/hyperf/hyperf/pull/7411) Remove `Hyperf\Utils` Component.

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -160,7 +160,8 @@ class Blueprint
             $method = 'compile' . ucfirst($command->name);
 
             if (method_exists($grammar, $method)) {
-                if (! is_null($sql = $grammar->{$method}($this, $command, $connection))) {
+                $sql = $grammar->{$method}($this, $command, $connection);
+                if (!is_null($sql) && !empty($sql)) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -161,7 +161,7 @@ class Blueprint
 
             if (method_exists($grammar, $method)) {
                 $sql = $grammar->{$method}($this, $command, $connection);
-                if (!is_null($sql) && !empty($sql)) {
+                if (! is_null($sql) && ! empty($sql)) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -160,8 +160,7 @@ class Blueprint
             $method = 'compile' . ucfirst($command->name);
 
             if (method_exists($grammar, $method)) {
-                $sql = $grammar->{$method}($this, $command, $connection);
-                if (! is_null($sql) && ! empty($sql)) {
+                if (! empty($sql = $grammar->{$method}($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }


### PR DESCRIPTION
This supposed to be a fix for Issue #6923 .

I believe it would also unblock Issue [#21](https://github.com/hypervel/hypervel/issues/21) of Hypervel.

### Current Behaviour Running Migrations Using Sqlite
![Screenshot 2025-06-06 at 2 20 14 PM](https://github.com/user-attachments/assets/23660415-3c68-4e8e-b676-e577902f9e06)
### The Applied Fix In This PR
![Screenshot 2025-06-06 at 2 18 20 PM](https://github.com/user-attachments/assets/cff741da-c857-4b20-9ff4-37085d16ab2b)
### Result of the Change. Sqlite Migrations With Foreign Keys Running Smoothly
![Screenshot 2025-06-06 at 2 18 55 PM](https://github.com/user-attachments/assets/1504bf0c-2544-44eb-b438-67ec6d1b01a9)

I must apologize for not writing any test for this. I had some challenges switching from php8.4 back to 8.1 and setting up swoole, redis and kafka for that specific version.