### PR TITLE
Fixed bug that `exclude` cannot not work when using `validation`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,8 +1,9 @@
-# v3.1.58 - TBD
+# v3.1.59 - TBD
 
 ## Fixed
 
 - [#7421](https://github.com/hyperf/hyperf/pull/7421) Fixed bug that the cookie value cannot be deleted when set "".
+- [#7427](https://github.com/hyperf/hyperf/pull/7427) Fixed bug that `exclude` cannot not work when using `validation`.
 
 # v3.1.57 - 2025-06-23
 

--- a/src/validation/publish/en/validation.php
+++ b/src/validation/publish/en/validation.php
@@ -58,6 +58,11 @@ return [
     'email' => 'The :attribute must be a valid email address.',
     'ends_with' => 'The :attribute must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
+    'exclude' => 'The :attribute field is excluded.',
+    'exclude_if' => 'The :attribute field is excluded when :other is :value.',
+    'exclude_unless' => 'The :attribute field is excluded unless :other is in :values.',
+    'exclude_with' => 'The :attribute field is excluded when :values is present.',
+    'exclude_without' => 'The :attribute field is excluded when :values is not present.',
     'exists' => 'The selected :attribute is invalid.',
     'extensions' => 'The :attribute must have one of the following extensions: :values.',
     'file' => 'The :attribute must be a file.',
@@ -133,11 +138,6 @@ return [
     'required_with_all' => 'The :attribute field is required when :values is present.',
     'required_without' => 'The :attribute field is required when :values is not present.',
     'required_without_all' => 'The :attribute field is required when none of :values are present.',
-    'exclude' => 'The :attribute field is excluded.',
-    'exclude_if' => 'The :attribute field is excluded when :other is :value.',
-    'exclude_unless' => 'The :attribute field is excluded unless :other is in :values.',
-    'exclude_with' => 'The :attribute field is excluded when :values is present.',
-    'exclude_without' => 'The :attribute field is excluded when :values is not present.',
     'same' => 'The :attribute and :other must match.',
     'size' => [
         'numeric' => 'The :attribute must be :size.',
@@ -172,6 +172,7 @@ return [
         'string' => 'The :attribute must be between :min and :max characters when :other is :value.',
         'array' => 'The :attribute must have between :min and :max items when :other is :value.',
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Language Lines

--- a/src/validation/publish/zh_CN/validation.php
+++ b/src/validation/publish/zh_CN/validation.php
@@ -48,6 +48,11 @@ return [
     'dimensions' => ':attribute 具有无效的图片尺寸',
     'distinct' => ':attribute 字段具有重复值',
     'email' => ':attribute 必须是一个合法的电子邮件地址',
+    'exclude' => ':attribute 字段是被排除的',
+    'exclude_if' => '当 :other 为 :value 时，排除 :attribute 字段',
+    'exclude_unless' => '除非 :other 是在 :values 中，否则排除 :attribute 字段',
+    'exclude_with' => '当 :values 存在时，排除 :attribute 字段',
+    'exclude_without' => '当 :values 不存在时，排除 :attribute 字段',
     'exists' => '选定的 :attribute 是无效的',
     'file' => ':attribute 必须是一个文件',
     'filled' => ':attribute 的字段是必填的',
@@ -111,11 +116,6 @@ return [
     'required_with_all' => ':attribute 字段是必须的当 :values 是存在的',
     'required_without' => ':attribute 字段是必须的当 :values 是不存在的',
     'required_without_all' => ':attribute 字段是必须的当 没有一个 :values 是存在的',
-    'exclude' => ':attribute 字段是被排除的',
-    'exclude_if' => '当 :other 为 :value 时，排除 :attribute 字段',
-    'exclude_unless' => '除非 :other 是在 :values 中，否则排除 :attribute 字段',
-    'exclude_with' => '当 :values 存在时，排除 :attribute 字段',
-    'exclude_without' => '当 :values 不存在时，排除 :attribute 字段',
     'same' => ':attribute 和 :other 必须匹配',
     'size' => [
         'numeric' => ':attribute 必须是 :size',
@@ -148,6 +148,7 @@ return [
         'string' => '当 :other 为 :value 时 :attribute 必须介于 :min - :max 个字符之间',
         'array' => '当 :other 为 :value 时 :attribute 必须只有 :min - :max 个单元',
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Language Lines

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -136,19 +136,21 @@ class Validator implements ValidatorContract
      * The validation rules that imply the field is required.
      */
     protected array $implicitRules = [
-        'Required', 'Filled', 'Missing', 'MissingIf', 'MissingUnless', 'MissingWith',
-        'MissingWithAll', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Accepted', 'AcceptedIf', 'Declined', 'DeclinedIf', 'Present',
+        'Accepted', 'AcceptedIf', 'Declined', 'DeclinedIf', 'Filled', 'Missing', 'MissingIf',
+        'MissingUnless', 'MissingWith', 'MissingWithAll', 'Present', 'Required', 'RequiredIf',
+        'RequiredUnless', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout',
+        'RequiredWithoutAll',
     ];
 
     /**
      * The validation rules which depend on other fields as parameters.
      */
     protected array $dependentRules = [
-        'AcceptedIf', 'DeclinedIf', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout',
-        'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different',
-        'Unique', 'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'Gt', 'Lt', 'Gte', 'Lte',
-        'Prohibits', 'ExcludeIf', 'ExcludeUnless', 'ExcludeWith', 'ExcludeWithout', 'MissingIf', 'MissingUnless', 'MissingWith', 'MissingWithAll',
+        'After', 'AfterOrEqual', 'AcceptedIf', 'Before', 'BeforeOrEqual', 'Confirmed',
+        'DeclinedIf', 'Different', 'ExcludeIf', 'ExcludeUnless', 'ExcludeWith', 'ExcludeWithout',
+        'Gt', 'Gte', 'Lt', 'Lte', 'MissingIf', 'MissingUnless', 'MissingWith', 'MissingWithAll',
+        'Prohibits', 'RequiredIf', 'RequiredUnless', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout',
+        'RequiredWithoutAll', 'Same', 'Unique',
     ];
 
     /**
@@ -274,6 +276,12 @@ class Validator implements ValidatorContract
                 if ($this->shouldStopValidating($attribute)) {
                     break;
                 }
+            }
+        }
+
+        foreach ($this->rules as $attribute => $rules) {
+            if ($this->shouldBeExcluded($attribute)) {
+                $this->removeAttribute($attribute);
             }
         }
 
@@ -771,6 +779,15 @@ class Validator implements ValidatorContract
         }
 
         return false;
+    }
+    
+    /**
+     * Remove the given attribute.
+     */
+    protected function removeAttribute(string $attribute): void
+    {
+        Arr::forget($this->data, $attribute);
+        Arr::forget($this->rules, $attribute);
     }
 
     /**

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -780,7 +780,7 @@ class Validator implements ValidatorContract
 
         return false;
     }
-    
+
     /**
      * Remove the given attribute.
      */

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -5540,6 +5540,39 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame([], $v->validated());
     }
 
+    public function testExcludeBeforeADependentRule()
+    {
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [
+                'profile_id' => null,
+                'type' => 'denied',
+            ],
+            [
+                'type' => ['required', 'string', 'exclude'],
+                'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['profile_id' => null], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [
+                'profile_id' => null,
+                'type' => 'profile',
+            ],
+            [
+                'type' => ['required', 'string', 'exclude'],
+                'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
+            ],
+        );
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame(['profile_id' => ['validation.required_if']], $validator->getMessageBag()->getMessages());
+    }
+
     public function testValidateExcludeIf()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -5509,28 +5509,35 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'exclude|integer']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo('');
         $v = new Validator($trans, ['name' => $file], ['name' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['name' => $file], ['name' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $file2 = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['files' => [$file, $file2]], ['files.0' => 'exclude|required', 'files.1' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['files' => [$file, $file2]], ['files' => 'exclude|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
     }
 
     public function testValidateExcludeIf()
@@ -5538,26 +5545,32 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'exclude_if:first,biz|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'exclude_if:first,taylor|integer']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'exclude_if:first,taylor,dayle|integer']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'dayle', 'last' => 'rees'], ['last' => 'exclude_if:first,taylor,dayle|integer']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'exclude_if:foo,true|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'exclude_if:foo,false|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['bar' => ['validation.required']], $v->messages()->toArray());
 
         // error message when passed multiple values (exclude_if:foo,bar,baz)
         $trans = $this->getIlluminateArrayTranslator();
@@ -5572,22 +5585,27 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven'], ['last' => 'exclude_unless:first,taylor|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'exclude_unless:first,taylor|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven', 'last' => 'wittevrongel'], ['last' => 'exclude_unless:first,taylor|integer']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'exclude_unless:first,taylor,sven|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven'], ['last' => 'exclude_unless:first,taylor,sven|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         // error message when passed multiple values (exclude_unless:foo,bar,baz)
         $trans = $this->getIlluminateArrayTranslator();
@@ -5602,29 +5620,36 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['last' => 'exclude_with:first|required']);
         $this->assertFalse($v->passes());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $v = new Validator($trans, ['last' => ''], ['last' => 'exclude_with:first|required']);
         $this->assertFalse($v->passes());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $v = new Validator($trans, ['first' => 'biz'], ['last' => 'exclude_with:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['first' => 'Taylor', 'last' => 'Otwell'], ['last' => 'exclude_with:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file, 'foo' => ''], ['foo' => 'exclude_with:file|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $foo = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_with:file|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $foo = new SplFileInfo('');
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_with:file|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
     }
 
     public function testValidateExcludeWithout()
@@ -5632,50 +5657,62 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => ''], ['last' => 'exclude_without:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['first' => '', 'last' => ''], ['last' => 'exclude_without:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['first' => 'bar'], ['last' => 'exclude_without:first|required']);
         $this->assertFalse($v->passes());
+        $this->assertSame(['last' => ['validation.required']], $v->messages()->toArray());
 
         $v = new Validator($trans, [], ['last' => 'exclude_without:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $v = new Validator($trans, ['first' => 'Taylor', 'last' => 'Otwell'], ['last' => 'exclude_without:first|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame(['last' => 'Otwell'], $v->validated());
 
         $v = new Validator($trans, ['last' => 'Otwell'], ['last' => 'exclude_without:first']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file], ['foo' => 'exclude_without:file|required']);
         $this->assertFalse($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $foo = new SplFileInfo('');
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file|required']);
         $this->assertFalse($v->passes());
+        $this->assertSame(['foo' => ['validation.required']], $v->messages()->toArray());
 
         $file = new SplFileInfo(__FILE__);
         $foo = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file|required']);
         $this->assertTrue($v->passes());
+        $this->assertArrayHasKey('foo', $v->validated());
 
         $file = new SplFileInfo('');
         $foo = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file|required']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
 
         $file = new SplFileInfo(__FILE__);
         $foo = new SplFileInfo('');
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file|required']);
         $this->assertTrue($v->fails());
+        $this->assertSame(['foo' => ['validation.required']], $v->messages()->toArray());
 
         $file = new SplFileInfo('');
         $foo = new SplFileInfo('');
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file']);
         $this->assertTrue($v->passes());
+        $this->assertSame([], $v->validated());
     }
 
     protected function getTranslator()


### PR DESCRIPTION
### Description:

When using the `exclude`, `exclude_if`, `exclude_unless`, `exclude_with` and `exclude_without` validations, the request data is not removed when retrieved in `validated` and `validate` method.

My system

```bash
Linux faf9a935b5e0 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64 Linux
PHP 8.3.14 (cli) (built: Nov 21 2024 08:44:42) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.14, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.14, Copyright (c), by Zend Technologies
hyperf/cache                       3.1.56  A cache component for hyperf.
hyperf/code-parser                 3.1.52  A code parser component for Hyperf.
hyperf/codec                       3.1.42  A codec component for Hyperf.
hyperf/collection                  3.1.52  Hyperf Collection package which come from illuminate/collections
hyperf/command                     3.1.56  Command for hyperf
hyperf/conditionable               3.1.42  Hyperf Macroable package which come from illuminate/conditionable
hyperf/config                      3.1.42  An independent component that provides configuration container.
hyperf/context                     3.1.42  A coroutine/application context library.
hyperf/contract                    3.1.42  The contracts of Hyperf.
hyperf/coordinator                 3.1.42  Hyperf Coordinator
hyperf/coroutine                   3.1.54  Hyperf Coroutine
hyperf/database                    3.1.56  A flexible database library.
hyperf/db-connection               3.1.44  A hyperf db connection handler for hyperf/database.
hyperf/devtool                     3.1.51  A Devtool for Hyperf.
hyperf/di                          3.1.53  A DI for Hyperf.
hyperf/dispatcher                  3.1.42  A HTTP Server for Hyperf.
hyperf/engine                      2.14.0  Coroutine engine provided by swoole.
hyperf/engine-contract             1.13.0  Contract for Coroutine Engine
hyperf/event                       3.1.42  an event manager that implements PSR-14.
hyperf/exception-handler           3.1.42  Exception handler for hyperf
hyperf/framework                   3.1.42  A coroutine framework that focuses on hyperspeed and flexible, specifically use for build microservices a...
hyperf/guzzle                      3.1.42  Swoole coroutine handler for guzzle
hyperf/http-message                3.1.48  microservice framework base on swoole
hyperf/http-server                 3.1.55  A HTTP Server for Hyperf.
hyperf/logger                      3.1.55  A logger component for hyperf.
hyperf/macroable                   3.1.42  Hyperf Macroable package which come from illuminate/macroable
hyperf/memory                      3.1.53  An independent component that use to operate and manage memory.
hyperf/model-listener              3.1.42  A model listener for Hyperf.
hyperf/pipeline                    3.1.42  Hyperf Macroable package which come from illuminate/pipeline
hyperf/pool                        3.1.42  An independent universal connection pool component.
hyperf/process                     3.1.48  A process component for hyperf.
hyperf/serializer                  3.1.42  A serializer component for Hyperf.
hyperf/server                      3.1.42  A base server library for Hyperf.
hyperf/stdlib                      3.1.42  A stdlib component for Hyperf.
hyperf/stringable                  3.1.55  Hyperf Stringable package which come from illuminate/support
hyperf/support                     3.1.51  A support component for Hyperf.
hyperf/tappable                    3.1.42  Hyperf Macroable package which come from illuminate/tappable
hyperf/testing                     3.1.55  Testing for hyperf
hyperf/translation                 3.1.42  An independent translation component, forked by illuminate/translation.
hyperf/utils                       3.1.42  A tools package that could help developer solved the problem quickly.
hyperf/validation                  3.1.53  hyperf validation
hyperf/watcher                     3.1.54  Hot reload watcher for Hyperf

swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 6.0.1
Built => Feb 17 2025 02:52:16
coroutine => enabled with boost asm context
epoll => enabled
eventfd => enabled
signalfd => enabled
cpu_affinity => enabled
spinlock => enabled
rwlock => enabled
openssl => OpenSSL 3.1.8 11 Feb 2025
dtls => enabled
http2 => enabled
json => enabled
curl-native => enabled
curl-version => 8.12.1
c-ares => 1.27.0
zlib => 1.3.1
brotli => E16781312/D16781312
mutex_timedlock => enabled
pthread_barrier => enabled
coroutine_pgsql => enabled
coroutine_odbc => enabled
coroutine_sqlite => enabled

Directive => Local Value => Master Value
swoole.enable_library => On => On
swoole.enable_fiber_mock => Off => Off
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 8388608 => 8388608
```

### Steps To Reproduce:

Request

```php
class ValidateRequest extends FormRequest
{
    public function authorize(): bool
    {
        return true;
    }

    public function rules(): array
    {
        return [
            'foo' => ['exclude'],
        ];
    }
}
```

Controller
```php
class ValidateController
{
    public function handle(ValidateRequest $request)
    {
        return [
            'message' => 'Validation passed',
            'all' => $request->all(),
            'validated' => $request->validated(),
        ];
    }
}
```

Output
```json
{
    "message": "Validation passed",
    "all": {
        "foo": "foz"
    },
    "validated": {
        "foo": "foz"
    }
}
```

Expected
```json
{
    "message": "Validation passed",
    "all": {
        "foo": "foz"
    },
    "validated": []
}
```


