### PR TITLE
Refactor test providers and constructor property visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -537,7 +537,7 @@
     },
     "scripts": {
         "analyse": "phpstan analyse --memory-limit=-1",
-        "cs-fix": "php-cs-fixer fix $1",
+        "cs-fix": "php-cs-fixer fix $1 --verbose",
         "json-fix": [
             "./bin/composer-json-fixer",
             "@composer normalize --no-update-lock",

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -695,19 +695,6 @@ class CollectionTest extends TestCase
         $this->assertSame(['foo'], $c->all());
     }
 
-    /**
-     * Provides each collection class, respectively.
-     *
-     * @return array
-     */
-    public static function collectionClassProvider()
-    {
-        return [
-            [Collection::class],
-            [LazyCollection::class],
-        ];
-    }
-
     #[DataProvider('collectionClassProvider')]
     public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists($collection): void
     {
@@ -1353,5 +1340,18 @@ class CollectionTest extends TestCase
             ['id' => 2, 'name' => 'b'],
             ['id' => 1, 'name' => null],
         ]), json_encode($dataManyNull));
+    }
+
+    /**
+     * Provides each collection class, respectively.
+     *
+     * @return array
+     */
+    public static function collectionClassProvider()
+    {
+        return [
+            [Collection::class],
+            [LazyCollection::class],
+        ];
     }
 }

--- a/src/config-center/tests/AbstractDriverTest.php
+++ b/src/config-center/tests/AbstractDriverTest.php
@@ -54,6 +54,14 @@ class AbstractDriverTest extends TestCase
         $this->assertSame(['message' => 'Hello Hyperf', 'id' => 1], $config->get('test'));
     }
 
+    public static function getConfig(): array
+    {
+        return [
+            [self::getEtcdConfig()],
+            [self::getNacosConfig()],
+        ];
+    }
+
     #[DataProvider('getConfigAndPipeMessage')]
     public function testOnPipeMessage(Config $config, PipeMessageInterface $pipeMessage, array $assert)
     {
@@ -64,14 +72,6 @@ class AbstractDriverTest extends TestCase
 
         $driver->onPipeMessage($pipeMessage);
         $this->assertSame($assert, $config->get('test'));
-    }
-
-    public static function getConfig(): array
-    {
-        return [
-            [self::getEtcdConfig()],
-            [self::getNacosConfig()],
-        ];
     }
 
     public static function getConfigAndPipeMessage()

--- a/src/migration-generator/src/TableData.php
+++ b/src/migration-generator/src/TableData.php
@@ -16,7 +16,7 @@ use JetBrains\PhpStorm\ArrayShape;
 
 final class TableData
 {
-    public function __construct(protected array $columns, protected array $indexes, protected string $comment)
+    public function __construct(private array $columns, private array $indexes, private string $comment)
     {
     }
 

--- a/src/stringable/tests/StrTest.php
+++ b/src/stringable/tests/StrTest.php
@@ -431,12 +431,6 @@ class StrTest extends TestCase
         $this->assertTrue(Str::isUrl($url));
     }
 
-    #[DataProvider('invalidUrls')]
-    public function testInvalidUrls($url)
-    {
-        $this->assertFalse(Str::isUrl($url));
-    }
-
     public static function validUrls()
     {
         return [
@@ -677,6 +671,12 @@ class StrTest extends TestCase
             ['https://hyperf.wiki#fragment'],
             ['https://hyperf.wiki/#fragment'],
         ];
+    }
+
+    #[DataProvider('invalidUrls')]
+    public function testInvalidUrls($url)
+    {
+        $this->assertFalse(Str::isUrl($url));
     }
 
     public static function invalidUrls()

--- a/src/validation/tests/Cases/ValidationEnumRuleTest.php
+++ b/src/validation/tests/Cases/ValidationEnumRuleTest.php
@@ -149,6 +149,16 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertSame($expected, $v->fails());
     }
 
+    public static function conditionalCasesDataProvider(): array
+    {
+        return [
+            [IntegerStatus::done, IntegerStatus::done, true],
+            [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
+            [IntegerStatus::pending->value, [IntegerStatus::done, IntegerStatus::pending], true],
+            [IntegerStatus::done->value, IntegerStatus::pending, false],
+        ];
+    }
+
     public function testOnlyHasHigherOrderThanExcept(): void
     {
         $v = new Validator(
@@ -269,16 +279,6 @@ class ValidationEnumRuleTest extends TestCase
 
         $this->assertTrue($v->fails());
         $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
-    }
-
-    public static function conditionalCasesDataProvider(): array
-    {
-        return [
-            [IntegerStatus::done, IntegerStatus::done, true],
-            [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
-            [IntegerStatus::pending->value, [IntegerStatus::done, IntegerStatus::pending], true],
-            [IntegerStatus::done->value, IntegerStatus::pending, false],
-        ];
     }
 
     private function getTranslator(): Translator

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -2893,17 +2893,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @param mixed $invalidUrl
-     */
-    #[DataProvider('invalidUrls')]
-    public function testValidateUrlWithInvalidUrls($invalidUrl)
-    {
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => $invalidUrl], ['x' => 'Url']);
-        $this->assertFalse($v->passes());
-    }
-
     public static function validUrls()
     {
         return [
@@ -3144,6 +3133,17 @@ class ValidationValidatorTest extends TestCase
             ['https://laravel.com#fragment'],
             ['https://laravel.com/#fragment'],
         ];
+    }
+
+    /**
+     * @param mixed $invalidUrl
+     */
+    #[DataProvider('invalidUrls')]
+    public function testValidateUrlWithInvalidUrls($invalidUrl)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => $invalidUrl], ['x' => 'Url']);
+        $this->assertFalse($v->passes());
     }
 
     public static function invalidUrls()
@@ -5299,17 +5299,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    /**
-     * @param mixed $uuid
-     */
-    #[DataProvider('invalidUuidList')]
-    public function testValidateWithInvalidUuid($uuid)
-    {
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => $uuid], ['foo' => 'uuid']);
-        $this->assertFalse($v->passes());
-    }
-
     public static function validUuidList()
     {
         return [
@@ -5324,6 +5313,17 @@ class ValidationValidatorTest extends TestCase
             ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'],
             ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'],
         ];
+    }
+
+    /**
+     * @param mixed $uuid
+     */
+    #[DataProvider('invalidUuidList')]
+    public function testValidateWithInvalidUuid($uuid)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => $uuid], ['foo' => 'uuid']);
+        $this->assertFalse($v->passes());
     }
 
     public static function invalidUuidList()

--- a/src/watcher/src/Listener/ReloadDotenvListener.php
+++ b/src/watcher/src/Listener/ReloadDotenvListener.php
@@ -19,7 +19,7 @@ use Psr\Container\ContainerInterface;
 
 final class ReloadDotenvListener implements ListenerInterface
 {
-    public function __construct(protected ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
     }
 


### PR DESCRIPTION
Moved data provider methods in several test classes to improve code organization. Updated constructor property visibility from protected to private in TableData and ReloadDotenvListener for better encapsulation. Also added --verbose flag to the cs-fix Composer script.

```shell
> php-cs-fixer fix $1 --verbose
Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use unsupportedPhpVersionAllowed config instead.
PHP CS Fixer 3.80.0 Alexander by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.28
Running analysis on 10 cores with 20 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config default from "/Users/github/hyperf/.php-cs-fixer.php".
 2894/2894 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

   1) src/migration-generator/src/TableData.php (protected_to_private, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
   2) src/watcher/src/Listener/ReloadDotenvListener.php (protected_to_private, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
   3) src/collection/tests/CollectionTest.php (php_unit_data_provider_method_order, phpdoc_no_alias_tag, unary_operator_spaces, not_operator_with_successor_space, no_extra_blank_lines, header_comment, blank_lines_before_namespace, blank_line_between_import_groups)
   4) src/support/src/Fluent.php (phpdoc_no_alias_tag, global_namespace_import, header_comment, blank_lines_before_namespace)
   5) src/config-center/tests/AbstractDriverTest.php (php_unit_data_provider_method_order, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
   6) src/validation/tests/Cases/ValidationEnumRuleTest.php (php_unit_data_provider_method_order, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
   7) src/stringable/tests/StrTest.php (php_unit_data_provider_method_order, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
   8) src/validation/tests/Cases/ValidationValidatorTest.php (php_unit_data_provider_method_order, phpdoc_no_alias_tag, header_comment, blank_lines_before_namespace)
```