### PR TITLE
Fix hyperf/collection dependency version 3.1.23 to 3.2.0

### DIFF
--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.2",
         "hyperf/code-parser": "~3.2.0",
-        "hyperf/collection": "~3.1.23",
+        "hyperf/collection": "~3.2.0",
         "hyperf/conditionable": "~3.2.0",
         "hyperf/context": "~3.2.0",
         "hyperf/contract": "~3.2.0",

--- a/src/view-engine/composer.json
+++ b/src/view-engine/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "hyperf/collection": "~3.1.23",
+        "hyperf/collection": "~3.2.0",
         "hyperf/config": "~3.2.0",
         "hyperf/context": "~3.2.0",
         "hyperf/contract": "~3.2.0",


### PR DESCRIPTION
Maybe this dependency missed a find-and-replace operation looking for "~3.1.0" because it was set to "~3.1.23"