### PR TITLE
Fixed bug that the command `migrate:fresh` can't drop postgres tables by default.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#7447](https://github.com/hyperf/hyperf/pull/7447) Fixed bug that the `migrate:fresh` command did not drop Postgres tables by default.
+- [#7447](https://github.com/hyperf/hyperf/pull/7447) Fixed bug that the command `migrate:fresh` can't drop postgres tables by default.
 - [#7449](https://github.com/hyperf/hyperf/pull/7449) Fixed bug that `Hyperf\Database\Migrations\Migrator::reset()` cannot support string paths.
 
 # v3.1.59 - 2025-07-03

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.60 - TBD
 
+## Fixed
+
+- [#7447](https://github.com/hyperf/hyperf/pull/7447) Fixed bug that the `migrate:fresh` command did not drop Postgres tables by default.
+
 # v3.1.59 - 2025-07-03
 
 ## Fixed

--- a/src/database-pgsql/src/Schema/PostgresBuilder.php
+++ b/src/database-pgsql/src/Schema/PostgresBuilder.php
@@ -263,8 +263,6 @@ class PostgresBuilder extends Builder
 
     /**
      * Get the schemas for the connection.
-     *
-     * @return array
      */
     protected function getSchemas(): array
     {

--- a/src/database-pgsql/src/Schema/PostgresBuilder.php
+++ b/src/database-pgsql/src/Schema/PostgresBuilder.php
@@ -147,8 +147,13 @@ class PostgresBuilder extends Builder
      */
     public function getAllTables(): array
     {
+        $schemas = (array) $this->connection->getConfig('schema');
+        if (empty($schemas)) {
+            $schemas = ['public'];
+        }
+
         return $this->connection->select(
-            $this->grammar->compileGetAllTables((array) $this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllTables($schemas)
         );
     }
 

--- a/src/database-pgsql/src/Schema/PostgresBuilder.php
+++ b/src/database-pgsql/src/Schema/PostgresBuilder.php
@@ -147,13 +147,8 @@ class PostgresBuilder extends Builder
      */
     public function getAllTables(): array
     {
-        $schemas = (array) $this->connection->getConfig('schema');
-        if (empty($schemas)) {
-            $schemas = ['public'];
-        }
-
         return $this->connection->select(
-            $this->grammar->compileGetAllTables($schemas)
+            $this->grammar->compileGetAllTables($this->getSchemas())
         );
     }
 
@@ -163,7 +158,7 @@ class PostgresBuilder extends Builder
     public function getAllViews(): array
     {
         return $this->connection->select(
-            $this->grammar->compileGetAllViews((array) $this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllViews($this->getSchemas())
         );
     }
 
@@ -264,6 +259,17 @@ class PostgresBuilder extends Builder
         return $this->connection->getPostProcessor()->processIndexes(
             $this->connection->selectFromWriteConnection($this->grammar->compileIndexes($schema, $table))
         );
+    }
+
+    /**
+     * Get the schemas for the connection.
+     *
+     * @return array
+     */
+    protected function getSchemas(): array
+    {
+        $schemas = (array) $this->connection->getConfig('schema');
+        return empty($schemas) ? ['public'] : $schemas;
     }
 
     /**


### PR DESCRIPTION
When running `php bin/hyperf.php migrate:fresh` with PostgreSQL, tables are not dropped if no schema is configured in the database config. This happens because `PostgresBuilder::getAllTables()` passes an empty array to `compileGetAllTables()` when no schema is configured, which results in no tables being returned.

This PR adds a `getSchemas()` method that defaults to `['public']` when no schema is configured, matching Laravel's behavior:
https://github.com/laravel/framework/blob/0bbe0022ea60de20fabaed520c00c84689b083ee/src/Illuminate/Database/Schema/PostgresBuilder.php#L237