### PR TITLE
Fixed bug that the type of parameter is not matching when string type

### DIFF
--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -157,7 +157,7 @@ class Migrator
             return [];
         }
 
-        return $this->resetMigrations($migrations, $paths, $pretend);
+        return $this->resetMigrations($migrations, Arr::wrap($paths), $pretend);
     }
 
     /**


### PR DESCRIPTION
reset方法接收paths参数允许array和string类型，在reset方法中调用的resetMigrations方法的接收参数paths只允许array类型，在reset方法中未对paths的数据类型进行处理。
调用reset方法时，若paths参数为string类型，会报错“Hyperf\Database\Migrations\Migrator::resetMigrations(): Argument #2 ($paths) must be of type array, string given”，因此使用Arr::wrap()方法对paths参数进行处理，确保传递的参数为array类型。