### PR TITLE
WebSocket Server allow dependencies.php overrides like Http Server

### DIFF
--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -79,7 +79,7 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
     public function initCoreMiddleware(string $serverName): void
     {
         $this->serverName = $serverName;
-        $this->coreMiddleware = new CoreMiddleware($this->container, $serverName);
+        $this->coreMiddleware = $this->createCoreMiddleware();
 
         $config = $this->container->get(ConfigInterface::class);
         $this->middlewares = $config->get('middlewares.' . $serverName, []);
@@ -322,5 +322,10 @@ class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, On
         $instance = $this->container->get($callback);
 
         return [$instance, $method];
+    }
+
+    protected function createCoreMiddleware(): CoreMiddlewareInterface
+    {
+        return make(CoreMiddleware::class, [$this->container, $this->serverName]);
     }
 }

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -56,6 +56,7 @@ use Throwable;
 
 use function Hyperf\Coroutine\defer;
 use function Hyperf\Coroutine\wait;
+use function Hyperf\Support\make;
 
 class Server implements MiddlewareInitializerInterface, OnHandShakeInterface, OnCloseInterface, OnMessageInterface
 {


### PR DESCRIPTION
Instead of hard-coded instantiating `new CoreMiddleware`
Do the same as `Hyperf\HttpServer\Server`
Use container `make()` so it can use overrides of custom CoreMiddleware from config/autoload/dependencies.php