### PR TITLE
Implement SQLite schema builder getTables() and getAllTables()

### DIFF
--- a/src/database-sqlite/src/Schema/SQLiteBuilder.php
+++ b/src/database-sqlite/src/Schema/SQLiteBuilder.php
@@ -135,6 +135,16 @@ class SQLiteBuilder extends Builder
     }
 
     /**
+     * Get all of the table names for the database.
+     */
+    public function getAllTables(): array
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllTables()
+        );
+    }
+
+    /**
      * Empty the database file.
      */
     public function refreshDatabaseFile(): void

--- a/src/database-sqlite/src/Schema/SQLiteBuilder.php
+++ b/src/database-sqlite/src/Schema/SQLiteBuilder.php
@@ -101,6 +101,16 @@ class SQLiteBuilder extends Builder
 
         return false;
     }
+    
+    /**
+     * Get the tables that belong to the database.
+     */
+    public function getTables(bool $withSize = false): array
+    {
+        return $this->connection->getPostProcessor()->processTables(
+            $this->connection->selectFromWriteConnection($this->grammar->compileTables($withSize))
+        );
+    }
 
     /**
      * Drop all tables from the database.


### PR DESCRIPTION
The grammar for these have already been implemented for sqlite, apparently sitting unused for a year and a half, still getting `LogicException('This database driver does not support getting all tables.')`