### PR TITLE
feat: 验证器涉及到数据表相关的规则，添加table参数传递ModelName::class格式的支持

### DIFF
--- a/src/validation/src/Rules/DatabaseRule.php
+++ b/src/validation/src/Rules/DatabaseRule.php
@@ -14,6 +14,7 @@ namespace Hyperf\Validation\Rules;
 
 use Closure;
 
+use Hyperf\Database\Model\Model;
 use function Hyperf\Collection\collect;
 
 trait DatabaseRule
@@ -36,6 +37,34 @@ trait DatabaseRule
      */
     public function __construct(protected string $table, protected string $column = 'NULL')
     {
+        $this->table = $this->resolveTableName($table);
+    }
+
+    /**
+     * Resolves the name of the table from the given string.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function resolveTableName(string $table): string
+    {
+        if (! str_contains($table, '\\') || ! class_exists($table)) {
+            return $table;
+        }
+
+        if (is_subclass_of($table, Model::class)) {
+            $model = new $table;
+
+            if (str_contains($model->getTable(), '.')) {
+                return $table;
+            }
+
+            return implode('.', array_map(function (string $part) {
+                return trim($part, '.');
+            }, array_filter([$model->getConnectionName(), $model->getTable()])));
+        }
+
+        return $table;
     }
 
     /**


### PR DESCRIPTION
目前的规则默认会使用default的数据库连接，当使用多个数据库连接时需要手动拼接连接名称。

传递ModelName::class作为table的值后，会自动解析模型的连接名和表明。

该功能从Laravel同步。