### PR TITLE
Bump PHP requirement to >=8.2 in composer.json

### DIFF
--- a/src/conditionable/composer.json
+++ b/src/conditionable/composer.json
@@ -16,7 +16,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/contract/composer.json
+++ b/src/contract/composer.json
@@ -15,7 +15,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/macroable/composer.json
+++ b/src/macroable/composer.json
@@ -16,7 +16,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/memory/composer.json
+++ b/src/memory/composer.json
@@ -16,7 +16,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/stdlib/composer.json
+++ b/src/stdlib/composer.json
@@ -16,7 +16,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/tappable/composer.json
+++ b/src/tappable/composer.json
@@ -16,7 +16,7 @@
         "pull-request": "https://github.com/hyperf/hyperf/pulls"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated the PHP version constraint from >=8.1 to >=8.2 in composer.json for conditionable, contract, macroable, memory, stdlib, and tappable packages to require PHP 8.2 or higher.