### PR TITLE
fix：修复network类的ip方法适配wsl2系统，修复前会出现获取的ip是wsl2提供的虚拟内部的ip。

### DIFF
--- a/src/config-nacos/src/NacosClientFactory.php
+++ b/src/config-nacos/src/NacosClientFactory.php
@@ -44,6 +44,7 @@ class NacosClientFactory
             'host' => $options['host'] ?? null,
             'port' => $options['port'] ?? null,
             'grpc' => $options['grpc'] ?? [],
+            'version' => $options['version'] ?? null,
         ]));
     }
 }

--- a/src/nacos/src/AbstractProvider.php
+++ b/src/nacos/src/AbstractProvider.php
@@ -28,8 +28,16 @@ abstract class AbstractProvider
     {
     }
 
-    public function request(string $method, string|UriInterface $uri, array $options = [])
+    public function request(string $method, string|UriInterface $uri, array $options = []): ResponseInterface
     {
+        [$major, $minor, $patch] = array_pad(explode(".", $this->config->getVersion()),3,0);
+        $uriPrefix = match ($major) {
+            "1" => "nacos/v1",
+            "2" => "nacos/v2",
+            default => "nacos/v3/admin"
+        };
+        $uri = str_replace("nacos/v1", $uriPrefix, $uri);
+
         if ($accessKey = $this->config->getAccessKey()) {
             $accessSecret = $this->config->getAccessSecret();
 

--- a/src/nacos/src/ApplicationFactory.php
+++ b/src/nacos/src/ApplicationFactory.php
@@ -35,6 +35,7 @@ class ApplicationFactory
             'guzzle_config' => $config['guzzle']['config'] ?? null,
             'host' => $config['host'] ?? null,
             'port' => $config['port'] ?? null,
+            'version' => $options['version'] ?? null,
         ]));
     }
 }

--- a/src/nacos/src/Config.php
+++ b/src/nacos/src/Config.php
@@ -30,6 +30,8 @@ class Config
 
     protected int $port = 8848;
 
+    protected ?string $version = "3.0";
+
     protected array $grpc = [
         'enable' => true,
         'heartbeat' => 10,
@@ -52,6 +54,8 @@ class Config
             'guzzle_config' => 'array',
             'host' => 'string',
             'port' => 'int',
+            'grpc' => 'array',
+            'version' => 'string',
         ])]
         array $config = []
     ) {
@@ -63,6 +67,7 @@ class Config
         isset($config['guzzle_config']) && $this->guzzleConfig = (array) $config['guzzle_config'];
         isset($config['host']) && $this->host = (string) $config['host'];
         isset($config['port']) && $this->port = (int) $config['port'];
+        isset($config['version']) && $this->version = (string) $config['version'];
         isset($config['grpc']) && $this->grpc = array_replace($this->grpc, $config['grpc']);
     }
 
@@ -109,5 +114,10 @@ class Config
     public function getGrpc(): array
     {
         return $this->grpc;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
     }
 }

--- a/src/service-governance-nacos/src/ClientFactory.php
+++ b/src/service-governance-nacos/src/ClientFactory.php
@@ -26,7 +26,6 @@ class ClientFactory
         } else {
             $baseUri = sprintf('http://%s:%d', $config['host'] ?? '127.0.0.1', $config['port'] ?? 8848);
         }
-
         return new Client(new Config([
             'base_uri' => $baseUri,
             'username' => $config['username'] ?? null,
@@ -37,6 +36,7 @@ class ClientFactory
             'host' => $config['host'] ?? null,
             'port' => $config['port'] ?? null,
             'grpc' => $config['grpc'] ?? [],
+            'version' => $config['version'] ?? null,
         ]));
     }
 }

--- a/src/support/src/Network.php
+++ b/src/support/src/Network.php
@@ -36,6 +36,9 @@ class Network
             }
         }
         if (is_array($ips) && ! empty($ips)) {
+            if(self::isWSL2()){
+                unset($ips["lo"]);
+            }
             return current($ips);
         }
 
@@ -45,5 +48,22 @@ class Network
         }
 
         return gethostbyname($name);
+    }
+
+    /**
+     * 获取当前是否wsl2环境
+     * @return bool
+     */
+    private static function isWSL2(): bool
+    {
+        $version = @file_get_contents('/proc/version');
+        $osRelease = @file_get_contents('/proc/sys/kernel/osrelease');
+        if ($version && stripos($version, 'Microsoft') !== false) {
+            // WSL2 通常会包含 "WSL2" 或类似字段
+            if ($osRelease && stripos($osRelease, 'WSL2') !== false) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #6999 