### PR TITLE
Added `isEmpty` / `isNotEmpty` / `getIterator` methods to Fluent class

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.60 - TBD
 
+## Added
+
+- [#7466](https://github.com/hyperf/hyperf/pull/7466) Added `isEmpty` and `isNotEmpty` methods to `Hyperf\Support\Fluent` class.
+
 ## Fixed
 
 - [#7449](https://github.com/hyperf/hyperf/pull/7449) Fixed bug that `Hyperf\Database\Migrations\Migrator::reset()` cannot support string paths.

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-- [#7466](https://github.com/hyperf/hyperf/pull/7466) Added `isEmpty` and `isNotEmpty` methods to `Hyperf\Support\Fluent` class.
+- [#7466](https://github.com/hyperf/hyperf/pull/7466) Added `isEmpty` / `isNotEmpty` / `getIterator` methods to `Hyperf\Support\Fluent` class.
 
 ## Fixed
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,9 +1,5 @@
 # v3.1.60 - TBD
 
-## Added
-
-- [#7466](https://github.com/hyperf/hyperf/pull/7466) Added `isEmpty` / `isNotEmpty` / `getIterator` methods to `Hyperf\Support\Fluent` class.
-
 ## Fixed
 
 - [#7447](https://github.com/hyperf/hyperf/pull/7447) Fixed bug that the command `migrate:fresh` can't drop postgres tables by default.
@@ -11,6 +7,7 @@
 
 ## Added
 
+- [#7466](https://github.com/hyperf/hyperf/pull/7466) Added `isEmpty` / `isNotEmpty` / `getIterator` methods to `Hyperf\Support\Fluent` class.
 - [#7473](https://github.com/hyperf/hyperf/pull/7473) Added config `produce_retry` and `producer_retry_sleep` for `kafka`.
 
 # v3.1.59 - 2025-07-03

--- a/src/support/src/Fluent.php
+++ b/src/support/src/Fluent.php
@@ -140,6 +140,26 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Determine if the fluent instance is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->attributes);
+    }
+
+    /**
+     * Determine if the fluent instance is not empty.
+     *  
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return !$this->isEmpty();
+    }
+
+    /**
      * Convert the fluent instance to an array.
      *
      * @return array<TKey, TValue>

--- a/src/support/src/Fluent.php
+++ b/src/support/src/Fluent.php
@@ -151,12 +151,12 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 
     /**
      * Determine if the fluent instance is not empty.
-     *  
+     *
      * @return bool
      */
     public function isNotEmpty()
     {
-        return !$this->isEmpty();
+        return ! $this->isEmpty();
     }
 
     /**

--- a/src/support/src/Fluent.php
+++ b/src/support/src/Fluent.php
@@ -16,6 +16,7 @@ use ArrayAccess;
 use Closure;
 use Hyperf\Contract\Arrayable;
 use Hyperf\Contract\Jsonable;
+use Hyperf\Macroable\Macroable;
 use JsonSerializable;
 
 /**
@@ -30,6 +31,10 @@ use JsonSerializable;
  */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
+    use Macroable{
+        __call as macroCall;
+    }
+
     /**
      * All the attributes set on the fluent instance.
      *
@@ -58,6 +63,10 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         $this->attributes[$method] = count($parameters) > 0 ? $parameters[0] : true;
 
         return $this;

--- a/src/support/src/Fluent.php
+++ b/src/support/src/Fluent.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 namespace Hyperf\Support;
 
 use ArrayAccess;
+use ArrayIterator;
 use Closure;
 use Hyperf\Contract\Arrayable;
 use Hyperf\Contract\Jsonable;
 use Hyperf\Macroable\Macroable;
+use IteratorAggregate;
 use JsonSerializable;
+use Traversable;
 
 /**
  * Most of the methods in this file come from illuminate/support,
@@ -29,7 +32,7 @@ use JsonSerializable;
  * @implements \Hyperf\Contract\Arrayable<TKey, TValue>
  * @implements ArrayAccess<TKey, TValue>
  */
-class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
+class Fluent implements ArrayAccess, Arrayable, IteratorAggregate, Jsonable, JsonSerializable
 {
     use Macroable{
         __call as macroCall;
@@ -239,5 +242,15 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     public function offsetUnset(mixed $offset): void
     {
         unset($this->attributes[$offset]);
+    }
+
+    /**
+     * Get an iterator for the attributes.
+     *
+     * @return ArrayIterator<TKey, TValue>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->attributes);
     }
 }

--- a/src/support/tests/FluentTest.php
+++ b/src/support/tests/FluentTest.php
@@ -433,4 +433,23 @@ class FluentTest extends TestCase
         $this->assertEquals('John Doe', $fluent->getFullName());
         $this->assertEquals(['first_name' => 'John', 'last_name' => 'Doe'], $fluent->getAttributes());
     }
+
+    public function testFluentIsIterable()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ]);
+
+        $result = [];
+
+        foreach ($fluent as $key => $value) {
+            $result[$key] = $value;
+        }
+
+        $this->assertSame([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ], $result);
+    }
 }

--- a/src/support/tests/FluentTest.php
+++ b/src/support/tests/FluentTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Support;
+
+use Hyperf\Support\Fluent;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class FluentTest extends TestCase
+{
+    public function testIsEmpty()
+    {
+        $fluent = new Fluent();
+        $this->assertTrue($fluent->isEmpty());
+
+        $fluent = new Fluent([]);
+        $this->assertTrue($fluent->isEmpty());
+
+        $fluent = new Fluent(['key' => 'value']);
+        $this->assertFalse($fluent->isEmpty());
+
+        $fluent = new Fluent(['key' => null]);
+        $this->assertFalse($fluent->isEmpty());
+
+        $fluent = new Fluent(['key' => '']);
+        $this->assertFalse($fluent->isEmpty());
+
+        $fluent = new Fluent(['key' => 0]);
+        $this->assertFalse($fluent->isEmpty());
+    }
+
+    public function testIsNotEmpty()
+    {
+        $fluent = new Fluent();
+        $this->assertFalse($fluent->isNotEmpty());
+
+        $fluent = new Fluent([]);
+        $this->assertFalse($fluent->isNotEmpty());
+
+        $fluent = new Fluent(['key' => 'value']);
+        $this->assertTrue($fluent->isNotEmpty());
+
+        $fluent = new Fluent(['key' => null]);
+        $this->assertTrue($fluent->isNotEmpty());
+
+        $fluent = new Fluent(['key' => '']);
+        $this->assertTrue($fluent->isNotEmpty());
+
+        $fluent = new Fluent(['key' => 0]);
+        $this->assertTrue($fluent->isNotEmpty());
+    }
+
+    public function testIsEmptyWithDynamicSetters()
+    {
+        $fluent = new Fluent();
+        $this->assertTrue($fluent->isEmpty());
+
+        $fluent->name('John');
+        $this->assertFalse($fluent->isEmpty());
+        $this->assertTrue($fluent->isNotEmpty());
+    }
+
+    public function testIsEmptyWithArrayAccess()
+    {
+        $fluent = new Fluent();
+        $this->assertTrue($fluent->isEmpty());
+
+        $fluent['key'] = 'value';
+        $this->assertFalse($fluent->isEmpty());
+        $this->assertTrue($fluent->isNotEmpty());
+
+        unset($fluent['key']);
+        $this->assertTrue($fluent->isEmpty());
+        $this->assertFalse($fluent->isNotEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `isEmpty()` method to check if fluent instance has no attributes
- Add `isNotEmpty()` method as convenience method returning `\!isEmpty()`
- Include comprehensive unit tests covering various scenarios

## Test plan
- [x] Unit tests pass for both new methods
- [x] Tests cover empty instances, different value types, dynamic setters, and array access
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)