### PR TITLE
Added config `produce_retry` and `producer_retry_sleep` for `kafka`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,7 +7,7 @@
 
 ## Added
 
-- [#7473](https://github.com/hyperf/hyperf/pull/7473)
+- [#7473](https://github.com/hyperf/hyperf/pull/7473) Added config `produce_retry` and `producer_retry_sleep` for `kafka`.
 
 # v3.1.59 - 2025-07-03
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,10 @@
 
 - [#7449](https://github.com/hyperf/hyperf/pull/7449) Fixed bug that `Hyperf\Database\Migrations\Migrator::reset()` cannot support string paths.
 
+## Added
+
+- [#7473](https://github.com/hyperf/hyperf/pull/7473)
+
 # v3.1.59 - 2025-07-03
 
 ## Fixed

--- a/src/kafka/publish/kafka.php
+++ b/src/kafka/publish/kafka.php
@@ -28,6 +28,10 @@ return [
         'acks' => -1,
         'producer_id' => -1,
         'producer_epoch' => -1,
+        'produce' => [
+            'max_retries' => 3,
+            'retry_delay' => 0.1,
+        ],
         'partition_leader_epoch' => -1,
         'interval' => 0,
         'session_timeout' => 60,

--- a/src/kafka/publish/kafka.php
+++ b/src/kafka/publish/kafka.php
@@ -28,10 +28,8 @@ return [
         'acks' => -1,
         'producer_id' => -1,
         'producer_epoch' => -1,
-        'produce' => [
-            'max_retries' => 3,
-            'retry_delay' => 0.1,
-        ],
+        'produce_retry' => 3,
+        'produce_retry_sleep' => 0.1,
         'partition_leader_epoch' => -1,
         'interval' => 0,
         'session_timeout' => 60,

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -172,9 +172,9 @@ class Producer
         $producerConfig->setAcks($config['acks']);
         $producerConfig->setProducerId($config['producer_id']);
         $producerConfig->setProducerEpoch($config['producer_epoch']);
-        $producerConfig->setProduceRetry($config['produce_retry']);
+        $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
         isset($config['produce_retry_sleep']) && $producerConfig->setProduceRetrySleep($config['produce_retry_sleep']);
-        isset($config['partition_leader_epoch']) && $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
+        isset($config['produce_retry']) && $producerConfig->setProduceRetry($config['produce_retry']);
         $producerConfig->setAutoCreateTopic($config['auto_create_topic']);
         ! empty($config['sasl']) && $producerConfig->setSasl($config['sasl']);
         ! empty($config['ssl']) && $producerConfig->setSsl($config['ssl']);

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -173,8 +173,8 @@ class Producer
         $producerConfig->setProducerId($config['producer_id']);
         $producerConfig->setProducerEpoch($config['producer_epoch']);
         $producerConfig->setProduceRetry($config['produce_retry']);
-        $producerConfig->setProduceRetrySleep($config['produce_retry_sleep']);
-        $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
+        isset($config['produce_retry_sleep']) && $producerConfig->setProduceRetrySleep($config['produce_retry_sleep']);
+        isset($config['partition_leader_epoch']) && $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
         $producerConfig->setAutoCreateTopic($config['auto_create_topic']);
         ! empty($config['sasl']) && $producerConfig->setSasl($config['sasl']);
         ! empty($config['ssl']) && $producerConfig->setSsl($config['ssl']);

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -172,6 +172,8 @@ class Producer
         $producerConfig->setAcks($config['acks']);
         $producerConfig->setProducerId($config['producer_id']);
         $producerConfig->setProducerEpoch($config['producer_epoch']);
+        $producerConfig->setProduceRetry($config['produce']['max_retries']);
+        $producerConfig->setProduceRetrySleep($config['produce']['retry_delay']);
         $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
         $producerConfig->setAutoCreateTopic($config['auto_create_topic']);
         ! empty($config['sasl']) && $producerConfig->setSasl($config['sasl']);

--- a/src/kafka/src/Producer.php
+++ b/src/kafka/src/Producer.php
@@ -172,8 +172,8 @@ class Producer
         $producerConfig->setAcks($config['acks']);
         $producerConfig->setProducerId($config['producer_id']);
         $producerConfig->setProducerEpoch($config['producer_epoch']);
-        $producerConfig->setProduceRetry($config['produce']['max_retries']);
-        $producerConfig->setProduceRetrySleep($config['produce']['retry_delay']);
+        $producerConfig->setProduceRetry($config['produce_retry']);
+        $producerConfig->setProduceRetrySleep($config['produce_retry_sleep']);
         $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
         $producerConfig->setAutoCreateTopic($config['auto_create_topic']);
         ! empty($config['sasl']) && $producerConfig->setSasl($config['sasl']);


### PR DESCRIPTION
### Changed

This PR introduces support for configuring retry behavior in the Kafka producer by adding two new options:
* `produce.max_retries`: Number of times to retry sending a message if it initially fails.
* `produce.retry_delay`: Time to wait (in seconds) between each retry attempt.

These values are injected into the producer via two new setter methods:
* `setProduceRetry(int $times)`
* `setProduceRetrySleep(float $seconds)`