### PR TITLE
Update Swoole version from v5.1.6 to v5.1.8 in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.3', '8.2', '8.1' ]
-        sw-version: [ 'v5.0.3', 'v5.1.6', 'v6.0.2', 'master' ]
+        sw-version: [ 'v5.0.3', 'v5.1.8', 'v6.0.2', 'master' ]
         exclude:
           - php-version: '8.3'
             sw-version: 'v5.0.3'


### PR DESCRIPTION
## Summary
- Updated Swoole version from v5.1.6 to v5.1.8 in the GitHub Actions CI workflow
- This ensures testing against the latest stable Swoole v5.1.x release

## Test plan
- [x] CI workflow will automatically test with the updated Swoole version
- [x] All existing test suites should continue to pass
- [x] No breaking changes expected as this is a patch version update

🤖 Generated with [Claude Code](https://claude.ai/code)