### PR TITLE
Added methods `Collection::doesntContainStrict()` and `LazyCollection::doesntContainStrict()`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -5,7 +5,7 @@
 - [#7467](https://github.com/hyperf/hyperf/pull/7467) Support versions v2 and v3 for nacos sdk.
 - [#7476](https://github.com/hyperf/hyperf/pull/7476) Added trait `InteractsWithData` to `Hyperf\Support\Fluent`.
 - [#7480](https://github.com/hyperf/hyperf/pull/7480) Added method `Hyperf\Database\Model\Builder::incrementOrCreate()`.
-- [#7481](https://github.com/hyperf/hyperf/pull/7481) Added `doesntContainStrict` method to `Collection` and `LazyCollection`.
+- [#7481](https://github.com/hyperf/hyperf/pull/7481) Added methods `Collection::doesntContainStrict()` and `LazyCollection::doesntContainStrict()`.
 - [#7483](https://github.com/hyperf/hyperf/pull/7483) Added the alias `disassociate()` of `Hyperf\Database\Model\Relations\BelongsTo::dissociate()`.
 - [#7484](https://github.com/hyperf/hyperf/pull/7484) Added method `Hyperf\Database\Model\Model::isSoftDeletable()`.
 - [#7486](https://github.com/hyperf/hyperf/pull/7486) Added method `Hyperf\Database\Model\Builder::except()`.

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.61 - TBD
 
+## Added
+
+- [#7481](https://github.com/hyperf/hyperf/pull/7481) Added `doesntContainStrict` method to `Collection` and `LazyCollection`.
+
 # v3.1.60 - 2025-08-02
 
 ## Fixed

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -211,6 +211,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if an item is not contained in the enumerable, using strict comparison.
+     *
+     * @param mixed $key
+     * @param mixed $operator
+     * @param mixed $value
+     * @return bool
+     */
+    public function doesntContainStrict($key, $operator = null, $value = null)
+    {
+        return ! $this->containsStrict(...func_get_args());
+    }
+
+    /**
      * Flatten a multi-dimensional associative array with dots.
      *
      * @return static<TKey, TValue>

--- a/src/collection/src/LazyCollection.php
+++ b/src/collection/src/LazyCollection.php
@@ -276,6 +276,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if an item is not contained in the enumerable, using strict comparison.
+     *
+     * @param mixed $key
+     * @param mixed $operator
+     * @param mixed $value
+     * @return bool
+     */
+    public function doesntContainStrict($key, $operator = null, $value = null)
+    {
+        return ! $this->containsStrict(...func_get_args());
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @template TCrossJoinKey

--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -135,6 +135,54 @@ class CollectionTest extends TestCase
         }));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testDoesntContainStrict($collection)
+    {
+        $c = new $collection([1, 3, 5, '02']);
+
+        $this->assertFalse($c->doesntContainStrict(1));
+        $this->assertTrue($c->doesntContainStrict('1'));
+        $this->assertTrue($c->doesntContainStrict(2));
+        $this->assertFalse($c->doesntContainStrict('02'));
+        $this->assertTrue($c->doesntContainStrict('2'));
+        $this->assertTrue($c->doesntContainStrict(true));
+        $this->assertFalse($c->doesntContainStrict(function ($value) {
+            return $value < 5;
+        }));
+        $this->assertTrue($c->doesntContainStrict(function ($value) {
+            return $value > 5;
+        }));
+
+        $c = new $collection([0]);
+        $this->assertFalse($c->doesntContainStrict(0));
+        $this->assertTrue($c->doesntContainStrict('0'));
+
+        $this->assertTrue($c->doesntContainStrict(false));
+        $this->assertTrue($c->doesntContainStrict(null));
+
+        $c = new $collection([1, null]);
+        $this->assertFalse($c->doesntContainStrict(null));
+        $this->assertTrue($c->doesntContainStrict(0));
+        $this->assertTrue($c->doesntContainStrict(false));
+
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => '04'], ['v' => 5]]);
+
+        $this->assertFalse($c->doesntContainStrict('v', 1));
+        $this->assertTrue($c->doesntContainStrict('v', 2));
+        $this->assertTrue($c->doesntContainStrict('v', '1'));
+        $this->assertTrue($c->doesntContainStrict('v', 4));
+        $this->assertFalse($c->doesntContainStrict('v', '04'));
+        $this->assertTrue($c->doesntContainStrict('v', '4'));
+
+        $c = new $collection(['date', 'class', (object) ['foo' => 50], '']);
+
+        $this->assertFalse($c->doesntContainStrict('date'));
+        $this->assertFalse($c->doesntContainStrict('class'));
+        $this->assertTrue($c->doesntContainStrict('foo'));
+        $this->assertTrue($c->doesntContainStrict(null));
+        $this->assertFalse($c->doesntContainStrict(''));
+    }
+
     public function testDot(): void
     {
         $col = Collection::make([


### PR DESCRIPTION
## Summary
- Added `doesntContainStrict` method to Collection class for strict comparison checks
- Added `doesntContainStrict` method to LazyCollection class  
- Added comprehensive test cases for `doesntContainStrict` functionality
- Method returns inverse of `containsStrict` for better API consistency

## Test plan
- Run collection tests to verify the new method works correctly
- Test strict comparison behavior with different data types
- Ensure compatibility with existing Collection and LazyCollection APIs