### PR TITLE
Add disassociate alias method to BelongsTo relation

### DIFF
--- a/src/database/src/Model/Relations/BelongsTo.php
+++ b/src/database/src/Model/Relations/BelongsTo.php
@@ -362,4 +362,14 @@ class BelongsTo extends Relation
     {
         return $this->related->newInstance();
     }
+
+    /**
+     * Alias of "dissociate" method.
+     *
+     * @return Model
+     */
+    public function disassociate()
+    {
+        return $this->dissociate();
+    }
 }

--- a/src/database/src/Model/Relations/BelongsTo.php
+++ b/src/database/src/Model/Relations/BelongsTo.php
@@ -372,4 +372,5 @@ class BelongsTo extends Relation
     {
         return $this->dissociate();
     }
+
 }


### PR DESCRIPTION
Added disassociate() method as an alias for dissociate() to provide alternative spelling for the relationship dissociation method in BelongsTo relation class.