### PR TITLE
Add isSoftDeletable method to Model class with comprehensive tests

### DIFF
--- a/src/database/src/Model/Model.php
+++ b/src/database/src/Model/Model.php
@@ -1199,6 +1199,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if the model is soft deletable.
+     */
+    public static function isSoftDeletable(): bool
+    {
+        return in_array(SoftDeletes::class, class_uses_recursive(static::class));
+    }
+
+    /**
      * Determine if the given attribute exists.
      */
     public function offsetExists(mixed $offset): bool

--- a/src/database/tests/ModelTest.php
+++ b/src/database/tests/ModelTest.php
@@ -67,6 +67,8 @@ use HyperfTest\Database\Stubs\ModelWithoutRelationStub;
 use HyperfTest\Database\Stubs\ModelWithoutTableStub;
 use HyperfTest\Database\Stubs\ModelWithStub;
 use HyperfTest\Database\Stubs\NoConnectionModelStub;
+use HyperfTest\Database\Stubs\NonSoftDeletableModelStub;
+use HyperfTest\Database\Stubs\SoftDeletableModelStub;
 use HyperfTest\Database\Stubs\User;
 use LogicException;
 use Mockery;
@@ -2103,6 +2105,13 @@ class ModelTest extends TestCase
         } finally {
             Relation::morphMap([], false);
         }
+    }
+
+    public function testIsSoftDeletable()
+    {
+        $this->assertTrue(SoftDeletableModelStub::isSoftDeletable());
+        $this->assertFalse(NonSoftDeletableModelStub::isSoftDeletable());
+        $this->assertFalse(ModelStub::isSoftDeletable());
     }
 
     protected function getContainer()

--- a/src/database/tests/Stubs/NonSoftDeletableModelStub.php
+++ b/src/database/tests/Stubs/NonSoftDeletableModelStub.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Database\Stubs;
+
+use Hyperf\Database\Model\Model;
+
+class NonSoftDeletableModelStub extends Model
+{
+    protected ?string $table = 'non_soft_deletable_stub';
+
+    protected array $fillable = ['name'];
+}

--- a/src/database/tests/Stubs/SoftDeletableModelStub.php
+++ b/src/database/tests/Stubs/SoftDeletableModelStub.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Database\Stubs;
+
+use Hyperf\Database\Model\Model;
+use Hyperf\Database\Model\SoftDeletes;
+
+class SoftDeletableModelStub extends Model
+{
+    use SoftDeletes;
+
+    protected ?string $table = 'soft_deletable_stub';
+
+    protected array $fillable = ['name'];
+}


### PR DESCRIPTION
- Added static isSoftDeletable() method to check if a model uses SoftDeletes trait
- Method uses class_uses_recursive() to detect SoftDeletes trait in class hierarchy
- Added comprehensive unit tests with dedicated test stub classes
- Created SoftDeletableModelStub and NonSoftDeletableModelStub for testing
- Tests verify correct behavior for models with and without SoftDeletes trait

🤖 Generated with [Claude Code](https://claude.ai/code)