### PR TITLE
migrate from deprecated Monolog\Logger to Monolog\Level

### DIFF
--- a/src/logger/publish/logger.php
+++ b/src/logger/publish/logger.php
@@ -20,7 +20,7 @@ return [
                 'class' => StreamHandler::class,
                 'constructor' => [
                     'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-                    'level' => Level::DEBUG,
+                    'level' => Level::Debug,
                 ],
                 'formatter' => [
                     'class' => LineFormatter::class,

--- a/src/logger/publish/logger.php
+++ b/src/logger/publish/logger.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
+use Monolog\Level;
 
 return [
     'default' => [
@@ -20,7 +20,7 @@ return [
                 'class' => StreamHandler::class,
                 'constructor' => [
                     'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-                    'level' => Logger::DEBUG,
+                    'level' => Level::DEBUG,
                 ],
                 'formatter' => [
                     'class' => LineFormatter::class,


### PR DESCRIPTION
This PR migrates the logger configuration from using deprecated `Monolog\Logger` log level constants to the new `Monolog\Level` enum, as recommended by the Monolog library.

- Update import statement from `Monolog\Logger` to `Monolog\Level`
- Replace `Logger::DEBUG` with `Level::Debug` in logger configuration