### PR TITLE
Added Macroable trait to `Hyperf\Pipeline\Pipeline`.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.61 - TBD
 
+## Added
+
+- [#7492](https://github.com/hyperf/hyperf/pull/7492) Added Macroable trait to `Hyperf\Pipeline\Pipeline` class with comprehensive unit tests.
+
 # v3.1.60 - 2025-08-02
 
 ## Fixed

--- a/src/pipeline/composer.json
+++ b/src/pipeline/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": ">=8.1",
+        "hyperf/macroable": "~3.1.0",
         "psr/container": "^1.0 || ^2.0"
     },
     "autoload": {

--- a/src/pipeline/src/Pipeline.php
+++ b/src/pipeline/src/Pipeline.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Pipeline;
 
 use Closure;
+use Hyperf\Macroable\Macroable;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -21,6 +22,8 @@ use Psr\Container\ContainerInterface;
  */
 class Pipeline
 {
+    use Macroable;
+
     /**
      * The object being passed through the pipeline.
      */

--- a/src/pipeline/tests/PipelineTest.php
+++ b/src/pipeline/tests/PipelineTest.php
@@ -211,6 +211,58 @@ class PipelineTest extends TestCase
         $this->assertSame($id + 6, $result);
     }
 
+    public function testPipelineMacro()
+    {
+        Pipeline::macro('customMethod', function ($value) {
+            return 'custom_' . $value;
+        });
+
+        $pipeline = new Pipeline($this->getContainer());
+        $this->assertTrue($pipeline->hasMacro('customMethod'));
+        $this->assertSame('custom_test', $pipeline->customMethod('test'));
+    }
+
+    public function testPipelineMacroWithThis()
+    {
+        Pipeline::macro('getPipes', function () {
+            return $this->pipes;
+        });
+
+        $pipeline = new Pipeline($this->getContainer());
+        $pipeline->through(['pipe1', 'pipe2']);
+
+        $this->assertEquals(['pipe1', 'pipe2'], $pipeline->getPipes());
+    }
+
+    public function testPipelineHasMacro()
+    {
+        Pipeline::macro('existingMacro', function () {
+            return 'exists';
+        });
+
+        $pipeline = new Pipeline($this->getContainer());
+
+        $this->assertTrue($pipeline->hasMacro('existingMacro'));
+        $this->assertFalse($pipeline->hasMacro('nonExistingMacro'));
+    }
+
+    public function testPipelineMacroOverwrite()
+    {
+        Pipeline::macro('testMacro', function () {
+            return 'first';
+        });
+
+        $pipeline = new Pipeline($this->getContainer());
+        $this->assertSame('first', $pipeline->testMacro());
+
+        Pipeline::macro('testMacro', function () {
+            return 'second';
+        });
+
+        $pipeline2 = new Pipeline($this->getContainer());
+        $this->assertSame('second', $pipeline2->testMacro());
+    }
+
     protected function getContainer()
     {
         $container = Mockery::mock(ContainerInterface::class);


### PR DESCRIPTION
## Summary
- Added Macroable trait to Pipeline class
- Added hyperf/macroable dependency to composer.json  
- Added comprehensive unit tests for Macroable functionality

## Changes
- Use Macroable trait in Pipeline class
- Add hyperf/macroable dependency
- Add unit tests covering:
  - Basic macro functionality
  - Macro with $this context access
  - hasMacro method
  - Macro overwriting behavior

## Test plan
- [x] Run unit tests (14 tests, 28 assertions passed)
- [x] Code style fixed
- [x] Static analysis passed