### PR TITLE
Fix macro validation for reference parameters and Redis formatting

### DIFF
--- a/src/macroable/src/Macroable.php
+++ b/src/macroable/src/Macroable.php
@@ -14,8 +14,10 @@ namespace Hyperf\Macroable;
 
 use BadMethodCallException;
 use Closure;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionFunction;
 use ReflectionMethod;
 
 /**
@@ -93,6 +95,18 @@ trait Macroable
      */
     public static function macro($name, $macro)
     {
+        if ($macro instanceof Closure) {
+            $reflection = new ReflectionFunction($macro);
+            foreach ($reflection->getParameters() as $parameter) {
+                if ($parameter->isPassedByReference()) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Macro %s cannot accept parameters passed by reference.',
+                        $name
+                    ));
+                }
+            }
+        }
+
         static::$macros[$name] = $macro;
     }
 

--- a/src/macroable/tests/MacroableTest.php
+++ b/src/macroable/tests/MacroableTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace HyperfTest\Macroable;
 
 use Hyperf\Macroable\Macroable;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
@@ -83,6 +84,16 @@ class MacroableTest extends TestCase
 
         TestMacroable::mixin(new TestMixin());
         $this->assertSame('foo', $instance->methodThree());
+    }
+
+    public function testParametersPassedByReference()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Macro methodFour cannot accept parameters passed by reference.');
+
+        TestMacroable::macro('methodFour', function (&$value) {
+            return $value;
+        });
     }
 
     private function createObjectForTrait()

--- a/src/metric/src/Adapter/Prometheus/Redis.php
+++ b/src/metric/src/Adapter/Prometheus/Redis.php
@@ -78,8 +78,7 @@ if tonumber(result) >= tonumber(ARGV[3]) then
     redis.call('sAdd', KEYS[2], KEYS[1])
 end
 return result
-LUA
-            ,
+LUA,
             [
                 $this->toMetricKey($data),
                 $this->getMetricGatherKey(Histogram::TYPE),
@@ -114,8 +113,7 @@ else
         redis.call('sAdd', KEYS[2], KEYS[1])
     end
 end
-LUA
-            ,
+LUA,
             [
                 $this->toMetricKey($data),
                 $this->getMetricGatherKey(Gauge::TYPE),
@@ -144,8 +142,7 @@ if added == 1 then
     redis.call('hMSet', KEYS[1], '__meta', ARGV[4])
 end
 return result
-LUA
-            ,
+LUA,
             [
                 $this->toMetricKey($data),
                 $this->getMetricGatherKey(Counter::TYPE),
@@ -183,8 +180,7 @@ repeat
         redis.call('DEL', key)
     end
 until cursor == "0"
-LUA
-            ,
+LUA,
             [$searchPattern],
             0
         );


### PR DESCRIPTION
## Summary
This PR fixes two issues:

1. **Macroable trait validation**: Added validation to prevent macros with reference parameters, which can cause unexpected behavior and potential issues
2. **Redis adapter formatting**: Fixed formatting inconsistencies in LUA scripts within the Prometheus Redis adapter

## Changes
- Added parameter validation in `Macroable::macro()` method to detect and reject closures with reference parameters
- Added `InvalidArgumentException` with descriptive error message when reference parameters are detected
- Added comprehensive test case to ensure reference parameter validation works correctly
- Fixed formatting issues in Redis adapter LUA scripts (removed extra newlines for consistency)

## Testing
- Added new test case `testParametersPassedByReference()` in `MacroableTest.php`
- All existing tests continue to pass
- Manual verification of the changes

## Impact
- **Breaking change**: Macros with reference parameters will now throw `InvalidArgumentException`
- **Code quality**: Improved consistency in Redis adapter code formatting
- **Stability**: Prevents potential issues with macro binding and reference parameters

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation update