### PR TITLE
Add php-polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
+        "symfony/polyfill-php83": "^1.33",
+        "symfony/polyfill-php84": "^1.33",
+        "symfony/polyfill-php85": "^1.33"
     },
     "require-dev": {
         "doctrine/dbal": "^3.6",

--- a/src/collection/composer.json
+++ b/src/collection/composer.json
@@ -20,7 +20,9 @@
         "hyperf/conditionable": "~3.1.0",
         "hyperf/contract": "~3.1.0",
         "hyperf/macroable": "~3.1.0",
-        "hyperf/stringable": "~3.1.0"
+        "hyperf/stringable": "~3.1.0",
+        "symfony/polyfill-php84": "^1.33",
+        "symfony/polyfill-php85": "^1.33"
     },
     "autoload": {
         "psr-4": {

--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -139,16 +139,21 @@ class Arr
             if (empty($array)) {
                 return value($default);
             }
+
+            if (is_array($array)) {
+                return array_first($array);
+            }
+
             foreach ($array as $item) {
                 return $item;
             }
+
+            return value($default);
         }
-        foreach ($array as $key => $value) {
-            if (call_user_func($callback, $value, $key)) {
-                return $value;
-            }
-        }
-        return value($default);
+
+        $key = array_find_key($array, $callback);
+
+        return $key !== null ? $array[$key] : value($default);
     }
 
     /**

--- a/src/collection/src/Collection.php
+++ b/src/collection/src/Collection.php
@@ -155,8 +155,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (func_num_args() === 1) {
             if ($this->useAsCallable($key)) {
-                $placeholder = new stdClass();
-                return $this->first($key, $placeholder) !== $placeholder;
+                return array_any($this->items, $key);
             }
             return in_array($key, $this->items);
         }
@@ -497,12 +496,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function has($key): bool
     {
         $keys = is_array($key) ? $key : func_get_args();
-        foreach ($keys as $value) {
-            if (! $this->offsetExists($value)) {
-                return false;
-            }
-        }
-        return true;
+
+        return array_all($keys, fn ($key) => array_key_exists($key, $this->items));
     }
 
     /**
@@ -518,13 +513,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $value) {
-            if ($this->has($value)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => array_key_exists($key, $this->items));
     }
 
     /**
@@ -900,12 +889,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         if (! $this->useAsCallable($value)) {
             return array_search($value, $this->items, $strict);
         }
-        foreach ($this->items as $key => $item) {
-            if (call_user_func($value, $item, $key)) {
-                return $key;
-            }
-        }
-        return false;
+
+        return array_find_key($this->items, $value) ?? false;
     }
 
     /**

--- a/src/stringable/composer.json
+++ b/src/stringable/composer.json
@@ -22,7 +22,8 @@
         "hyperf/collection": "~3.1.0",
         "hyperf/conditionable": "~3.1.0",
         "hyperf/macroable": "~3.1.0",
-        "hyperf/tappable": "~3.1.0"
+        "hyperf/tappable": "~3.1.0",
+        "symfony/polyfill-php83": "^1.33"
     },
     "suggest": {
         "doctrine/inflector": "Required to use plural and singular methods.(^2.0|^3.0)",

--- a/src/stringable/src/Str.php
+++ b/src/stringable/src/Str.php
@@ -19,7 +19,6 @@ use Hyperf\Collection\Arr;
 use Hyperf\Collection\Collection;
 use Hyperf\Macroable\Macroable;
 use InvalidArgumentException;
-use JsonException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
@@ -1113,17 +1112,7 @@ class Str
             return false;
         }
 
-        if (function_exists('json_validate')) {
-            return json_validate($value, 512);
-        }
-
-        try {
-            json_decode($value, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            return false;
-        }
-
-        return true;
+        return json_validate($value, 512);
     }
 
     /**

--- a/src/validation/composer.json
+++ b/src/validation/composer.json
@@ -24,7 +24,8 @@
         "nesbot/carbon": "^2.21",
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^1.0 || ^2.0",
+        "symfony/polyfill-php83": "^1.33"
     },
     "suggest": {
         "hyperf/database": "Required if you want to use the database validation rule (~3.1.0).",

--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -956,17 +956,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if (function_exists('json_validate')) {
-            return json_validate($value);
-        }
-
-        try {
-            json_decode($value, flags: JSON_THROW_ON_ERROR);
-        } catch (Throwable) {
-            return false;
-        }
-
-        return true;
+        return json_validate($value);
     }
 
     /**


### PR DESCRIPTION
Replaced custom JSON validation logic with direct calls to json_validate in Str and ValidatesAttributes. Updated composer.json files to require symfony/polyfill-php83, php84, and php85 for improved PHP compatibility. Refactored array utility usage in Arr and Collection for consistency and performance.