### PR TITLE
remove internal

### DIFF
--- a/src/di/src/Container.php
+++ b/src/di/src/Container.php
@@ -91,7 +91,6 @@ class Container implements HyperfContainerInterface
     }
 
     /**
-     * @internal
      * @param mixed $id
      */
     public function get($id)
@@ -104,7 +103,6 @@ class Container implements HyperfContainerInterface
     }
 
     /**
-     * @internal
      * @param mixed $id
      */
     public function has($id): bool


### PR DESCRIPTION
移除internal
ContainerInterface  get和has是公开方法

```php
namespace Psr\Container;

interface ContainerInterface
{

    public function get(string $id);

    public function has(string $id): bool;
}

```