### PR TITLE
fix: validated method

### DIFF
--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -324,7 +324,11 @@ class Validator implements ValidatorContract
      */
     public function validated(): array
     {
-        if ($this->invalid()) {
+        if (! $this->messages) {
+            $this->passes();
+        }
+
+        if ($this->messages->isNotEmpty()) {
             throw new ValidationException($this);
         }
 

--- a/src/validation/tests/Cases/ValidationMiddlewareTest.php
+++ b/src/validation/tests/Cases/ValidationMiddlewareTest.php
@@ -128,13 +128,15 @@ class ValidationMiddlewareTest extends TestCase
         $request = Context::set(ServerRequestInterface::class, $request->withAttribute(Dispatched::class, new Dispatched($routes)));
         $response = $middleware->process($request, $handler);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('{"id":1,"request":{"username":"Hyperf","password":"Hyperf"}}', (string) $response->getBody());
+        $this->assertEquals('{"id":1,"request":{"username":"Hyperf","password":"Hyperf"}}', (string)$response->getBody());
     }
 
     public function testGetValidatorInstance()
     {
         $container = $this->createContainer();
-        Context::set(ServerRequestInterface::class, new Request('POST', new Uri('/')));
+        $request = (new Request('POST', new Uri('/')))
+            ->withParsedBody(['username' => 'Hyperf', 'password' => 'password']);
+        Context::set(ServerRequestInterface::class, $request);
         $request = $container->get(DemoRequest::class);
 
         $request->validated();

--- a/src/validation/tests/Cases/ValidationValidatorTest.php
+++ b/src/validation/tests/Cases/ValidationValidatorTest.php
@@ -5712,6 +5712,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
         $this->assertSame([], $v->validated());
 
+        $this->expectException(ValidationException::class);
         $file = new SplFileInfo(__FILE__);
         $v = new Validator($trans, ['file' => $file], ['foo' => 'exclude_without:file|required']);
         $this->assertFalse($v->passes());
@@ -5746,6 +5747,35 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'exclude_without:file']);
         $this->assertTrue($v->passes());
         $this->assertSame([], $v->validated());
+    }
+
+    public function testValidatedThrowsOnFail()
+    {
+        $this->expectException(ValidationException::class);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
+
+        $v->validated();
+    }
+
+    public function testValidatedThrowsOnFailEvenAfterPassesCall()
+    {
+        $this->expectException(ValidationException::class);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
+
+        $v->passes();
+        $v->validated();
+    }
+
+    public function testValidatedDoesntThrowOnPass()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
+
+        $this->assertSame(['foo' => 'bar'], $v->validated());
     }
 
     protected function getTranslator()


### PR DESCRIPTION
修复 validated 方法在验证不存在的数据时可以跳过的问题。
```php
  public function testValidatedThrowsOnFail()
  {
      $this->expectException(ValidationException::class);
      $v = new Validator($this->getContainer()->make(TranslatorContract::class), [], ['foo' => 'required']);
      $v->validated();
  }
```
<img width="1125" height="486" alt="image" src="https://github.com/user-attachments/assets/6a8e8f91-9e45-46d1-96bc-8807da1ef3a1" />

#5904  #4720