### PR TITLE
fix(command): add coordinator cleanup in command execution finally block

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.62 - TBD
 
+## Optimized
+
+- [#7545](https://github.com/hyperf/hyperf/pull/7545) Added coordinator resume in command execution finally block.
+
 # v3.1.61 - 2025-09-04
 
 ## Added

--- a/src/command/composer.json
+++ b/src/command/composer.json
@@ -13,6 +13,7 @@
         "hyperf/collection": "~3.1.0",
         "hyperf/context": "~3.1.0",
         "hyperf/contract": "~3.1.0",
+        "hyperf/coordinator": "~3.1.0",
         "hyperf/coroutine": "~3.1.0",
         "hyperf/di": "~3.1.0",
         "hyperf/stringable": "~3.1.0",

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -199,7 +199,9 @@ abstract class Command extends SymfonyCommand
                 $this->eventDispatcher?->dispatch(new Event\AfterExecute($this, $exception ?? null));
 
                 try {
-                    CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
+                    if ($this->getApplication()->isAutoExitEnabled()) {
+                        CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
+                    }
                 } catch (Throwable) {
                 }
             }

--- a/src/command/src/Command.php
+++ b/src/command/src/Command.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Hyperf\Command;
 
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Coroutine\Coroutine;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Swoole\ExitException;
@@ -195,6 +197,11 @@ abstract class Command extends SymfonyCommand
                 $this->eventDispatcher->dispatch(new Event\FailToHandle($this, $exception));
             } finally {
                 $this->eventDispatcher?->dispatch(new Event\AfterExecute($this, $exception ?? null));
+
+                try {
+                    CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
+                } catch (Throwable) {
+                }
             }
 
             return $this->exitCode;

--- a/src/coordinator/src/Listener/ResumeExitCoordinatorListener.php
+++ b/src/coordinator/src/Listener/ResumeExitCoordinatorListener.php
@@ -17,6 +17,9 @@ use Hyperf\Coordinator\Constants;
 use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Event\Contract\ListenerInterface;
 
+/**
+ * @deprecated since v3.1, will be removed in v3.2
+ */
 class ResumeExitCoordinatorListener implements ListenerInterface
 {
     public function listen(): array
@@ -28,6 +31,6 @@ class ResumeExitCoordinatorListener implements ListenerInterface
 
     public function process(object $event): void
     {
-        CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
+        // CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
     }
 }


### PR DESCRIPTION
## Summary
- Add CoordinatorManager cleanup in the finally block of command execution
- Ensure proper coordinator cleanup after command execution completes
- Wrap cleanup call in try-catch to prevent exceptions from interrupting the cleanup flow

## Changes
- Added `CoordinatorManager::until(Constants::WORKER_EXIT)->resume()` in the finally block
- Added necessary imports for `Hyperf\Coordinator\Constants` and `Hyperf\Coordinator\CoordinatorManager`
- Wrapped the cleanup call in try-catch block to handle any potential exceptions gracefully

## Test plan
- [x] Verify command execution works normally
- [x] Confirm coordinator cleanup is called after command execution
- [x] Test that exceptions in cleanup don't affect command execution flow