### PR TITLE
Fix/redis cluster config order

### DIFF
--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -203,9 +203,7 @@ class RedisConnection extends BaseConnection implements ConnectionInterface
             $parameters[] = $this->config['timeout'] ?? 0.0;
             $parameters[] = $this->config['cluster']['read_timeout'] ?? 0.0;
             $parameters[] = $this->config['cluster']['persistent'] ?? false;
-            if (isset($this->config['auth'])) {
-                $parameters[] = $this->config['auth'];
-            }
+            $parameters[] = $this->config['auth'];
             if (! empty($this->config['cluster']['context'])) {
                 $parameters[] = $this->config['cluster']['context'];
             }


### PR DESCRIPTION
this fix a issue that you cannot use context config without set auth config, the isset ignore null config causing the creation of RedisCluster with context config as auth, creating problems like configure TLS config like the redis extension documentation says:

```PHP 
// Connect with cluster using TLS
// last argument is an optional array with [SSL context options](https://www.php.net/manual/en/context.ssl.php) (TLS options)
// If value is array (even empty), it will connect via TLS.  If not, it will connect without TLS.
// Note: If the seeds start with "ssl:// or tls://", it will connect to the seeds via TLS, but the subsequent connections will connect without TLS if this value is null.  So, if your nodes require TLS, this value must be an array, even if empty.
$obj_cluster = new RedisCluster(NULL, ["host:7000", "host:7001"], 1.5, 1.5, true, NULL, ["verify_peer" => false]);
```

https://github.com/phpredis/phpredis/blob/develop/cluster.md#creating-and-connecting-to-a-cluster


