### PR TITLE
[bugfix] http pool client need reset cookie before use

### DIFF
--- a/src/guzzle/src/PoolHandler.php
+++ b/src/guzzle/src/PoolHandler.php
@@ -51,7 +51,12 @@ class PoolHandler extends CoroutineHandler
         $connection = $pool->get();
         $response = null;
         try {
+            /**
+             * @var \Hyperf\Engine\Http\Client
+             */
             $client = $connection->getConnection();
+            // cookie reset
+            $client->setCookies([]);
             $headers = $this->initHeaders($request, $options);
             $settings = $this->getSettings($request, $options);
             if (! empty($settings)) {


### PR DESCRIPTION
When app use http pool, current http request cookie will be affected by previous http response's set-cookie,So When got client by http pool,should reset client's cookie first.