### PR TITLE
Fixed PHPStan type assertions in database model types

### DIFF
--- a/src/database/types/Model/Builder.php
+++ b/src/database/types/Model/Builder.php
@@ -48,11 +48,11 @@ function test(
     assertType('Hyperf\Database\Model\Collection<int, Hyperf\Types\Builder\User>', $query->findOr([1], callback: fn () => 42));
     assertType('Hyperf\Types\Builder\User', $query->findOrFail(1));
     assertType('Hyperf\Types\Builder\User|null', $query->find(1));
-    assertType('Hyperf\Types\Builder\User|int', $query->findOr(1, fn () => 42));
-    assertType('Hyperf\Types\Builder\User|int', $query->findOr(1, callback: fn () => 42));
+    assertType('42|Hyperf\Types\Builder\User', $query->findOr(1, fn () => 42));
+    assertType('42|Hyperf\Types\Builder\User', $query->findOr(1, callback: fn () => 42));
     assertType('Hyperf\Types\Builder\User|null', $query->first());
-    assertType('Hyperf\Types\Builder\User|int', $query->firstOr(fn () => 42));
-    assertType('Hyperf\Types\Builder\User|int', $query->firstOr(callback: fn () => 42));
+    assertType('42|Hyperf\Types\Builder\User', $query->firstOr(fn () => 42));
+    assertType('42|Hyperf\Types\Builder\User', $query->firstOr(callback: fn () => 42));
     assertType('Hyperf\Types\Builder\User', $query->firstOrNew(['id' => 1]));
     assertType('Hyperf\Types\Builder\User', $query->findOrNew(1));
     assertType('Hyperf\Types\Builder\User', $query->firstOrCreate(['id' => 1]));

--- a/src/database/types/Model/Collection.php
+++ b/src/database/types/Model/Collection.php
@@ -15,7 +15,7 @@ $collection = User::all();
 assertType('Hyperf\Database\Model\Collection<int, User>', $collection);
 
 assertType('User|null', $collection->find(1));
-assertType('string|User', $collection->find(1, 'string'));
+assertType('\'string\'|User', $collection->find(1, 'string'));
 assertType('Hyperf\Database\Model\Collection<int, User>', $collection->find([1]));
 
 assertType('Hyperf\Database\Model\Collection<int, User>', $collection->load('string'));


### PR DESCRIPTION
## Summary
Fixed PHPStan type assertions in database model type test files to ensure proper literal type recognition.

## Changes
- Updated return type assertions for findOr() and firstOr() methods in src/database/types/Model/Builder.php
  - Changed from User|int to 42|User format to properly represent literal types
- Fixed string literal type assertion in src/database/types/Model/Collection.php
  - Changed from string|User to 'string'|User format for proper literal type recognition

## Test plan
- [x] PHPStan analysis should pass with correct type assertions
- [x] Type inference should properly recognize literal types in test scenarios

These changes ensure PHPStan properly recognizes the literal types in the type analysis tests.