### PR TITLE
chore(ci): upgrade Swoole version from v6.1.0 to v6.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.3', '8.2', '8.1' ]
-        sw-version: ['v6.1.0',  'v6.0.2', 'v5.1.8', 'v5.0.3', 'master' ]
+        sw-version: ['v6.1.1',  'v6.0.2', 'v5.1.8', 'v5.0.3', 'master' ]
         exclude:
           - php-version: '8.3'
             sw-version: 'v5.0.3'


### PR DESCRIPTION
## Summary
- Updates the GitHub Actions test workflow to use Swoole v6.1.1 instead of v6.1.0
- Ensures compatibility testing with the latest Swoole release

## Changes
- Updated `.github/workflows/test.yml` to use Swoole v6.1.1 in the test matrix

## Test plan
- CI tests will run automatically with the new Swoole version