### PR TITLE
chore(ci): re-enable PHAR build test

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -141,7 +141,7 @@ jobs:
   phar:
     name: Test for Building PHAR
     runs-on: 'ubuntu-latest'
-    if: false # Disable this job
+    # if: false # Disable this job
     env:
       PHP_VERSION: ${{ matrix.php-version }}
     strategy:


### PR DESCRIPTION
## Summary
- Re-enabled the PHAR build test job in the GitHub Actions workflow
- The test was previously disabled with `if: false` condition, now commented out

## Changes
- Modified `.github/workflows/test-components.yml` to re-enable the PHAR build test job

## Test plan
- [x] Verify the workflow syntax is correct
- [ ] Confirm PHAR build test runs successfully in CI