### PR TITLE
refactor(async-queue): strengthen Result type handling in Driver and AfterHandle event

### DIFF
--- a/src/async-queue/src/Event/AfterHandle.php
+++ b/src/async-queue/src/Event/AfterHandle.php
@@ -17,7 +17,7 @@ use Hyperf\AsyncQueue\Result;
 
 class AfterHandle extends Event
 {
-    public function __construct(MessageInterface $message, public ?Result $result = null)
+    public function __construct(MessageInterface $message, public Result $result)
     {
         parent::__construct($message);
     }


### PR DESCRIPTION
## Summary

- Normalize job handler return value to `Result` enum, defaulting to `Result::ACK` for non-Result returns
- Remove redundant `default` case from match expression since all `Result` cases are explicitly handled  
- Change `AfterHandle` event's `$result` property from nullable `Result` to required `Result` type
- Eliminate duplicate `Result` type check when dispatching `AfterHandle` event

## Changes

### Driver.php (src/async-queue/src/Driver/Driver.php:123-132)
- Added normalization: `$result = $result instanceof Result ? $result : Result::ACK;`
- Removed redundant `default => $this->ack($data)` case from match expression
- Simplified `AfterHandle` dispatch to pass `$result` directly without type check

### AfterHandle.php (src/async-queue/src/Event/AfterHandle.php:20)
- Changed constructor parameter from `public ?Result $result = null` to `public Result $result`

## Benefits

- **Type Safety**: Ensures `AfterHandle` event always receives a valid `Result` enum value
- **Code Clarity**: Removes redundant type checking and default handling
- **Backward Compatibility**: Jobs not returning a `Result` enum will automatically get `Result::ACK` behavior
- **Consistency**: All result handling paths now work with the `Result` enum type

## Test plan

- Verify existing async queue jobs continue to work correctly
- Test jobs that return `Result` enum values (`ACK`, `REQUEUE`, `RETRY`, `DROP`)
- Test jobs that return non-Result values (should default to `ACK`)
- Verify `AfterHandle` event listeners receive proper `Result` values