### PR TITLE
ci: add retry mechanism for test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,4 +107,8 @@ jobs:
           php -i
           php -m
       - name: Run Test Cases
-        run: ./.travis/run.test.sh
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          command: ./.travis/run.test.sh


### PR DESCRIPTION
## Summary
- Added retry mechanism to GitHub Actions test workflow using `nick-fields/retry@v3` action
- Tests will automatically retry up to 2 times if they fail
- Added 10-minute timeout per attempt to prevent indefinite hangs

## Motivation
This change improves CI stability by handling flaky tests that may occasionally fail due to transient issues such as network timeouts, race conditions, or external service unavailability.

## Changes
- Modified `.github/workflows/test.yml` to wrap test execution with retry action
- Configured max attempts: 2
- Configured timeout: 10 minutes per attempt

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Monitor CI runs to ensure retry mechanism works as expected
- [ ] Confirm that legitimate failures still get reported after retry attempts