### PR TITLE
Fixed setlocale set failed 

### DIFF
--- a/src/collection/tests/CollectionTest.php
+++ b/src/collection/tests/CollectionTest.php
@@ -1283,7 +1283,7 @@ class CollectionTest extends TestCase
             ]
         ))->sortBy('name', SORT_LOCALE_STRING);
 
-        // 只取 name 排序
+        // name sort by locale string
         $nameArray = $data->pluck('name')->toArray();
         asort($nameArray, SORT_LOCALE_STRING);
         $this->assertEquals(json_encode(array_values($nameArray)), (string) $data->values()->pluck('name'));


### PR DESCRIPTION
In my macos , original setlocale return `false` .

https://www.php.net/manual/zh/function.setlocale.php
```
返回值
返回新的当前区域，如果区域功能没有在当前平台实现、指定区域不存在或类别名无效时返回 [false]
````

