### PR TITLE
feat(async-queue): introduce PendingDispatch for fluent job dispatching

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -74,6 +74,25 @@ return [
 ];
 ```
 
+4. The `dispatch()` function now returns `PendingDispatch` instead of `bool`. Please refer to [#7623](https://github.com/hyperf/hyperf/pull/7623).
+
+```php
+<?php
+
+use function Hyperf\AsyncQueue\dispatch;
+
+// Before
+$result = dispatch($job, 60, 3, 'custom');
+// $result is bool
+
+// After
+dispatch($job)->delay(60)->setMaxAttempts(3)->onPool('custom');
+// Or with conditional chaining
+dispatch($job)
+    ->when($condition, fn($pending) => $pending->delay(60))
+    ->unless($anotherCondition, fn($pending) => $pending->onPool('custom'));
+```
+
 ## Dependencies Upgrade
 
 - Upgrade the php version to `>=8.2`
@@ -109,6 +128,7 @@ return [
 - [#7312](https://github.com/hyperf/hyperf/pull/7312) Added `Macroable` support to `Hyperf\Context\Context`.
 - [#7605](https://github.com/hyperf/hyperf/pull/7605) Added `NonCoroutine` attribute for flexible test execution control.
 - [#7618](https://github.com/hyperf/hyperf/pull/7618) Added a new registration mode for async queue consumer processes that supports automatic registration based on configuration, eliminating the need for manual process registration in `config/autoload/processes.php`.
+- [#7623](https://github.com/hyperf/hyperf/pull/7623) Added `PendingDispatch` class with fluent interface for dispatching async queue jobs, supporting method chaining with `setMaxAttempts()`, `onPool()`, `delay()`, and conditional methods `when()`/`unless()` via `Conditionable` trait.
 
 ## Changed
 

--- a/src/async-queue/composer.json
+++ b/src/async-queue/composer.json
@@ -19,6 +19,7 @@
         "hyperf/codec": "~3.2.0",
         "hyperf/collection": "~3.2.0",
         "hyperf/command": "~3.2.0",
+        "hyperf/conditionable": "~3.2.0",
         "hyperf/context": "~3.2.0",
         "hyperf/contract": "~3.2.0",
         "hyperf/coroutine": "~3.2.0",

--- a/src/async-queue/src/Functions.php
+++ b/src/async-queue/src/Functions.php
@@ -12,19 +12,10 @@ declare(strict_types=1);
 
 namespace Hyperf\AsyncQueue;
 
-use Hyperf\AsyncQueue\Driver\DriverFactory;
-use Hyperf\Context\ApplicationContext;
-
-function dispatch(JobInterface $job, ?int $delay = null, ?int $maxAttempts = null, ?string $queue = null): bool
+/**
+ * Do not assign a value to the return value of this function unless you are very clear about the consequences of doing so.
+ */
+function dispatch(JobInterface $job): PendingDispatch
 {
-    if (is_int($maxAttempts)) {
-        $job->setMaxAttempts($maxAttempts);
-    }
-
-    $queue ??= $job->getQueueName();
-
-    return ApplicationContext::getContainer()
-        ->get(DriverFactory::class)
-        ->get($queue)
-        ->push($job, $delay ?? 0);
+    return new PendingDispatch($job);
 }

--- a/src/async-queue/src/PendingDispatch.php
+++ b/src/async-queue/src/PendingDispatch.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\AsyncQueue;
+
+use Hyperf\AsyncQueue\Driver\DriverFactory;
+use Hyperf\Conditionable\Conditionable;
+use Hyperf\Context\ApplicationContext;
+
+class PendingDispatch
+{
+    use Conditionable;
+
+    protected int $delay = 0;
+
+    protected string $pool = 'default';
+
+    public function __construct(protected JobInterface $job)
+    {
+    }
+
+    public function __destruct()
+    {
+        ApplicationContext::getContainer()
+            ->get(DriverFactory::class)
+            ->get($this->pool)
+            ->push($this->job, $this->delay);
+    }
+
+    public function setMaxAttempts(int $maxAttempts): static
+    {
+        $this->job->setMaxAttempts($maxAttempts);
+        return $this;
+    }
+
+    public function onPool(string $pool): static
+    {
+        $this->pool = $pool;
+        return $this;
+    }
+
+    public function delay(int $delay): static
+    {
+        $this->delay = $delay;
+        return $this;
+    }
+}

--- a/src/async-queue/tests/PendingDispatchTest.php
+++ b/src/async-queue/tests/PendingDispatchTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\AsyncQueue;
+
+use Hyperf\AsyncQueue\Driver\DriverFactory;
+use Hyperf\AsyncQueue\Driver\DriverInterface;
+use Hyperf\AsyncQueue\PendingDispatch;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Di\Container;
+use HyperfTest\AsyncQueue\Stub\DemoJob;
+use Mockery;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class PendingDispatchTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testConstructor()
+    {
+        $job = new DemoJob(1);
+        $this->setupContainer($job, 0, 'default');
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $this->assertInstanceOf(PendingDispatch::class, $pendingDispatch);
+    }
+
+    public function testSetMaxAttempts()
+    {
+        $job = new DemoJob(1);
+        $this->setupContainer($job, 0, 'default');
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch->setMaxAttempts(5);
+
+        $this->assertSame($pendingDispatch, $result);
+        $this->assertSame(5, $job->getMaxAttempts());
+    }
+
+    public function testOnPool()
+    {
+        $job = new DemoJob(1);
+        $this->setupContainer($job, 0, 'custom_pool');
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch->onPool('custom_pool');
+
+        $this->assertSame($pendingDispatch, $result);
+    }
+
+    public function testDelay()
+    {
+        $job = new DemoJob(1);
+        $this->setupContainer($job, 100, 'default');
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch->delay(100);
+
+        $this->assertSame($pendingDispatch, $result);
+    }
+
+    public function testMethodChaining()
+    {
+        $job = new DemoJob(1);
+        $this->setupContainer($job, 60, 'test_pool');
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch
+            ->setMaxAttempts(3)
+            ->onPool('test_pool')
+            ->delay(60);
+
+        $this->assertSame($pendingDispatch, $result);
+        $this->assertSame(3, $job->getMaxAttempts());
+    }
+
+    public function testDestructorPushesJobToDefaultQueue()
+    {
+        $job = new DemoJob(123);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 0)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('default')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+        unset($pendingDispatch); // Trigger destructor
+
+        // Mock expectations will be verified in tearDown by Mockery::close()
+        $this->assertTrue(true);
+    }
+
+    public function testDestructorPushesJobToCustomPool()
+    {
+        $job = new DemoJob(456);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 0)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('custom_pool')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+        $pendingDispatch->onPool('custom_pool');
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testDestructorPushesJobWithDelay()
+    {
+        $job = new DemoJob(789);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 120)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('default')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+        $pendingDispatch->delay(120);
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testDestructorWithAllOptions()
+    {
+        $job = new DemoJob(999);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 300)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('priority_pool')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+        $pendingDispatch
+            ->setMaxAttempts(10)
+            ->onPool('priority_pool')
+            ->delay(300);
+
+        $this->assertSame(10, $job->getMaxAttempts());
+
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testConditionableWhen()
+    {
+        $job = new DemoJob(111);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 50) // The callback sets delay to 50
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('default')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch->when(true, function ($pending) {
+            return $pending->delay(50);
+        });
+
+        $this->assertSame($pendingDispatch, $result);
+
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testConditionableWhenFalse()
+    {
+        $job = new DemoJob(222);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 0) // Should be 0 since when condition is false
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('default')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+        $pendingDispatch->when(false, function ($pending) {
+            return $pending->delay(50);
+        });
+
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testConditionableUnless()
+    {
+        $job = new DemoJob(333);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 75) // The callback sets delay to 75
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('default')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $pendingDispatch = new PendingDispatch($job);
+
+        $result = $pendingDispatch->unless(false, function ($pending) {
+            return $pending->delay(75);
+        });
+
+        $this->assertSame($pendingDispatch, $result);
+
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    public function testConditionableChaining()
+    {
+        $job = new DemoJob(444);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, 100)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with('conditional_pool')
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+
+        $isHighPriority = true;
+        $hasDelay = true;
+
+        $pendingDispatch = new PendingDispatch($job);
+        $pendingDispatch
+            ->setMaxAttempts(5)
+            ->when($isHighPriority, function ($pending) {
+                return $pending->onPool('conditional_pool');
+            })
+            ->unless(! $hasDelay, function ($pending) {
+                return $pending->delay(100);
+            });
+
+        $this->assertSame(5, $job->getMaxAttempts());
+
+        unset($pendingDispatch); // Trigger destructor
+
+        $this->assertTrue(true);
+    }
+
+    protected function setupContainer(DemoJob $job, int $delay, string $pool): void
+    {
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('push')
+            ->once()
+            ->with($job, $delay)
+            ->andReturn(true);
+
+        $driverFactory = Mockery::mock(DriverFactory::class);
+        $driverFactory->shouldReceive('get')
+            ->once()
+            ->with($pool)
+            ->andReturn($driver);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('get')
+            ->once()
+            ->with(DriverFactory::class)
+            ->andReturn($driverFactory);
+
+        ApplicationContext::setContainer($container);
+    }
+}


### PR DESCRIPTION
This commit introduces a new PendingDispatch class that provides a fluent interface for dispatching async queue jobs with enhanced flexibility and composability.

Key changes:
- Added PendingDispatch class with fluent methods: setMaxAttempts(), onPool(), delay()
- Integrated Conditionable trait for conditional method chaining (when/unless)
- Refactored dispatch() function to return PendingDispatch instead of bool
- Added hyperf/conditionable dependency to composer.json
- Job dispatch now happens automatically in PendingDispatch destructor
- Comprehensive test suite with 100% coverage of all features

Breaking change: dispatch() now returns PendingDispatch instead of bool. Users should not assign the return value unless they understand the implications (as noted in the function documentation).

Migration examples:
- Old: dispatch($job, 60, 3, 'custom');
- New: dispatch($job)->delay(60)->setMaxAttempts(3)->onPool('custom');