### PR TITLE
更正 ResponseInterface 的类型定义

### DIFF
--- a/src/http-server/src/Contract/ResponseInterface.php
+++ b/src/http-server/src/Contract/ResponseInterface.php
@@ -19,7 +19,7 @@ use Hyperf\HttpMessage\Cookie\Cookie;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Stringable;
 
-interface ResponseInterface
+interface ResponseInterface extends PsrResponseInterface
 {
     /**
      * Format data to JSON and return data with Content-Type:application/json header.


### PR DESCRIPTION
Hyperf\HttpServer\Response 继承了 \Psr\Http\Message\ResponseInterface：

<img width="2266" height="816" alt="image" src="https://github.com/user-attachments/assets/23ab93fa-55c5-4f3a-97dc-cb01f744642f" />

但是用于注入 Hyperf\HttpServer\Response 的 Hyperf\HttpServer\Contract\ResponseInterface 没有继承 \Psr\Http\Message\ResponseInterface：

<img width="1632" height="734" alt="image" src="https://github.com/user-attachments/assets/08a6dfa7-2c0e-42a6-95be-fcd7cd6cae9e" />

导致一些静态类型推断错误（代码实际可以运行）：

<img width="1962" height="614" alt="image" src="https://github.com/user-attachments/assets/51a0026b-0c9a-4418-82fd-92b85866d2d4" />

根据[文档](https://www.hyperf.wiki/3.1/#/zh-cn/response:~:text=%E5%9C%A8%20Hyperf%20%E9%87%8C%E5%8F%AF%E9%80%9A%E8%BF%87%20Hyperf%5CHttpServer%5CContract%5CResponseInterface%20%E6%8E%A5%E5%8F%A3%E7%B1%BB%E6%9D%A5%E6%B3%A8%E5%85%A5%20Response%20%E4%BB%A3%E7%90%86%E5%AF%B9%E8%B1%A1%E5%AF%B9%E5%93%8D%E5%BA%94%E8%BF%9B%E8%A1%8C%E5%A4%84%E7%90%86%EF%BC%8C%E9%BB%98%E8%AE%A4%E8%BF%94%E5%9B%9E%20Hyperf%5CHttpServer%5CResponse%20%E5%AF%B9%E8%B1%A1%EF%BC%8C%E8%AF%A5%E5%AF%B9%E8%B1%A1%E5%8F%AF%E7%9B%B4%E6%8E%A5%E8%B0%83%E7%94%A8%E6%89%80%E6%9C%89%20Psr%5CHttp%5CMessage%5CResponseInterface%20%E7%9A%84%E6%96%B9%E6%B3%95%E3%80%82)，现给 Hyperf\HttpServer\Contract\ResponseInterface 加上继承语句，使注入前后类型保持一致