### PR TITLE
fix(database): correct return type for Blueprint::foreign()

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -5,6 +5,10 @@
 - [#7668](https://github.com/hyperf/hyperf/pull/7668) Added the `$isCookiePersistent` parameter to `Hyperf\Guzzle\PoolHandler` to enable persistent cookies.
 - [#7667](https://github.com/hyperf/hyperf/pull/7667) [#7672](https://github.com/hyperf/hyperf/pull/7672) Added support for `client_count` option to create multiple gRPC clients with load balancing in `hyperf/grpc-client`.
 
+## Fixed
+
+- [#7682](https://github.com/hyperf/hyperf/pull/7682) Fixed incorrect return type for `Blueprint::foreign()` which caused static analysis errors when chaining `references()`, `on()`, etc.
+
 # v3.1.65 - 2025-12-04
 
 ## Added

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -481,7 +481,7 @@ class Blueprint
      *
      * @param array|string $columns
      * @param string $name
-     * @return Fluent|ForeignKeyDefinition
+     * @return ForeignKeyDefinition
      */
     public function foreign($columns, $name = null)
     {


### PR DESCRIPTION
The `foreign()` method always returns `ForeignKeyDefinition`, not `Fluent|ForeignKeyDefinition` as the docblock claimed. This caused phpstan errors in downstream code:

  `Call to an undefined method Hyperf\Support\Fluent::references()`

The method creates a `ForeignKeyDefinition` and returns it directly, so the union type was wrong. `ForeignKeyDefinition` extends `Fluent` and has the references(), on(), onDelete() etc. methods via @method annotations.