### PR TITLE
fix: 修复使用Nacos GRPC客户端做服务注册发现且没使用配置中心时，仍然发送配置监听请求的问题

### DIFF
--- a/src/nacos/src/GrpcClient.php
+++ b/src/nacos/src/GrpcClient.php
@@ -150,6 +150,10 @@ class GrpcClient
 
     public function listen(): void
     {
+        if (empty($this->configListenContexts)) {
+            return;
+        }
+
         $request = new ConfigBatchListenRequest(true, array_values($this->configListenContexts));
         $response = $this->request($request);
         if ($response instanceof ConfigChangeBatchListenResponse) {


### PR DESCRIPTION
运行环境：hyperf/hyperf:8.3-alpine-v3.20-swoole-v5.1
Hyperf版本：3.1

复现场景：有使用基于nacos的服务注册发现，但未使用配置中心。按默认配置下启动服务10秒后会出现以下报错
[ERROR] Hyperf\Http2Client\Exception\TimeoutException: Recv timeout. in /data/project/vendor/hyperf/http2-client/src/Client.php:114
Stack trace:
#0 /data/project/vendor/hyperf/http2-client/src/Client.php(133): Hyperf\Http2Client\Client->recv()
#1 /data/project/vendor/hyperf/nacos/src/GrpcClient.php(110): Hyperf\Http2Client\Client->request()
#2 /data/project/vendor/hyperf/nacos/src/GrpcClient.php(158): Hyperf\Nacos\GrpcClient->request()
#3 /data/project/vendor/hyperf/nacos/src/GrpcClient.php(233): Hyperf\Nacos\GrpcClient->listen()
#4 /data/project/vendor/hyperf/coroutine/src/Coroutine.php(80): Hyperf\Nacos\GrpcClient->Hyperf\Nacos\{closure}()
#5 [internal function]: Hyperf\Coroutine\Coroutine::Hyperf\Coroutine\{closure}()
#6 {main}
[WARNING] Hyperf\Http2Client\Exception\TimeoutException: Recv timeout. in /data/project/vendor/hyperf/http2-client/src/Client.php:114
Stack trace:
#0 /data/project/vendor/hyperf/http2-client/src/Client.php(133): Hyperf\Http2Client\Client->recv()
#1 /data/project/vendor/hyperf/nacos/src/GrpcClient.php(110): Hyperf\Http2Client\Client->request()
#2 /data/project/vendor/hyperf/nacos/src/GrpcClient.php(194): Hyperf\Nacos\GrpcClient->request()
#3 /data/project/vendor/hyperf/coroutine/src/Coroutine.php(80): Hyperf\Nacos\GrpcClient->Hyperf\Nacos\{closure}()
#4 [internal function]: Hyperf\Coroutine\Coroutine::Hyperf\Coroutine\{closure}()
#5 {main}

原因：vendor/hyperf/nacos/src/GrpcClient.php的listen方法中，即使没使用配置中心，也会无差别的发送空的配置监听请求