### PR TITLE
fix: remove parentheses from ENV in Dockerfile

### DIFF
--- a/.travis/http_server/Dockerfile
+++ b/.travis/http_server/Dockerfile
@@ -16,7 +16,7 @@ ARG timezone
 
 ENV TIMEZONE=${timezone:-"Asia/Shanghai"} \
     APP_ENV=prod \
-    SCAN_CACHEABLE=(true)
+    SCAN_CACHEABLE=true
 
 # update
 RUN set -ex \


### PR DESCRIPTION
remove parentheses from ENV in Dockerfile to prevent string literal parsing
`
➜  hyperf-test docker build -t hyperftest:v1.0.1 . 
`
`➜  hyperf-test docker run --rm --entrypoint php hyperftest:v1.0.1 -r "var_dump(getenv('SCAN_CACHEABLE'));"`
`string(6) "(true)"`