### PR TITLE
Fixed bug that PostgresProcessor cannot process indexes and foreign keys when columns is null.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- [#7737](https://github.com/hyperf/hyperf/pull/7737) Fixed bug that `Hyperf\Database\PgSQL\Query\Processors\PostgresProcessor::processIndexes/processForeignKeys` cannot not work when columns is null.
+- [#7737](https://github.com/hyperf/hyperf/pull/7737) Fixed bug that PostgresProcessor cannot process indexes and foreign keys when columns is null.
 
 # v3.1.67 - 2026-02-24
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#7734](https://github.com/hyperf/hyperf/pull/7734) Fixed bug that memory leak when using `Redis::pipeline()` for long-lived environment.
+- [#7737](https://github.com/hyperf/hyperf/pull/7737) Fixed bug that PostgresProcessor cannot process indexes and foreign keys when columns is null.
 - [#7745](https://github.com/hyperf/hyperf/pull/7745) Fixed bug that `getUri()->getHost()` returns server IP instead of domain when using Swoole 6.2.0, due to `server_addr` having higher priority than `header['host']` in `getUriFromGlobals()`.
 
 # v3.1.68 - 2026-04-21
@@ -16,10 +17,6 @@
 ## Optimized
 
 - [#7741](https://github.com/hyperf/hyperf/pull/7741) Optimized the `Hyperf\Amqp\Message\Message::getTypeString()` method to prevent conflicts between property and getter methods.
-
-## Fixed
-
-- [#7737](https://github.com/hyperf/hyperf/pull/7737) Fixed bug that PostgresProcessor cannot process indexes and foreign keys when columns is null.
 
 # v3.1.67 - 2026-02-24
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.68 - TBD
 
+## Fixed
+
+- [#7737](https://github.com/hyperf/hyperf/pull/7737) Fixed bug that `Hyperf\Database\PgSQL\Query\Processors\PostgresProcessor::processIndexes/processForeignKeys` cannot not work when columns is null.
+
 # v3.1.67 - 2026-02-24
 
 ## Added

--- a/src/database-pgsql/src/Query/Processors/PostgresProcessor.php
+++ b/src/database-pgsql/src/Query/Processors/PostgresProcessor.php
@@ -72,7 +72,7 @@ class PostgresProcessor extends Processor
 
             return [
                 'name' => strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => explode(',', $result->columns ?: ''),
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,
@@ -90,10 +90,10 @@ class PostgresProcessor extends Processor
 
             return [
                 'name' => $result->name,
-                'columns' => explode(',', $result->columns),
+                'columns' => explode(',', $result->columns ?: ''),
                 'foreign_schema' => $result->foreign_schema,
                 'foreign_table' => $result->foreign_table,
-                'foreign_columns' => explode(',', $result->foreign_columns),
+                'foreign_columns' => explode(',', $result->foreign_columns ?: ''),
                 'on_update' => match (strtolower($result->on_update)) {
                     'a' => 'no action',
                     'r' => 'restrict',


### PR DESCRIPTION
Compatible with cases where the columns field is null.