### PR TITLE
Fix host priority in getUriFromGlobals() for Swoole 6.2.0 compatibility

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - [#7734](https://github.com/hyperf/hyperf/pull/7734) Fixed bug that memory leak when using `Redis::pipeline()` for long-lived environment.
+- [#7745](https://github.com/hyperf/hyperf/pull/7745) Fixed bug that `getUri()->getHost()` returns server IP instead of domain when using Swoole 6.2.0, due to `server_addr` having higher priority than `header['host']` in `getUriFromGlobals()`.
 
 # v3.1.68 - 2026-04-21
 

--- a/src/http-message/src/Server/Request.php
+++ b/src/http-message/src/Server/Request.php
@@ -592,10 +592,6 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
                 $hasPort = true;
                 $uri = $uri->withPort($port);
             }
-        } elseif (isset($server['server_name'])) {
-            $uri = $uri->withHost($server['server_name']);
-        } elseif (isset($server['server_addr'])) {
-            $uri = $uri->withHost($server['server_addr']);
         } elseif (isset($header['host'])) {
             $hasPort = true;
             [$host, $port] = self::parseHost($header['host']);
@@ -604,6 +600,10 @@ class Request extends \Hyperf\HttpMessage\Base\Request implements ServerRequestI
             }
 
             $uri = $uri->withHost($host);
+        } elseif (isset($server['server_name'])) {
+            $uri = $uri->withHost($server['server_name']);
+        } elseif (isset($server['server_addr'])) {
+            $uri = $uri->withHost($server['server_addr']);
         }
 
         if (! $hasPort && isset($server['server_port'])) {

--- a/src/http-message/tests/ServerRequestTest.php
+++ b/src/http-message/tests/ServerRequestTest.php
@@ -165,8 +165,8 @@ class ServerRequestTest extends TestCase
 
     public function testGetUriFromGlobalsHeaderHostPriorityOverServerAddr()
     {
-        // 模拟 Swoole 6.2.0 在 $request->server 中设置 server_addr 的场景
-        // header['host'] 应优先于 server_addr
+        // Simulate the Swoole 6.2.0 scenario where server_addr is set in $request->server.
+        // header['host'] should take precedence over server_addr.
         $swooleRequest = Mockery::mock(SwooleRequest::class);
         $swooleRequest->shouldReceive('rawContent')->andReturn('');
         $swooleRequest->header = ['host' => 'hyperf.example.com'];
@@ -183,7 +183,7 @@ class ServerRequestTest extends TestCase
 
     public function testGetUriFromGlobalsServerAddrFallbackWhenNoHostHeader()
     {
-        // 当没有 Host 请求头时，server_addr 仍可作为兜底
+        // When no Host header is present, server_addr should still be used as fallback.
         $swooleRequest = Mockery::mock(SwooleRequest::class);
         $swooleRequest->shouldReceive('rawContent')->andReturn('');
         $swooleRequest->header = [];

--- a/src/http-message/tests/ServerRequestTest.php
+++ b/src/http-message/tests/ServerRequestTest.php
@@ -163,6 +163,39 @@ class ServerRequestTest extends TestCase
         $this->assertSame(null, $uri->getPort());
     }
 
+    public function testGetUriFromGlobalsHeaderHostPriorityOverServerAddr()
+    {
+        // 模拟 Swoole 6.2.0 在 $request->server 中设置 server_addr 的场景
+        // header['host'] 应优先于 server_addr
+        $swooleRequest = Mockery::mock(SwooleRequest::class);
+        $swooleRequest->shouldReceive('rawContent')->andReturn('');
+        $swooleRequest->header = ['host' => 'hyperf.example.com'];
+        $swooleRequest->server = [
+            'server_port' => 9501,
+            'server_addr' => '127.0.0.1',
+            'remote_addr' => '10.0.0.1',
+        ];
+        $request = Request::loadFromSwooleRequest($swooleRequest);
+        $uri = $request->getUri();
+        $this->assertSame('hyperf.example.com', $uri->getHost());
+        $this->assertSame(null, $uri->getPort());
+    }
+
+    public function testGetUriFromGlobalsServerAddrFallbackWhenNoHostHeader()
+    {
+        // 当没有 Host 请求头时，server_addr 仍可作为兜底
+        $swooleRequest = Mockery::mock(SwooleRequest::class);
+        $swooleRequest->shouldReceive('rawContent')->andReturn('');
+        $swooleRequest->header = [];
+        $swooleRequest->server = [
+            'server_port' => 9501,
+            'server_addr' => '192.168.1.100',
+        ];
+        $request = Request::loadFromSwooleRequest($swooleRequest);
+        $uri = $request->getUri();
+        $this->assertSame('192.168.1.100', $uri->getHost());
+    }
+
     #[Group('ParseHost')]
     public function testParseHost()
     {


### PR DESCRIPTION
Fix #7744 #7735

## 问题

Swoole 6.2.0 在 `$swooleRequest->server` 中新增了 `server_addr` 字段（服务器本地 IP）。当前代码中 `server_addr` 的优先级高于 `header['host']`，导致 `getUri()->getHost()` 返回服务器本地 IP（如 `127.0.0.1`）而非 HTTP Host 请求头中的域名（如 `hyperf.example.com`）。

修复前优先级：`http_host` → `server_name` → `server_addr` → `header['host']`

这与 PHP-FPM / nginx 的行为不一致——`$_SERVER['HTTP_HOST']` 始终优先于 `SERVER_ADDR`。

> Related: [Swoole v6.2.0 Release Note](https://github.com/swoole/swoole-src/releases/tag/v6.2.0) — "在 Swoole 的 HTTP 服务器回调函数中，Swoole\Http\Request 对象的 server 属性新增了 server_addr 字段，该字段用于标识服务端的 IP 地址"

## 修复

调整优先级为：`http_host` → `header['host']` → `server_name` → `server_addr`

## 变更

- `src/http-message/src/Server/Request.php`：调整 `getUriFromGlobals()` 中 `elseif` 链的顺序
- `src/http-message/tests/ServerRequestTest.php`：新增 2 个测试用例
  - `testGetUriFromGlobalsHeaderHostPriorityOverServerAddr`：验证 `server_addr` 存在时 `header['host']` 仍优先（Swoole 6.2.0 场景）
  - `testGetUriFromGlobalsServerAddrFallbackWhenNoHostHeader`：验证无 Host 请求头时 `server_addr` 仍可作为兜底