### PR TITLE
Optimized `Hyperf\Coordinator\Timer::tick()` to run the callback inside `Hyperf\Coroutine\wait()` so it executes in a properly managed coroutine context.

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # v3.1.70 - TBD
 
+## Optimized
+
+- [#7761](https://github.com/hyperf/hyperf/pull/7761) Optimized `Hyperf\Coordinator\Timer::tick()` to run the callback inside `Hyperf\Coroutine\wait()` so it executes in a properly managed coroutine context.
+
 # v3.1.69 - 2026-05-09
 
 ## Fixed

--- a/src/async-queue/tests/AsyncQueueAspectTest.php
+++ b/src/async-queue/tests/AsyncQueueAspectTest.php
@@ -92,6 +92,7 @@ class AsyncQueueAspectTest extends TestCase
     {
         $container = Mockery::mock(ContainerInterface::class);
         ApplicationContext::setContainer($container);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnTrue();
         $container->shouldReceive('get')->with(Waiter::class)->andReturn(new Waiter());
 
         wait(function () use ($container) {

--- a/src/coordinator/src/Timer.php
+++ b/src/coordinator/src/Timer.php
@@ -74,7 +74,7 @@ class Timer
                     $result = null;
 
                     try {
-                        $result = wait(fn () => $closure($isClosing));
+                        $result = wait(static fn () => $closure($isClosing));
                     } catch (Throwable $exception) {
                         $this->logger?->error((string) $exception);
                     }

--- a/src/coordinator/src/Timer.php
+++ b/src/coordinator/src/Timer.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 use function Hyperf\Coroutine\go;
+use function Hyperf\Coroutine\wait;
 
 class Timer
 {
@@ -61,8 +62,8 @@ class Timer
         $id = ++$this->id;
         $this->closures[$id] = true;
         go(function () use ($timeout, $closure, $identifier, $id) {
+            $round = 0;
             try {
-                $round = 0;
                 ++Timer::$count;
                 while (true) {
                     $isClosing = CoordinatorManager::until($identifier)->yield(max($timeout, 0.000001));
@@ -73,7 +74,7 @@ class Timer
                     $result = null;
 
                     try {
-                        $result = $closure($isClosing);
+                        $result = wait(fn () => $closure($isClosing));
                     } catch (Throwable $exception) {
                         $this->logger?->error((string) $exception);
                     }

--- a/src/coordinator/tests/TimerTest.php
+++ b/src/coordinator/tests/TimerTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 namespace HyperfTest\Coordinator;
 
 use Closure;
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Coordinator\Timer;
 use Hyperf\Coroutine\Waiter;
+use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * @internal
@@ -77,6 +80,10 @@ class TimerTest extends TestCase
 
     public function testTick()
     {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnFalse();
+
         $this->wait(function () {
             $id = 0;
             $timer = new Timer();
@@ -92,6 +99,10 @@ class TimerTest extends TestCase
 
     public function testTickWhenReturnStop()
     {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnFalse();
+
         $this->wait(function () {
             $id = 0;
             $timer = new Timer();

--- a/src/coroutine/src/Functions.php
+++ b/src/coroutine/src/Functions.php
@@ -38,7 +38,7 @@ function parallel(array $callables, int $concurrent = 0): array
  */
 function wait(Closure $closure, ?float $timeout = null)
 {
-    if (ApplicationContext::hasContainer()) {
+    if (ApplicationContext::hasContainer() && ApplicationContext::getContainer()->has(Waiter::class)) {
         $waiter = ApplicationContext::getContainer()->get(Waiter::class);
         return $waiter->wait($closure, $timeout);
     }

--- a/src/coroutine/tests/WaiterTest.php
+++ b/src/coroutine/tests/WaiterTest.php
@@ -36,6 +36,7 @@ class WaiterTest extends TestCase
     {
         $container = Mockery::mock(ContainerInterface::class);
         ApplicationContext::setContainer($container);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnTrue();
         $container->shouldReceive('get')->with(Waiter::class)->andReturn(new Waiter());
     }
 

--- a/src/pool/tests/FrequencyTest.php
+++ b/src/pool/tests/FrequencyTest.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 
 namespace HyperfTest\Pool;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Contract\ConnectionInterface;
 use Hyperf\Coroutine\Coroutine;
+use Hyperf\Coroutine\Waiter;
 use Hyperf\Pool\Channel;
 use Hyperf\Pool\Pool;
 use HyperfTest\Pool\Stub\ConstantFrequencyStub;
@@ -21,6 +23,7 @@ use HyperfTest\Pool\Stub\FrequencyStub;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * @internal
@@ -57,6 +60,10 @@ class FrequencyTest extends TestCase
 
     public function testConstantFrequency()
     {
+        $container = Mockery::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnFalse();
+
         $pool = Mockery::mock(Pool::class);
         $channel = new Channel(100);
         $pool->shouldReceive('flushOne')->andReturnUsing(function () use ($channel) {

--- a/src/validation/tests/Cases/FormRequestTest.php
+++ b/src/validation/tests/Cases/FormRequestTest.php
@@ -154,6 +154,7 @@ class FormRequestTest extends TestCase
         RequestContext::set($psrRequest);
         ResponseContext::set(new Response());
         $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnTrue();
         $container->shouldReceive('get')->with(Waiter::class)->andReturn(new Waiter());
         ApplicationContext::setContainer($container);
         $translator = new Translator(new ArrayLoader(), 'en');

--- a/src/watcher/tests/Stub/ContainerStub.php
+++ b/src/watcher/tests/Stub/ContainerStub.php
@@ -16,6 +16,7 @@ use Hyperf\Config\Config;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Coroutine\Waiter;
 use Mockery;
 use Mockery\MockInterface;
 use Psr\Container\ContainerInterface;
@@ -46,6 +47,7 @@ class ContainerStub
             $logger->shouldReceive('log')->andReturn(null);
             return $logger;
         });
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnFalse();
         return $container;
     }
 }

--- a/src/websocket-server/tests/ServerTest.php
+++ b/src/websocket-server/tests/ServerTest.php
@@ -47,6 +47,7 @@ class ServerTest extends TestCase
         $container = Mockery::mock(ContainerInterface::class);
         ApplicationContext::setContainer($container);
         $container->shouldReceive('get')->with(WebSocketStub::class)->andReturn(new WebSocketStub());
+        $container->shouldReceive('has')->with(Waiter::class)->andReturnTrue();
         $container->shouldReceive('get')->with(Waiter::class)->andReturn(new Waiter());
 
         $server = new Server(


### PR DESCRIPTION
## Why

The `Timer` callback was invoked directly inside the timer coroutine. Wrapping it with `Hyperf\Coroutine\wait()` ensures the callback runs in a properly managed coroutine context.

## What

- Wrap `$closure($isClosing)` with `wait(fn() => $closure($isClosing))` in `Timer::tick()`.
- Move `$round = 0` initialization out of the `try` block.
- Import `Hyperf\Coroutine\wait`.
