### PR TITLE
fix(nats): store decoded payload separately from body

### DIFF
--- a/src/nats/src/EncodedConnection.php
+++ b/src/nats/src/EncodedConnection.php
@@ -53,7 +53,14 @@ class EncodedConnection extends Connection
     public function subscribe(string $subject, Closure $callback): string
     {
         $c = function ($message) use ($callback) {
-            $message->setBody($this->encoder->decode($message->getBody()));
+            $payload = $this->encoder->decode($message->getBody());
+
+            $message->setPayload($payload);
+
+            if (is_string($payload)) {
+                $message->setBody($payload);
+            }
+
             $callback($message);
         };
         return parent::subscribe($subject, $c);
@@ -69,7 +76,14 @@ class EncodedConnection extends Connection
     public function queueSubscribe(string $subject, string $queue, Closure $callback): string
     {
         $c = function ($message) use ($callback) {
-            $message->setBody($this->encoder->decode($message->getBody()));
+            $payload = $this->encoder->decode($message->getBody());
+
+            $message->setPayload($payload);
+
+            if (is_string($payload)) {
+                $message->setBody($payload);
+            }
+
             $callback($message);
         };
         return parent::queueSubscribe($subject, $queue, $c);

--- a/src/nats/src/Message.php
+++ b/src/nats/src/Message.php
@@ -40,6 +40,16 @@ class Message implements Stringable
     private Connection $conn;
 
     /**
+     * Decoded message payload.
+     */
+    private mixed $payload = null;
+
+    /**
+     * Whether the message payload has been decoded.
+     */
+    private bool $payloadDecoded = false;
+
+    /**
      * Message constructor.
      *
      * @param string $subject message subject
@@ -159,5 +169,34 @@ class Message implements Stringable
             $this->subject,
             $body
         );
+    }
+
+    /**
+     * Set decoded message payload.
+     */
+    public function setPayload(mixed $payload): static
+    {
+        $this->payload = $payload;
+        $this->payloadDecoded = true;
+
+        return $this;
+    }
+
+    /**
+     * Get decoded message payload.
+     *
+     * Returns the raw body when the payload has not been decoded.
+     */
+    public function getPayload(): mixed
+    {
+        return $this->payloadDecoded ? $this->payload : $this->body;
+    }
+
+    /**
+     * Determine whether the message payload has been decoded.
+     */
+    public function hasPayload(): bool
+    {
+        return $this->payloadDecoded;
     }
 }

--- a/src/nats/tests/NatsMessageTest.php
+++ b/src/nats/tests/NatsMessageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Nats;
+
+use Hyperf\Nats\Connection;
+use Hyperf\Nats\Message;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(Message::class)]
+class NatsMessageTest extends TestCase
+{
+    public function testDecodedArrayPayloadDoesNotOverrideStringBody(): void
+    {
+        $connection = new Connection();
+
+        $message = new Message('hyperf', '{"id":"Hyperf"}', '1', $connection);
+
+        $payload = ['id' => 'Hyperf'];
+
+        $message->setPayload($payload);
+
+        self::assertSame('{"id":"Hyperf"}', $message->getBody());
+        self::assertSame(['id' => 'Hyperf'], $message->getPayload());
+        self::assertTrue($message->hasPayload());
+    }
+
+    public function testDecodedStringPayloadCanRemainBackwardCompatible(): void
+    {
+        $connection = new Connection();
+
+        $message = new Message('hyperf', '"Hyperf"', '1', $connection);
+
+        $payload = 'Hyperf';
+
+        $message->setPayload($payload);
+
+        if (is_string($payload)) {
+            $message->setBody($payload);
+        }
+
+        self::assertSame('Hyperf', $message->getBody());
+        self::assertSame('Hyperf', $message->getPayload());
+    }
+
+    public function testNullPayloadIsAValidDecodedPayload(): void
+    {
+        $connection = new Connection();
+
+        $message = new Message('hyperf', 'null', '1', $connection);
+
+        $message->setPayload(null);
+
+        self::assertTrue($message->hasPayload());
+        self::assertNull($message->getPayload());
+        self::assertSame('null', $message->getBody());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a type incompatibility in `Hyperf\Nats\EncodedConnection` when an encoder decodes a message body into a non-string value.

Currently, `EncodedConnection::subscribe()` and `queueSubscribe()` pass the decoded value directly into `Message::setBody()`. This works only when the decoded payload is a string. For JSON objects, arrays, YAML structures, serialized arrays, or other non-string decoded values, this causes a `TypeError`, because `Message::setBody()` expects a string.

This PR keeps the existing `Message::getBody(): string` and `Message::setBody(string $body)` API unchanged for backward compatibility, and introduces a separate decoded payload API:

```php
$message->getBody();    // raw/backward-compatible string body
$message->getPayload(); // decoded payload
$message->hasPayload(); // whether decoded payload was set
```

For backward compatibility, when the decoded payload is a string, the message body is still updated with that string. When the decoded payload is not a string, the original body remains unchanged and the decoded value is available through getPayload().

This avoids changing the public body type to mixed, while fixing decoded array/object payloads.

Fixes #5222.