### PR TITLE
docs(readme): add OpenSSF Scorecard badge

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -10,6 +10,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/hyperf/hyperf/actions"><img src="https://github.com/hyperf/hyperf/workflows/PHPUnit%20for%20Hyperf/badge.svg" alt="PHPUnit for Hyperf"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/hyperf/hyperf"><img src="https://api.scorecard.dev/projects/github.com/hyperf/hyperf/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://packagist.org/packages/hyperf/framework"><img src="https://poser.pugx.org/hyperf/framework/downloads" alt="Total Downloads"></a>
   <a href="https://packagist.org/packages/hyperf/framework"><img src="https://poser.pugx.org/hyperf/framework/d/monthly" alt="Monthly Downloads"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ English | [中文](./README-CN.md)
 </p>
 <p align="center">
   <a href="https://github.com/hyperf/hyperf/actions"><img src="https://github.com/hyperf/hyperf/workflows/PHPUnit%20for%20Hyperf/badge.svg" alt="PHPUnit for Hyperf"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/hyperf/hyperf"><img src="https://api.scorecard.dev/projects/github.com/hyperf/hyperf/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://packagist.org/packages/hyperf/framework"><img src="https://poser.pugx.org/hyperf/framework/downloads" alt="Total Downloads"></a>
   <a href="https://packagist.org/packages/hyperf/framework"><img src="https://poser.pugx.org/hyperf/framework/d/monthly" alt="Monthly Downloads"></a>
 </p>


### PR DESCRIPTION
## Summary
- Add the OpenSSF Scorecard badge to the English and Chinese README files.

## Background
- The repository already includes a Scorecard supply-chain security workflow, and the README badge makes the result visible from the project landing page.

## Changes
- Added the Scorecard viewer badge to `README.md`.
- Added the same badge to `README-CN.md`.

## Test Plan
- Not run; README-only documentation change.

## Risks
- Low risk. The change only adds external badge links to documentation.
