### PR TITLE
Fixed incorrect @property type in generated models.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ "8.4", "8.3", "8.2" ]
-        sw-version: [ "master", '6.1', 'v6.1.7', "v6.0.2" ]
+        sw-version: [ "master", "v6.2.2", '6.1', 'v6.1.7', "v6.0.2" ]
       max-parallel: 20
       fail-fast: false
     env:

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # v3.2.3 - TBD
 
+## Fixed
+
+- [#7782](https://github.com/hyperf/hyperf/pull/7782) Fixed incorrect @property type in generated models, such as `@property int $id` -> `@property ?int $id`.
+
 # v3.2.2 - 2026-07-26
 
 ## Removed

--- a/src/database/src/Commands/Ast/ModelUpdateVisitor.php
+++ b/src/database/src/Commands/Ast/ModelUpdateVisitor.php
@@ -415,14 +415,14 @@ class ModelUpdateVisitor extends NodeVisitorAbstract
         }
 
         if (enum_exists($cast)) {
-            return '\\' . $cast;
+            return '?\\' . $cast;
         }
 
         return match ($cast) {
-            'integer' => 'int',
-            'date', 'datetime' => $this->uses['Carbon\Carbon'] ?? '\Carbon\Carbon',
-            'json' => 'array',
-            default => $cast,
+            'integer' => '?int',
+            'date', 'datetime' => '?' . ($this->uses['Carbon\Carbon'] ?? '\Carbon\Carbon'),
+            'json' => '?array',
+            default => '?' . $cast,
         };
     }
 

--- a/src/database/tests/GenModelTest.php
+++ b/src/database/tests/GenModelTest.php
@@ -81,13 +81,13 @@ declare (strict_types=1);
 namespace HyperfTest\Database\Stubs\Model;
 
 /**
- * @property int $id 
- * @property int $count 
- * @property string $float_num 
- * @property string $str 
- * @property string $json 
- * @property \Carbon\Carbon $created_at 
- * @property string $updated_at 
+ * @property ?int $id 
+ * @property ?int $count 
+ * @property ?string $float_num 
+ * @property ?string $str 
+ * @property ?string $json 
+ * @property ?\Carbon\Carbon $created_at 
+ * @property ?string $updated_at 
  */
 class UserExtEmpty extends Model
 {
@@ -138,11 +138,11 @@ namespace HyperfTest\\Database\\Stubs\\Model;
 
 use Carbon\\Carbon;
 /**
- * @property int \$id 
- * @property string \$name 
- * @property \\HyperfTest\\Database\\Stubs\\Model\\Gender \$gender 
- * @property Carbon \$created_at 
- * @property Carbon \$updated_at 
+ * @property ?int \$id 
+ * @property ?string \$name 
+ * @property ?\\HyperfTest\\Database\\Stubs\\Model\\Gender \$gender 
+ * @property ?Carbon \$created_at 
+ * @property ?Carbon \$updated_at 
  * @property-read null|Book \$book 
  */
 class UserEnum extends Model


### PR DESCRIPTION
The $id field may be null before persistence, so @property ?int $id is more accurate than @property int $id.