### PR TITLE
[3.2] Fixed bug that `MorphTo` relationships eager loading specific columns.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -8,6 +8,7 @@
 
 - [#7782](https://github.com/hyperf/hyperf/pull/7782) Fixed incorrect @property type in generated models, such as `@property int $id` -> `@property ?int $id`.
 - [#7784](https://github.com/hyperf/hyperf/pull/7784) [#7785](https://github.com/hyperf/hyperf/pull/7785) Fixed phpdoc for `Hyperf\ModelCache\Cacheable`.
+- [#7788](https://github.com/hyperf/hyperf/pull/7788) Fixed bug that `MorphTo` relationships eager loading specific columns.
 
 # v3.2.2 - 2026-07-26
 

--- a/src/database/src/Model/Relations/MorphTo.php
+++ b/src/database/src/Model/Relations/MorphTo.php
@@ -317,7 +317,7 @@ class MorphTo extends BelongsTo
     protected function replayMacros(Builder $query)
     {
         foreach ($this->macroBuffer as $macro) {
-            $query->{$macro['method']}(...$macro['parameters']);
+            $query->{$macro['name']}(...$macro['arguments']);
         }
 
         return $query;

--- a/src/database/tests/ModelMorphEagerLoadingTest.php
+++ b/src/database/tests/ModelMorphEagerLoadingTest.php
@@ -101,6 +101,25 @@ class ModelMorphEagerLoadingTest extends TestCase
         }
     }
 
+    public function testMorphEagerLoadWithColumns()
+    {
+        $this->getContainer();
+        $images = Image::query()->with(['imageable:id,name'])->where('imageable_type', 'user')->get();
+
+        $this->assertInstanceOf(User::class, $images[1]->imageable);
+        $this->assertSame(2, $images[1]->imageable->id);
+
+        $sqls = [
+            'select * from `images` where `imageable_type` = ?',
+            'select `id`, `name` from `user` where `user`.`id` in (1, 2)',
+        ];
+        while ($event = $this->channel->pop(0.001)) {
+            if ($event instanceof QueryExecuted) {
+                $this->assertSame($event->sql, array_shift($sqls));
+            }
+        }
+    }
+
     public function testMorphAssociationEmpty()
     {
         $this->getContainer();


### PR DESCRIPTION
本次提交修复在 #7637 中把`__call()`参数从($method, $parameters)改成($name, $arguments)导致replaceMacros的参数名称不存在的错误。