### PR TITLE
Support nacos v1 v2 and v3 for reading hosts from instance list.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,10 @@
 
 - [#7792](https://github.com/hyperf/hyperf/pull/7792) Added function `Hyperf\Support\assert_instanceof()`.
 
+## Optimized
+
+- [#7790](https://github.com/hyperf/hyperf/pull/7790) Support nacos v1 v2 and v3 for reading hosts from instance list.
+
 # v3.2.3 - 2026-07-29
 
 ## Added

--- a/src/service-governance-nacos/src/NacosDriver.php
+++ b/src/service-governance-nacos/src/NacosDriver.php
@@ -66,7 +66,12 @@ class NacosDriver implements DriverInterface
         }
 
         $data = Json::decode((string) $response->getBody());
-        $hosts = $data['hosts'] ?? [];
+        $hosts = match (true) {
+            is_array($data['hosts'] ?? null) => $data['hosts'],
+            is_array($data['data']['hosts'] ?? null) => $data['data']['hosts'],
+            is_array($data['data'] ?? null) && array_is_list($data['data']) => $data['data'],
+            default => [],
+        };
         $nodes = [];
         foreach ($hosts as $node) {
             if (isset($node['ip'], $node['port']) && ($node['healthy'] ?? false)) {

--- a/src/service-governance-nacos/tests/NacosDriverTest.php
+++ b/src/service-governance-nacos/tests/NacosDriverTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\ServiceGovernanceNacos;
+
+use ErrorException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Hyperf\Config\Config;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Nacos\Config as NacosConfig;
+use Hyperf\ServiceGovernanceNacos\Client;
+use Hyperf\ServiceGovernanceNacos\NacosDriver;
+use Mockery;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class NacosDriverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testGetsNodesFromNacosV3InstanceListPayload(): void
+    {
+        $driver = $this->createDriver('3.0', [
+            'code' => 0,
+            'message' => 'success',
+            'data' => [
+                [
+                    'ip' => '127.0.0.1',
+                    'port' => 9501,
+                    'weight' => 0.5,
+                    'healthy' => true,
+                    'enabled' => true,
+                ],
+                [
+                    'ip' => '127.0.0.2',
+                    'port' => 9502,
+                    'weight' => 1,
+                    'healthy' => false,
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            [
+                'host' => '127.0.0.1',
+                'port' => 9501,
+                'weight' => 50,
+            ],
+        ], $driver->getNodes('', 'demo-service', []));
+    }
+
+    public function testGetsNodesFromNacosV2InstanceListPayload(): void
+    {
+        $driver = $this->createDriver('2.0', [
+            'code' => 0,
+            'message' => 'success',
+            'data' => [
+                'name' => 'DEFAULT_GROUP@@demo-service',
+                'groupName' => 'DEFAULT_GROUP',
+                'hosts' => [
+                    [
+                        'ip' => '127.0.0.1',
+                        'port' => 9501,
+                        'weight' => 0.5,
+                        'healthy' => true,
+                        'enabled' => true,
+                    ],
+                    [
+                        'ip' => '127.0.0.2',
+                        'port' => 9502,
+                        'weight' => 1,
+                        'healthy' => false,
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            [
+                'host' => '127.0.0.1',
+                'port' => 9501,
+                'weight' => 50,
+            ],
+        ], $driver->getNodes('', 'demo-service', []));
+    }
+
+    public function testGetsNodesFromNacosV1InstanceListPayload(): void
+    {
+        $driver = $this->createDriver('1.0', [
+            'name' => 'DEFAULT_GROUP@@demo-service',
+            'groupName' => 'DEFAULT_GROUP',
+            'hosts' => [
+                [
+                    'ip' => '127.0.0.1',
+                    'port' => 9501,
+                    'weight' => 0.5,
+                    'healthy' => true,
+                    'enabled' => true,
+                ],
+                [
+                    'ip' => '127.0.0.2',
+                    'port' => 9502,
+                    'weight' => 1,
+                    'healthy' => false,
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            [
+                'host' => '127.0.0.1',
+                'port' => 9501,
+                'weight' => 50,
+            ],
+        ], $driver->getNodes('', 'demo-service', []));
+    }
+
+    public function testIgnoresNonArrayInstanceListData(): void
+    {
+        $driver = $this->createDriver('3.0', [
+            'code' => 21000,
+            'message' => 'service name error',
+            'data' => 'invalid instance list',
+        ]);
+
+        set_error_handler(static function (int $severity, string $message): never {
+            throw new ErrorException($message, 0, $severity);
+        });
+
+        try {
+            $this->assertSame([], $driver->getNodes('', 'demo-service', []));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private function createDriver(string $version, array $payload): NacosDriver
+    {
+        $client = new Client(new NacosConfig([
+            'base_uri' => 'http://127.0.0.1:8848',
+            'version' => $version,
+            'guzzle_config' => [
+                'handler' => new MockHandler([
+                    new Response(200, [], json_encode($payload, JSON_THROW_ON_ERROR)),
+                ]),
+            ],
+        ]));
+        $config = new Config([
+            'services' => [
+                'drivers' => [
+                    'nacos' => [
+                        'group_name' => 'DEFAULT_GROUP',
+                        'namespace_id' => 'public',
+                    ],
+                ],
+            ],
+        ]);
+        $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('get')->with(Client::class)->andReturn($client);
+        $container->shouldReceive('get')->with(StdoutLoggerInterface::class)->andReturn(
+            Mockery::mock(StdoutLoggerInterface::class)
+        );
+        $container->shouldReceive('get')->with(ConfigInterface::class)->andReturn($config);
+
+        return new NacosDriver($container);
+    }
+}


### PR DESCRIPTION
### 修改内容

- 兼容 Nacos V1 的 `hosts` 实例列表结构。
- 兼容 Nacos V2 的 `data.hosts` 实例列表结构。
- 兼容 Nacos V3 的 `data` 实例列表结构。
- 保持现有的健康实例筛选和 HTTP 状态码异常处理逻辑不变。

### 问题原因

Nacos V3 使用统一响应结构，将实例数组放在 `data` 字段中。当前代码只读取
顶层 `hosts` 字段，因此使用 Nacos V3 进行服务发现时无法取得任何节点。

本次修改同时保留 V1 兼容性，并覆盖 Nacos 官方文档定义的 V2 响应结构。

### 测试

- 新增 Nacos V1、V2、V3 实例列表响应测试。
- 新增非数组 `data` 的回归测试，避免引入 PHP warning。
- 已运行 Nacos、Config Nacos 和 Service Governance Nacos 相关测试：
  18 个测试，32 个断言全部通过。
- PHP CS Fixer 和针对性 PHPStan 检查通过。

修复 #7571。

同时解决 #7542 中服务发现响应解析的部分；服务注册和心跳续约不在本次
PR 的修改范围内。
