### PR TITLE
Fixed TypeError thrown by string-based validation rules on non-string values

### DIFF
--- a/src/validation/src/Concerns/ValidatesAttributes.php
+++ b/src/validation/src/Concerns/ValidatesAttributes.php
@@ -822,7 +822,7 @@ trait ValidatesAttributes
      */
     public function validateLowercase(string $attribute, mixed $value, array $parameters): bool
     {
-        return Str::lower($value) === $value;
+        return is_string($value) && Str::lower($value) === $value;
     }
 
     /**
@@ -832,7 +832,7 @@ trait ValidatesAttributes
      */
     public function validateUppercase(string $attribute, mixed $value, array $parameters): bool
     {
-        return Str::upper($value) === $value;
+        return is_string($value) && Str::upper($value) === $value;
     }
 
     /**
@@ -1532,12 +1532,20 @@ trait ValidatesAttributes
      */
     public function validateStartsWith(string $attribute, $value, array $parameters): bool
     {
-        return Str::startsWith($value, $parameters);
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return Str::startsWith((string) $value, $parameters);
     }
 
     public function validateDoesntStartWith(string $attribute, mixed $value, array $parameters): bool
     {
-        return ! Str::startsWith($value, $parameters);
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return ! Str::startsWith((string) $value, $parameters);
     }
 
     /**
@@ -1547,12 +1555,20 @@ trait ValidatesAttributes
      */
     public function validateEndsWith(string $attribute, $value, array $parameters): bool
     {
-        return Str::endsWith($value, $parameters);
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return Str::endsWith((string) $value, $parameters);
     }
 
     public function validateDoesntEndWith($attribute, $value, $parameters): bool
     {
-        return ! Str::endsWith($value, $parameters);
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return ! Str::endsWith((string) $value, $parameters);
     }
 
     /**


### PR DESCRIPTION
### Problem

Six rules pass the raw value into `Str` methods that declare a `string`
parameter. Since `Str.php` is under `strict_types=1`, a non-string value
raises a `TypeError` instead of failing validation.

```php
$factory->make(['code' => 123], ['code' => 'string|uppercase'])->fails();

// TypeError: Hyperf\Stringable\Str::upper(): Argument #1 ($value)
// must be of type string, int given