### PR TITLE
feat(di): 代理类错误可直接定位原始源码(非代理文件)

### DIFF
--- a/src/di/src/Annotation/ScanConfig.php
+++ b/src/di/src/Annotation/ScanConfig.php
@@ -31,7 +31,8 @@ class ScanConfig
         private array $ignoreAnnotations = [],
         private array $globalImports = [],
         private array $collectors = [],
-        private array $classMap = []
+        private array $classMap = [],
+        private bool $lineMap = true
     ) {
     }
 
@@ -93,8 +94,27 @@ class ScanConfig
             $config['ignore_annotations'] ?? [],
             $config['global_imports'] ?? [],
             $config['collectors'] ?? [],
-            $config['class_map'] ?? []
+            $config['class_map'] ?? [],
+            static::resolveLineMap($config['line_map'] ?? true)
         );
+    }
+
+    public function getLineMap(): bool
+    {
+        return $this->lineMap;
+    }
+
+    /**
+     * Resolve the line map config value. The boolean value is wrapped
+     * into an array by the `allocateConfigValue()`, so it should be
+     * unwrapped first.
+     */
+    private static function resolveLineMap(array|bool $lineMap): bool
+    {
+        if (is_array($lineMap)) {
+            $lineMap = end($lineMap);
+        }
+        return (bool) $lineMap;
     }
 
     private static function initConfigByFile(string $configDir): array

--- a/src/di/src/Annotation/Scanner.php
+++ b/src/di/src/Annotation/Scanner.php
@@ -85,7 +85,9 @@ class Scanner
         }
 
         $lastCacheModified = file_exists($this->path) ? $this->filesystem->lastModified($this->path) : 0;
-        if ($lastCacheModified > 0 && $this->scanConfig->isCacheable()) {
+        if ($lastCacheModified > 0
+            && $this->scanConfig->isCacheable()
+            && ProxyManager::isLineMapCacheValid($proxyDir, $this->scanConfig->getLineMap())) {
             return $this->deserializeCachedScanData($collectors);
         }
 
@@ -127,7 +129,7 @@ class Scanner
 
         // Get the class map of Composer loader
         $classMap = array_merge($reflectionClassMap, $classMap);
-        $proxyManager = new ProxyManager($classMap, $proxyDir);
+        $proxyManager = new ProxyManager($classMap, $proxyDir, $this->scanConfig->getLineMap());
         $proxies = $proxyManager->getProxies();
         $aspectClasses = $proxyManager->getAspectClasses();
 

--- a/src/di/src/Aop/Ast.php
+++ b/src/di/src/Aop/Ast.php
@@ -13,8 +13,18 @@ declare(strict_types=1);
 namespace Hyperf\Di\Aop;
 
 use Hyperf\Support\Composer;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -55,6 +65,87 @@ class Ast
         return $this->printer->prettyPrintFile($modifiedStmts);
     }
 
+    /**
+     * Build the line map between the proxy code and the original code.
+     *
+     * The map is used to convert the file and line of an exception
+     * thrown in the proxy file back to the original class file,
+     * so that the developer can locate the problem in the original code.
+     *
+     * @return array<string, mixed> ['file' => string, 'ranges' => int[][], 'methods' => array]
+     */
+    public function buildLineMap(string $className, string $proxyCode): array
+    {
+        $originStmts = $this->astParser->parse($this->getCodeByClassName($className));
+        $proxyStmts = $this->astParser->parse($proxyCode);
+        if (! $originStmts || ! $proxyStmts) {
+            return [];
+        }
+
+        $originMethods = $this->collectMethods($originStmts, $className);
+        $proxyMethods = $this->collectMethods($proxyStmts, $className);
+        if (! $originMethods || ! $proxyMethods) {
+            return [];
+        }
+
+        $file = Composer::getLoader()->findFile($className);
+        $map = [
+            'file' => $file ? realpath($file) : $file,
+            'ranges' => [],
+            'methods' => [],
+        ];
+
+        foreach ($proxyMethods as $name => $proxyMethod) {
+            if (! isset($originMethods[$name])) {
+                continue;
+            }
+            $originMethod = $originMethods[$name];
+            $originBody = $originMethod->stmts ?? [];
+            $proxyBody = $proxyMethod->stmts ?? [];
+
+            // The rewritten method wraps the original body into a closure
+            // which is passed to `self::__proxyCall(...)`, extract it first.
+            if ($this->isProxyCallMethod($proxyBody)) {
+                $proxyBody = $this->extractProxyCallClosureStmts($proxyBody);
+            }
+            // The statements of the original method keep their order and
+            // structure in the proxy code, so align them one by one.
+            // The statements injected by the visitors, e.g. the
+            // `$this->__handlePropertyHandler(__CLASS__);` statement
+            // prepended to the constructor, should be skipped.
+            $i = 0;
+            $j = 0;
+            $originCount = count($originBody);
+            $proxyCount = count($proxyBody);
+            while ($i < $originCount && $j < $proxyCount) {
+                $proxy = $proxyBody[$j];
+                if ($this->isInjectedStatement($proxy)) {
+                    ++$j;
+                    continue;
+                }
+                $origin = $originBody[$i];
+                if (! $this->areStatementsAlignable($origin, $proxy)) {
+                    break;
+                }
+                $this->alignStatements($origin, $proxy, $map['ranges']);
+                ++$i;
+                ++$j;
+            }
+
+            // Method ranges are kept separately as a trace-only fallback.
+            // Exception locations use statement ranges exclusively to avoid
+            // guessing a source line when a visitor changed the structure.
+            $map['methods'][$name] = [
+                $proxyMethod->getStartLine(),
+                $proxyMethod->getEndLine(),
+                $originMethod->getStartLine(),
+                $originMethod->getEndLine(),
+            ];
+        }
+
+        return $map;
+    }
+
     public function parseClassByStmts(array $stmts): string
     {
         $namespace = $className = '';
@@ -70,6 +161,170 @@ class Ast
             }
         }
         return ($namespace && $className) ? $namespace . '\\' . $className : '';
+    }
+
+    /**
+     * Collect the class methods of the current namespace by their names.
+     */
+    private function collectMethods(array $stmts, string $className): array
+    {
+        $methods = [];
+        foreach ($stmts as $stmt) {
+            $namespace = '';
+            $members = [$stmt];
+            if ($stmt instanceof Namespace_) {
+                $namespace = $stmt->name?->toString() ?? '';
+                $members = $stmt->stmts;
+            }
+            foreach ($members as $class) {
+                if (! $class instanceof ClassLike) {
+                    continue;
+                }
+                $name = $class->name?->toString();
+                if ($name === null || ltrim($namespace . '\\' . $name, '\\') !== ltrim($className, '\\')) {
+                    continue;
+                }
+                foreach ($class->stmts as $member) {
+                    if ($member instanceof ClassMethod && $member->name) {
+                        $methods[$member->name->toString()] = $member;
+                    }
+                }
+            }
+        }
+        return $methods;
+    }
+
+    /**
+     * Align the node between the origin code and the proxy code, and
+     * record the line range pair. The nested nodes, e.g. the branches
+     * of an `if` statement, the statements of a `closure` or the
+     * statements of a `try` block, are aligned recursively so that
+     * the line translation inside the compound statements is precise.
+     */
+    private function alignStatements(Node $origin, Node $proxy, array &$ranges): void
+    {
+        if (! $this->areStatementsAlignable($origin, $proxy)) {
+            return;
+        }
+        $ranges[] = [
+            $proxy->getStartLine(),
+            $proxy->getEndLine(),
+            $origin->getStartLine(),
+            $origin->getEndLine(),
+        ];
+        $originChildren = $this->childStatements($origin);
+        $proxyChildren = $this->childStatements($proxy);
+        // If the structures are not isomorphic, e.g. the statements
+        // injected by the visitors, fall back to the compound range
+        // which is already recorded above.
+        if (count($originChildren) !== count($proxyChildren)) {
+            return;
+        }
+        foreach ($originChildren as $i => $child) {
+            $this->alignStatements($child, $proxyChildren[$i], $ranges);
+        }
+    }
+
+    /**
+     * A visitor may inject arbitrary statements. Only align nodes whose
+     * statement and top-level expression shapes still match.
+     */
+    private function areStatementsAlignable(Node $origin, Node $proxy): bool
+    {
+        if ($origin::class !== $proxy::class) {
+            return false;
+        }
+        if ($origin instanceof Expression && $proxy instanceof Expression) {
+            return $origin->expr::class === $proxy->expr::class;
+        }
+        if ($origin instanceof Return_ && $proxy instanceof Return_) {
+            return $origin->expr?->getType() === $proxy->expr?->getType();
+        }
+        return true;
+    }
+
+    /**
+     * Collect the child statements or closures of a node, including
+     * the statements of the compound statements such as `if`, `for`,
+     * `foreach`, `try`, `closure`, `elseif` and `catch`.
+     *
+     * @return array<Closure|Stmt>
+     */
+    private function childStatements(Node $node): array
+    {
+        $children = [];
+        foreach ($node->getSubNodeNames() as $name) {
+            $value = $node->{$name};
+            if (is_array($value)) {
+                foreach ($value as $item) {
+                    if ($item instanceof Stmt || $item instanceof Closure) {
+                        $children[] = $item;
+                    }
+                }
+            } elseif ($value instanceof Stmt || $value instanceof Closure) {
+                $children[] = $value;
+            }
+        }
+        return $children;
+    }
+
+    /**
+     * Whether the statement is injected by the visitors, e.g. the
+     * `$this->__handlePropertyHandler(__CLASS__);` statement prepended
+     * to the constructor by the PropertyHandlerVisitor.
+     */
+    private function isInjectedStatement(Stmt $stmt): bool
+    {
+        if (! $stmt instanceof Expression || ! $stmt->expr instanceof MethodCall) {
+            return false;
+        }
+        return $stmt->expr->var instanceof Variable
+            && $stmt->expr->var->name === 'this'
+            && $stmt->expr->name instanceof Identifier
+            && $stmt->expr->name->toString() === '__handlePropertyHandler';
+    }
+
+    /**
+     * Whether the method is rewritten into a `self::__proxyCall(...)` call,
+     * which means its original body is wrapped into the closure argument.
+     */
+    private function isProxyCallMethod(array $stmts): bool
+    {
+        $last = end($stmts);
+        if ($last instanceof Return_) {
+            return $last->expr instanceof StaticCall && $this->isProxyCallName($last->expr->name);
+        }
+        if ($last instanceof Expression) {
+            return $last->expr instanceof StaticCall && $this->isProxyCallName($last->expr->name);
+        }
+        return false;
+    }
+
+    private function isProxyCallName(Identifier $name): bool
+    {
+        return $name->toString() === '__proxyCall';
+    }
+
+    /**
+     * Extract the original method body from the closure argument of
+     * the `self::__proxyCall(...)` call.
+     *
+     * @return array<Stmt>
+     */
+    private function extractProxyCallClosureStmts(array $stmts): array
+    {
+        $last = end($stmts);
+        $expr = $last instanceof Return_ || $last instanceof Expression ? $last->expr : null;
+        if (! $expr instanceof StaticCall) {
+            return [];
+        }
+        // The 4th argument of `__proxyCall()` is the closure which
+        // wrapped the original method body.
+        $closure = $expr->args[3]->value ?? null;
+        if (! $closure instanceof Closure) {
+            return [];
+        }
+        return $closure->stmts ?? [];
     }
 
     private function getCodeByClassName(string $className): string

--- a/src/di/src/Aop/LineMapFixer.php
+++ b/src/di/src/Aop/LineMapFixer.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\Di\Aop;
+
+use Throwable;
+
+/**
+ * Resolve proxy locations to their original source locations without
+ * modifying the Throwable object or its engine-managed trace.
+ */
+class LineMapFixer
+{
+    /**
+     * The loaded line maps, lazy loaded from the `line-map.php` file.
+     */
+    private static array $mapsByDirectory = [];
+
+    /**
+     * Format an exception with proxy locations translated to source locations.
+     */
+    public static function format(Throwable $exception): string
+    {
+        return self::formatText($exception, (string) $exception);
+    }
+
+    /**
+     * Translate proxy locations in already-rendered exception output.
+     */
+    public static function formatText(Throwable $exception, string $text): string
+    {
+        $replacements = [];
+        for ($current = $exception; $current !== null; $current = $current->getPrevious()) {
+            self::addReplacement(
+                $current->getFile(),
+                $current->getLine(),
+                $replacements
+            );
+            foreach ($current->getTrace() as $frame) {
+                if (isset($frame['file'], $frame['line'])) {
+                    self::addReplacement($frame['file'], $frame['line'], $replacements);
+                }
+            }
+        }
+
+        return strtr($text, $replacements);
+    }
+
+    /**
+     * Resolve one proxy file location. Unmapped locations are returned unchanged.
+     *
+     * @return array{file: string, line: int}
+     */
+    public static function resolveLocation(string $file, int $line): array
+    {
+        if (! self::isProxyFile($file)) {
+            return ['file' => $file, 'line' => $line];
+        }
+
+        $map = self::getMapByFile($file);
+        $originLine = $map === null ? null : self::translate($map, $line);
+        if ($originLine === null || ! is_string($map['file'] ?? null)) {
+            return ['file' => $file, 'line' => $line];
+        }
+
+        return ['file' => $map['file'], 'line' => $originLine];
+    }
+
+    private static function addReplacement(
+        string $file,
+        int $line,
+        array &$replacements
+    ): void {
+        $location = self::resolveLocation($file, $line);
+        if ($location['file'] === $file && $location['line'] === $line) {
+            return;
+        }
+
+        foreach ([
+            [sprintf('%s:%d', $file, $line), sprintf('%s:%d', $location['file'], $location['line'])],
+            [sprintf('%s(%d)', $file, $line), sprintf('%s(%d)', $location['file'], $location['line'])],
+            [sprintf('%s on line %d', $file, $line), sprintf('%s on line %d', $location['file'], $location['line'])],
+        ] as [$from, $to]) {
+            $replacements[$from] = $to;
+        }
+    }
+
+    /**
+     * Find the map by the proxy filename. The map file is stored next to
+     * generated proxies and keys maps by the original class name.
+     */
+    private static function getMapByFile(string $proxyFile): ?array
+    {
+        $proxyName = basename($proxyFile);
+        foreach (self::loadMaps(dirname($proxyFile)) as $className => $map) {
+            if ($proxyName === str_replace('\\', '_', $className) . '.proxy.php') {
+                return is_array($map) ? $map : null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Load the line maps from the `line-map.php` file which is next
+     * to the proxy files. The maps are only loaded once.
+     */
+    private static function loadMaps(string $proxyDir): array
+    {
+        $proxyDir = realpath($proxyDir) ?: $proxyDir;
+        if (array_key_exists($proxyDir, self::$mapsByDirectory)) {
+            return self::$mapsByDirectory[$proxyDir];
+        }
+        $mapFile = $proxyDir . '/line-map.php';
+        if (! is_file($mapFile)) {
+            return self::$mapsByDirectory[$proxyDir] = [];
+        }
+        try {
+            $data = (array) require $mapFile;
+            $maps = is_array($data['maps'] ?? null) ? $data['maps'] : $data;
+        } catch (Throwable) {
+            $maps = [];
+        }
+        return self::$mapsByDirectory[$proxyDir] = $maps;
+    }
+
+    /**
+     * Translate the line number in the proxy file to the line number
+     * in the original file by the narrowest matched range.
+     */
+    private static function translate(array $map, int $line): ?int
+    {
+        $best = null;
+        foreach ($map['ranges'] ?? [] as $range) {
+            [$proxyStart, $proxyEnd] = $range;
+            if ($line < $proxyStart || $line > $proxyEnd) {
+                continue;
+            }
+            if ($best === null || ($proxyEnd - $proxyStart) < ($best[1] - $best[0])) {
+                $best = $range;
+            }
+        }
+        if ($best === null) {
+            return null;
+        }
+        return min($best[3], $best[2] + ($line - $best[0]));
+    }
+
+    private static function isProxyFile(string $file): bool
+    {
+        return str_ends_with($file, '.proxy.php');
+    }
+}

--- a/src/di/src/Aop/ProxyManager.php
+++ b/src/di/src/Aop/ProxyManager.php
@@ -15,24 +15,41 @@ namespace Hyperf\Di\Aop;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Di\Annotation\AspectCollector;
 use Hyperf\Support\Filesystem\Filesystem;
+use RuntimeException;
+use Throwable;
 
 class ProxyManager
 {
+    public const LINE_MAP_VERSION = 3;
+
     /**
      * The classes which be rewritten by proxy.
      */
     protected array $proxies = [];
+
+    /**
+     * The line maps between the proxy files and the original class files.
+     */
+    protected array $lineMaps = [];
+
+    protected bool $forceRegenerate = false;
 
     protected Filesystem $filesystem;
 
     /**
      * @param array $classMap the map to collect the classes with paths
      * @param string $proxyDir the directory which the proxy file places in
+     * @param bool $lineMapEnabled whether to generate the line map file
+     *                             and fix the exception location
      */
     public function __construct(
         protected array $classMap = [],
-        protected string $proxyDir = ''
+        protected string $proxyDir = '',
+        protected bool $lineMapEnabled = true
     ) {
+        if ($this->proxyDir !== '') {
+            $this->proxyDir = rtrim($this->proxyDir, '/\\') . DIRECTORY_SEPARATOR;
+        }
         $this->filesystem = new Filesystem();
         $this->proxies = $this->generateProxyFiles($this->initProxiesByReflectionClassMap(
             $this->classMap
@@ -63,37 +80,173 @@ class ProxyManager
         return $aspectClasses;
     }
 
+    public function getLineMapFilePath(): string
+    {
+        return $this->getProxyDir() . 'line-map.php';
+    }
+
+    public static function isLineMapCacheValid(string $proxyDir, bool $enabled): bool
+    {
+        $mapFile = rtrim($proxyDir, '/\\') . DIRECTORY_SEPARATOR . 'line-map.php';
+        if (! $enabled) {
+            if (is_file($mapFile)) {
+                return false;
+            }
+            foreach (glob(rtrim($proxyDir, '/\\') . DIRECTORY_SEPARATOR . '*.proxy.php') ?: [] as $proxyFile) {
+                if (str_contains((string) file_get_contents($proxyFile), '__hyperf_exception__')) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (! is_file($mapFile)) {
+            return false;
+        }
+        try {
+            $data = (array) require $mapFile;
+        } catch (Throwable) {
+            return false;
+        }
+        return ($data['version'] ?? null) === self::LINE_MAP_VERSION
+            && is_array($data['maps'] ?? null);
+    }
+
     protected function generateProxyFiles(array $proxies = []): array
     {
         $proxyFiles = [];
-        if (! $proxies) {
+        if (! $proxies && $this->getProxyDir() === '') {
             return $proxyFiles;
         }
         if (! file_exists($this->getProxyDir())) {
             mkdir($this->getProxyDir(), 0755, true);
+        }
+        if (! $proxies) {
+            if ($this->lineMapEnabled) {
+                $this->putLineMapFile();
+            } elseif (is_file($this->getLineMapFilePath())) {
+                $this->filesystem->delete($this->getLineMapFilePath());
+            }
+            return $proxyFiles;
+        }
+        if (! $this->lineMapEnabled) {
+            // Remove the stale line map file when the feature is disabled.
+            if (is_file($this->getLineMapFilePath())) {
+                $this->filesystem->delete($this->getLineMapFilePath());
+            }
+            // WARNING: Ast class SHOULD NOT use static instance, because it will read  the code from file, then would be caused coroutine switch.
+            $ast = new Ast();
+            foreach ($proxies as $className => $aspects) {
+                $proxyFiles[$className] = $this->putProxyFile($ast, $className);
+            }
+            return $proxyFiles;
+        }
+        // Reuse the existing line maps, so that the classes whose proxy
+        // files are not modified do not need to be parsed again.
+        if (is_file($this->getLineMapFilePath())) {
+            try {
+                $data = (array) require $this->getLineMapFilePath();
+                if (($data['version'] ?? null) === self::LINE_MAP_VERSION && is_array($data['maps'] ?? null)) {
+                    $this->lineMaps = array_intersect_key($data['maps'], $proxies);
+                } else {
+                    $this->forceRegenerate = true;
+                }
+            } catch (Throwable) {
+                $this->forceRegenerate = true;
+            }
+        } else {
+            $this->forceRegenerate = true;
         }
         // WARNING: Ast class SHOULD NOT use static instance, because it will read  the code from file, then would be caused coroutine switch.
         $ast = new Ast();
         foreach ($proxies as $className => $aspects) {
             $proxyFiles[$className] = $this->putProxyFile($ast, $className);
         }
+        $this->putLineMapFile();
         return $proxyFiles;
     }
 
     protected function putProxyFile(Ast $ast, $className)
     {
         $proxyFilePath = $this->getProxyFilePath($className);
-        $modified = true;
-        if (file_exists($proxyFilePath)) {
-            $modified = $this->isModified($className, $proxyFilePath);
+        $proxyFileExists = file_exists($proxyFilePath);
+        $modified = ! $proxyFileExists
+            || $this->forceRegenerate
+            || ($this->lineMapEnabled && ! array_key_exists($className, $this->lineMaps));
+        if ($proxyFileExists) {
+            $modified = $modified
+                || $this->isModified($className, $proxyFilePath)
+                || (! $this->lineMapEnabled && str_contains((string) file_get_contents($proxyFilePath), '__hyperf_exception__'));
         }
 
         if ($modified) {
             $code = $ast->proxy($className);
             file_put_contents($proxyFilePath, $code);
+            if ($this->lineMapEnabled) {
+                // Build the line map from the final proxy code, so that the
+                // exceptions thrown in the proxy file can be located in the
+                // original class file.
+                $this->lineMaps[$className] = $ast->buildLineMap($className, $code);
+            }
         }
 
         return $proxyFilePath;
+    }
+
+    protected function putLineMapFile(): void
+    {
+        $data = [
+            'version' => self::LINE_MAP_VERSION,
+            'maps' => $this->lineMaps,
+        ];
+        $content = "<?php\n\n// Generated by Hyperf. Do not edit it!\n\nreturn " . $this->exportShortArray($data) . ";\n";
+        // Write to the temporary file first, then rename it to avoid the
+        // incomplete file when multiple workers are generating at the same time.
+        $mapFile = $this->getLineMapFilePath();
+        $tmpFile = tempnam($this->getProxyDir(), 'line-map.php.');
+        if ($tmpFile === false) {
+            throw new RuntimeException(sprintf('Unable to create a temporary line map file in %s.', $this->getProxyDir()));
+        }
+        try {
+            if (file_put_contents($tmpFile, $content, LOCK_EX) === false || ! rename($tmpFile, $mapFile)) {
+                throw new RuntimeException(sprintf('Unable to write the proxy line map file %s.', $mapFile));
+            }
+        } finally {
+            if (is_file($tmpFile)) {
+                $this->filesystem->delete($tmpFile);
+            }
+        }
+    }
+
+    /**
+     * Export the array as the short array syntax, e.g. `[[1, 2], ['a' => 3]]`,
+     * which is more compact and readable than the `var_export()` output.
+     * The items of the associative arrays are separated by line breaks.
+     */
+    protected function exportShortArray(array $data, int $indent = 1): string
+    {
+        // Note: `range(0, -1)` returns `[0, -1]` instead of `[]`,
+        // so the empty array must be checked first.
+        $isList = $data === [] || array_keys($data) === range(0, count($data) - 1);
+        $parts = [];
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->exportShortArray($value, $indent + 1);
+            } elseif (is_string($value)) {
+                $value = var_export($value, true);
+            } elseif (is_int($value) || is_float($value)) {
+                $value = (string) $value;
+            } elseif (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            } elseif ($value === null) {
+                $value = 'null';
+            }
+            $parts[] = $isList ? $value : var_export($key, true) . ' => ' . $value;
+        }
+        if ($isList) {
+            return '[' . implode(', ', $parts) . ']';
+        }
+        $padding = str_repeat('    ', $indent);
+        return "[\n" . $padding . implode(",\n" . $padding, $parts) . ",\n" . str_repeat('    ', $indent - 1) . ']';
     }
 
     protected function isModified(string $className, ?string $proxyFilePath = null): bool

--- a/src/di/tests/Aop/LineMapFixerTest.php
+++ b/src/di/tests/Aop/LineMapFixerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Di\Aop;
+
+use Hyperf\Di\Aop\LineMapFixer;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use RuntimeException;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class LineMapFixerTest extends TestCase
+{
+    public function testTranslateDoesNotExceedTheOriginalRange(): void
+    {
+        $translate = new ReflectionMethod(LineMapFixer::class, 'translate');
+        $map = [
+            'ranges' => [[100, 110, 20, 22]],
+        ];
+
+        $this->assertSame(20, $translate->invoke(null, $map, 100));
+        $this->assertSame(22, $translate->invoke(null, $map, 105));
+        $this->assertNull($translate->invoke(null, $map, 99));
+    }
+
+    public function testFormatResolvesProxyLocationWithoutModifyingThrowable(): void
+    {
+        $directory = sys_get_temp_dir() . '/hyperf-line-map-' . uniqid();
+        mkdir($directory);
+        $proxyFile = $directory . '/App_LineMapStub.proxy.php';
+        $originFile = $directory . '/LineMapStub.php';
+        file_put_contents(
+            $proxyFile,
+            "<?php\n\n\$throw = static function (): void { throw new \\RuntimeException('line map'); };"
+            . str_repeat("\n", 27)
+            . "\$throw();\n"
+        );
+        file_put_contents($directory . '/line-map.php', sprintf(
+            "<?php\nreturn ['maps' => ['App\\\\LineMapStub' => ['file' => %s, 'ranges' => [[3, 3, 42, 42], [30, 30, 60, 60]], 'methods' => []]]];\n",
+            var_export($originFile, true)
+        ));
+
+        try {
+            require $proxyFile;
+            $this->fail('The proxy fixture must throw an exception.');
+        } catch (RuntimeException $exception) {
+            $formatted = LineMapFixer::format($exception);
+
+            $this->assertStringContainsString($originFile . ':42', $formatted);
+            $this->assertStringContainsString($originFile . '(60)', $formatted);
+            $this->assertStringNotContainsString($proxyFile . ':3', $formatted);
+            $this->assertStringNotContainsString(':420', $formatted);
+            $this->assertSame(realpath($proxyFile), $exception->getFile());
+            $this->assertSame(3, $exception->getLine());
+            $this->assertSame(
+                ['file' => $originFile, 'line' => 42],
+                LineMapFixer::resolveLocation($proxyFile, 3)
+            );
+        } finally {
+            @unlink($proxyFile);
+            @unlink($directory . '/line-map.php');
+            @rmdir($directory);
+        }
+    }
+}

--- a/src/di/tests/AstTest.php
+++ b/src/di/tests/AstTest.php
@@ -33,9 +33,11 @@ use HyperfTest\Di\Stub\FooAspect;
 use HyperfTest\Di\Stub\FooEnumStruct;
 use HyperfTest\Di\Stub\Par2;
 use HyperfTest\Di\Stub\PathStub;
+use HyperfTest\Di\Stub\ThrowingStub;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @internal
@@ -78,6 +80,56 @@ class Foo
     }
     use \Hyperf\Di\Aop\ProxyTrait;
 }', $code);
+    }
+
+    public function testLineMapOnlyCollectsMethodsFromTheTargetClass(): void
+    {
+        $ast = new Ast();
+        $stmts = $ast->parse(
+            <<<'PHP'
+<?php
+namespace App;
+
+class First
+{
+    public function duplicated() {}
+    public function firstOnly() {}
+}
+
+class Second
+{
+    public function duplicated() {}
+    public function secondOnly() {}
+}
+PHP
+        );
+        $collectMethods = new ReflectionMethod(Ast::class, 'collectMethods');
+
+        $methods = $collectMethods->invoke($ast, $stmts, 'App\First');
+
+        $this->assertSame(['duplicated', 'firstOnly'], array_keys($methods));
+    }
+
+    public function testLineMapSupportsPhpParserV5ThrowExpression(): void
+    {
+        $ast = new Ast();
+        $proxyCode = $ast->proxy(ThrowingStub::class);
+        $map = $ast->buildLineMap(ThrowingStub::class, $proxyCode);
+        $originLines = file((new ReflectionClass(ThrowingStub::class))->getFileName());
+        $throwLine = 0;
+        foreach ($originLines as $index => $line) {
+            if (str_contains($line, 'throw new RuntimeException')) {
+                $throwLine = $index + 1;
+                break;
+            }
+        }
+
+        $this->assertStringNotContainsString('__hyperf_exception__', $proxyCode);
+        $this->assertGreaterThan(0, $throwLine);
+        $this->assertNotEmpty(array_filter(
+            $map['ranges'],
+            static fn (array $range) => $range[2] <= $throwLine && $range[3] >= $throwLine
+        ));
     }
 
     public function testMagicConstDirAndFile()

--- a/src/di/tests/ProxyManagerTest.php
+++ b/src/di/tests/ProxyManagerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Di;
+
+use Hyperf\Di\Aop\ProxyManager;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class ProxyManagerTest extends TestCase
+{
+    public function testLineMapCacheValidation(): void
+    {
+        $directory = sys_get_temp_dir() . '/hyperf-proxy-manager-' . uniqid();
+        mkdir($directory);
+        $mapFile = $directory . '/line-map.php';
+
+        try {
+            $this->assertFalse(ProxyManager::isLineMapCacheValid($directory, true));
+            $this->assertTrue(ProxyManager::isLineMapCacheValid($directory, false));
+
+            $legacyProxy = $directory . '/App_Foo.proxy.php';
+            file_put_contents($legacyProxy, '<?php /* __hyperf_exception__ */');
+            $this->assertFalse(ProxyManager::isLineMapCacheValid($directory, false));
+            unlink($legacyProxy);
+
+            file_put_contents($mapFile, "<?php\nreturn ['legacy' => []];\n");
+            $this->assertFalse(ProxyManager::isLineMapCacheValid($directory, true));
+            $this->assertFalse(ProxyManager::isLineMapCacheValid($directory, false));
+
+            file_put_contents($mapFile, "<?php\nreturn ['version' => 2, 'maps' => []];\n");
+            $this->assertFalse(ProxyManager::isLineMapCacheValid($directory, true));
+
+            file_put_contents($mapFile, sprintf(
+                "<?php\nreturn ['version' => %d, 'maps' => []];\n",
+                ProxyManager::LINE_MAP_VERSION
+            ));
+            $this->assertTrue(ProxyManager::isLineMapCacheValid($directory, true));
+        } finally {
+            @unlink($directory . '/App_Foo.proxy.php');
+            @unlink($mapFile);
+            @rmdir($directory);
+        }
+    }
+}

--- a/src/di/tests/Stub/ThrowingStub.php
+++ b/src/di/tests/Stub/ThrowingStub.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Di\Stub;
+
+use RuntimeException;
+
+class ThrowingStub
+{
+    public function fail(): void
+    {
+        throw new RuntimeException('line map');
+    }
+}

--- a/src/exception-handler/src/Formatter/DefaultFormatter.php
+++ b/src/exception-handler/src/Formatter/DefaultFormatter.php
@@ -18,6 +18,10 @@ class DefaultFormatter implements FormatterInterface
 {
     public function format(Throwable $throwable): string
     {
+        $lineMapFixer = 'Hyperf\Di\Aop\LineMapFixer';
+        if (class_exists($lineMapFixer)) {
+            return $lineMapFixer::format($throwable);
+        }
         return (string) $throwable;
     }
 }

--- a/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
+++ b/src/exception-handler/src/Handler/WhoopsExceptionHandler.php
@@ -16,6 +16,7 @@ use Hyperf\Context\Context;
 use Hyperf\Context\RequestContext;
 use Hyperf\Contract\SessionInterface;
 use Hyperf\ExceptionHandler\ExceptionHandler;
+use Hyperf\ExceptionHandler\Whoops\LineMapInspectorFactory;
 use Hyperf\HttpMessage\Stream\SwooleStream;
 use Hyperf\Stringable\Str;
 use Swow\Psr7\Message\ResponsePlusInterface;
@@ -40,6 +41,7 @@ class WhoopsExceptionHandler extends ExceptionHandler
     public function handle(Throwable $throwable, ResponsePlusInterface $response)
     {
         $whoops = new Run();
+        $whoops->setInspectorFactory(new LineMapInspectorFactory());
         [$handler, $contentType] = $this->negotiateHandler();
 
         $whoops->pushHandler($handler);
@@ -47,6 +49,10 @@ class WhoopsExceptionHandler extends ExceptionHandler
         ob_start();
         $whoops->{RunInterface::EXCEPTION_HANDLER}($throwable);
         $content = ob_get_clean();
+        $lineMapFixer = 'Hyperf\Di\Aop\LineMapFixer';
+        if (class_exists($lineMapFixer)) {
+            $content = $lineMapFixer::formatText($throwable, (string) $content);
+        }
         return $response
             ->setStatus(500)
             ->addHeader('Content-Type', $contentType)

--- a/src/exception-handler/src/Whoops/LineMapInspector.php
+++ b/src/exception-handler/src/Whoops/LineMapInspector.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\ExceptionHandler\Whoops;
+
+use Whoops\Exception\Inspector;
+
+class LineMapInspector extends Inspector
+{
+    protected function getTrace($exception)
+    {
+        $trace = parent::getTrace($exception);
+        foreach ($trace as &$frame) {
+            $frame = $this->resolveFrame($frame);
+        }
+        return $trace;
+    }
+
+    protected function getFrameFromException($exception)
+    {
+        return $this->resolveFrame(parent::getFrameFromException($exception));
+    }
+
+    private function resolveFrame(array $frame): array
+    {
+        if (! isset($frame['file'], $frame['line'])) {
+            return $frame;
+        }
+
+        $lineMapFixer = 'Hyperf\Di\Aop\LineMapFixer';
+        if (class_exists($lineMapFixer)) {
+            $location = $lineMapFixer::resolveLocation($frame['file'], $frame['line']);
+            $frame['file'] = $location['file'];
+            $frame['line'] = $location['line'];
+        }
+        return $frame;
+    }
+}

--- a/src/exception-handler/src/Whoops/LineMapInspectorFactory.php
+++ b/src/exception-handler/src/Whoops/LineMapInspectorFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\ExceptionHandler\Whoops;
+
+use Whoops\Inspector\InspectorFactoryInterface;
+use Whoops\Inspector\InspectorInterface;
+
+class LineMapInspectorFactory implements InspectorFactoryInterface
+{
+    public function create($exception): InspectorInterface
+    {
+        return new LineMapInspector($exception, $this);
+    }
+}

--- a/src/exception-handler/tests/WhoopsExceptionHandlerTest.php
+++ b/src/exception-handler/tests/WhoopsExceptionHandlerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 
 use function json_decode;
 
@@ -39,6 +40,38 @@ class WhoopsExceptionHandlerTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('text/plain', $response->getHeader('Content-Type')[0]);
+    }
+
+    public function testPlainTextWhoopsResolvesProxyLocationWithoutModifyingThrowable(): void
+    {
+        Context::set(ServerRequestInterface::class, new Request('GET', '/'));
+        $directory = sys_get_temp_dir() . '/hyperf-whoops-line-map-' . uniqid();
+        mkdir($directory);
+        $proxyFile = $directory . '/App_WhoopsLineMapStub.proxy.php';
+        $originFile = $directory . '/WhoopsLineMapStub.php';
+        file_put_contents($proxyFile, "<?php\n\nthrow new \\RuntimeException('line map');\n");
+        file_put_contents($directory . '/line-map.php', sprintf(
+            "<?php\nreturn ['maps' => ['App\\\\WhoopsLineMapStub' => ['file' => %s, 'ranges' => [[3, 3, 42, 42]], 'methods' => []]]];\n",
+            var_export($originFile, true)
+        ));
+
+        try {
+            require $proxyFile;
+            $this->fail('The proxy fixture must throw an exception.');
+        } catch (RuntimeException $exception) {
+            $handler = new WhoopsExceptionHandler();
+            $response = $handler->handle($exception, new Response());
+            $content = (string) $response->getBody();
+
+            $this->assertStringContainsString($originFile . ' on line 42', $content);
+            $this->assertStringNotContainsString('WhoopsLineMapStub.proxy.php', $content);
+            $this->assertSame(realpath($proxyFile), $exception->getFile());
+            $this->assertSame(3, $exception->getLine());
+        } finally {
+            @unlink($proxyFile);
+            @unlink($directory . '/line-map.php');
+            @rmdir($directory);
+        }
     }
 
     public function testHtmlWhoops()


### PR DESCRIPTION
# 代理类异常行号修正（Proxy Line Map）改动说明

## 版本基线

- Hyperf 3.2
- PHP >= 8.2
- nikic/php-parser ^5.6（验证版本 5.8.0）

Hyperf 3.2 使用 php-parser v5 的 `ParserFactory::createForNewestSupportedVersion()` 和 `ClosureUse` 节点。line map 缓存版本提升为 3，升级后不会复用 Hyperf 3.1/php-parser v4 生成的代理映射。

## 一、背景

Hyperf DI 使用 AST 重新生成代理类。重新打印、trait 注入和 AOP 方法改写都会改变代理文件行号，因此异常位置可能指向 `runtime/container/proxy/*.proxy.php`，无法直接定位原始源码。

本方案在生成代理文件时同时生成 `line-map.php`，记录代理文件与原始文件的行号区间。运行时由异常 formatter 在生成日志或错误输出时应用映射，不修改异常对象。

## 二、设计原则

1. **不包装普通方法**：未被 AOP 改写的方法保持原有控制流，不生成方法级 `try/catch`。
2. **展示层统一处理**：`DefaultFormatter` 在生成异常文本时统一应用映射，代理方法和 dispatcher 都不捕获或改写异常。
3. **映射失败时保持原状**：找不到可靠映射时继续显示代理文件位置，不猜测业务源码位置。
4. **生成产物可失效**：map 文件包含格式版本。升级格式、首次启用或 map 条目缺失时会重新生成代理与映射。
5. **组件依赖保持可选**：`hyperf/exception-handler` 不强依赖 `hyperf/di`，formatter 仅在 `LineMapFixer` 存在时调用。

## 三、运行流程

### 生成阶段

`ScanConfig::getLineMap()` -> `Scanner` -> `ProxyManager` -> `Ast::buildLineMap()` -> `line-map.php`

`line-map.php` 格式：

```php
return [
    'version' => 3,
    'maps' => [
        App\Service\FooService::class => [
            'file' => '/app/app/Service/FooService.php',
            'ranges' => [
                // proxyStart, proxyEnd, originStart, originEnd
                [30, 30, 18, 18],
            ],
            'methods' => [
                'handle' => [25, 40, 13, 28],
            ],
        ],
    ],
];
```

映射只收集目标 class/trait/enum 的方法，避免同一文件中其他类的同名方法覆盖结果。语句精确映射要求节点类型和顶层表达式类型一致；遇到无法识别的 Visitor 结构变化时停止该方法的后续语句对齐。运行时只使用可靠的语句级映射，不根据方法范围猜测源码位置。

### 展示阶段

```text
Throwable -> DefaultFormatter -> LineMapFixer::format() -> mapped log text
```

因此代理类方法和 `ProxyTrait::__proxyCall()` 都不会为了行号映射生成以下代码：

```php
catch (\Throwable $__hyperf_exception__) {
    LineMapFixer::fix($__hyperf_exception__, __CLASS__);
    throw $__hyperf_exception__;
}
```

## 四、配置

`config/autoload/annotations.php`：

```php
return [
    'scan' => [
        'paths' => [...],
        'line_map' => true,
    ],
];
```

`line_map` 默认值为 `true`：

| 值 | 行为 |
|---|---|
| `true` | 生成 `line-map.php`，异常 formatter 输出原始源码位置 |
| `false` | 不生成映射并删除残留 map；异常继续显示代理文件位置 |

首次启用、map 格式升级或某个代理缺少 map 条目时，`ProxyManager` 会强制重新生成相关代理，避免复用不兼容缓存。旧版本遗留的 `__hyperf_exception__` 方法包装在关闭功能时也会触发一次重新生成。

## 五、边界

1. PHP 不提供安全修改现有 Throwable `file/line/trace` 的 API。`$e->getFile()`、`$e->getLine()` 和 `$e->getTrace()` 始终返回真实的代理执行位置。
2. 框架内置日志路径应使用 `FormatterInterface`。业务自定义异常 handler 如果直接拼接 `$e->getFile()`，需要改为注入 `FormatterInterface` 并调用 `format($e)`，或显式调用 `LineMapFixer::resolveLocation()`。
3. Hyperf 的 Whoops handler 使用只读 Inspector 副本映射 HTML、JSON、XML 和纯文本错误页。其他直接读取 Throwable 的第三方展示器需要单独接入 source map。
4. 宽区间换算结果会限制在原始区间内，避免映射到原方法范围之外。
5. `line-map.php` 是运行时生成产物，不应提交到版本库。

## 六、并发与缓存

map 写入使用每进程唯一临时文件、文件锁和同目录 `rename()`，避免多个进程共享固定 `.tmp` 文件。加载缓存按代理目录隔离，支持同一进程读取不同代理目录。

## 七、测试

覆盖范围包括：

- 普通代理方法不生成 catch 的既有 AST 快照；
- 多 class 文件只收集目标类方法；
- 行号换算不会超过原始区间；
- formatter 能读取 version 3 map 并修正输出，同时不修改 Throwable；
- Whoops Inspector 能修正错误页 frame，同时不修改 Throwable；
- AOP visitor 和既有 exception handler 行为回归。

