### PR TITLE
Support configuring secure session cookies.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # v3.2.5 - TBD
 
+## Added
+
+- [#7301](https://github.com/hyperf/hyperf/issues/7301) Added option `session.options.cookie_secure` to configure the Secure attribute of session cookies.
+
 # v3.2.4 - 2026-08-10
 
 ## Added

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-- [#7301](https://github.com/hyperf/hyperf/issues/7301) Added option `session.options.cookie_secure` to configure the Secure attribute of session cookies.
+- [#7798](https://github.com/hyperf/hyperf/pull/7798) Added option `session.options.cookie_secure` to configure the Secure attribute of session cookies.
 
 # v3.2.4 - 2026-08-10
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,9 +1,5 @@
 # v3.2.5 - TBD
 
-## Added
-
-- [#7798](https://github.com/hyperf/hyperf/pull/7798) Added option `session.options.cookie_secure` to configure the Secure attribute of session cookies.
-
 # v3.2.4 - 2026-08-10
 
 ## Added

--- a/src/session/publish/session.php
+++ b/src/session/publish/session.php
@@ -20,6 +20,7 @@ return [
         'session_name' => 'HYPERF_SESSION_ID',
         'domain' => null,
         'cookie_lifetime' => 5 * 60 * 60,
+        'cookie_secure' => null,
         'cookie_same_site' => 'lax',
     ],
 ];

--- a/src/session/src/Middleware/SessionMiddleware.php
+++ b/src/session/src/Middleware/SessionMiddleware.php
@@ -100,7 +100,8 @@ class SessionMiddleware implements MiddlewareInterface
     ): ResponseInterface {
         $uri = $request->getUri();
         $path = '/';
-        $secure = strtolower($uri->getScheme()) === 'https';
+        $secure = $this->config->get('session.options.cookie_secure', null);
+        $secure ??= strtolower($uri->getScheme()) === 'https';
 
         $domain = $this->config->get('session.options.domain') ?? $uri->getHost();
 

--- a/src/session/tests/SessionMiddlewareTest.php
+++ b/src/session/tests/SessionMiddlewareTest.php
@@ -30,6 +30,7 @@ use Hyperf\Support\Filesystem\Filesystem;
 use HyperfTest\Session\Stub\FooHandler;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -73,6 +74,7 @@ class SessionMiddlewareTest extends TestCase
         $config->shouldReceive('get')->with('session.options.session_name', 'HYPERF_SESSION_ID')->andReturn('HYPERF_SESSION_ID');
         $config->shouldReceive('get')->with('session.options.domain')->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_lifetime', 5 * 60)->andReturn(5 * 60);
+        $config->shouldReceive('get')->with('session.options.cookie_secure', null)->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_same_site')->andReturn(null);
 
         $sessionManager = new SessionManager($container, $config);
@@ -120,6 +122,7 @@ class SessionMiddlewareTest extends TestCase
         $config->shouldReceive('get')->with('session.options.session_name', 'HYPERF_SESSION_ID')->andReturn('HYPERF_SESSION_ID');
         $config->shouldReceive('get')->with('session.options.domain')->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_lifetime', 5 * 60 * 60)->andReturn(10 * 60 * 60);
+        $config->shouldReceive('get')->with('session.options.cookie_secure', null)->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_same_site')->andReturn(null);
 
         $sessionManager = new SessionManager($container, $config);
@@ -215,6 +218,37 @@ class SessionMiddlewareTest extends TestCase
         $this->assertSame('hyperf.wiki', $response->getCookies()['hyperf.wiki']['/']['test']->getDomain());
     }
 
+    #[DataProvider('provideSessionOptionsCookieSecure')]
+    public function testSessionOptionsCookieSecure(string $uri, array $options, bool $expected)
+    {
+        $config = new Config([
+            'session' => [
+                'options' => array_merge([
+                    'expire_on_close' => true,
+                    'domain' => null,
+                    'cookie_same_site' => 'none',
+                ], $options),
+            ],
+        ]);
+
+        $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);
+        $method = (new ReflectionClass($middleware))->getMethod('addCookieToResponse');
+        $request = new Request('GET', new Uri($uri));
+        $session = new Session('test', Mockery::mock(SessionHandlerInterface::class));
+        /** @var Response $response */
+        $response = $method->invokeArgs($middleware, [$request, new Response(), $session]);
+
+        $this->assertSame($expected, $response->getCookies()['hyperf.io']['/']['test']->isSecure());
+    }
+
+    public static function provideSessionOptionsCookieSecure(): iterable
+    {
+        yield 'force secure for HTTP' => ['http://hyperf.io', ['cookie_secure' => true], true];
+        yield 'disable secure for HTTPS' => ['https://hyperf.io', ['cookie_secure' => false], false];
+        yield 'detect insecure HTTP when null' => ['http://hyperf.io', ['cookie_secure' => null], false];
+        yield 'detect secure HTTPS when missing' => ['https://hyperf.io', [], true];
+    }
+
     public function testSessionStoreCurrentUrl()
     {
         $container = Mockery::mock(ContainerInterface::class);
@@ -247,6 +281,7 @@ class SessionMiddlewareTest extends TestCase
         $config->shouldReceive('get')->with('session.options.expire_on_close')->andReturn(0);
         $config->shouldReceive('get')->with('session.options.domain')->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_lifetime', 5 * 60 * 60)->andReturn(5 * 60);
+        $config->shouldReceive('get')->with('session.options.cookie_secure', null)->andReturn(null);
         $config->shouldReceive('get')->with('session.options.cookie_same_site')->andReturn(null);
 
         $middleware = new SessionMiddleware(Mockery::mock(SessionManager::class), $config);


### PR DESCRIPTION
### 修改内容

- 新增 `session.options.cookie_secure` 配置，用于显式控制 Session Cookie 的 `Secure` 属性。
- 配置为 `true` 或 `false` 时使用显式值。
- 配置为 `null` 或未配置时，继续根据请求 URI 的 scheme 自动判断，保持现有行为不变。
- 发布配置默认值为 `null`。

### 问题原因

当前 Session Cookie 的 `Secure` 属性只根据请求 URI 是否为 HTTPS 判断。
当 TLS 在反向代理终止、应用层接收到 HTTP 请求时，使用者无法强制为 Session Cookie 设置 `Secure` 属性。

本次修改只增加显式配置能力，不解析代理请求头，也不因 `SameSite=None` 自动强制开启 `Secure`。

### 测试

- 新增 HTTP 下强制开启 `Secure` 的测试。
- 新增 HTTPS 下显式关闭 `Secure` 的测试。
- 新增配置为 `null` 和未配置时保留原有自动判断行为的测试。
- 已运行 Session 组件测试：23 个测试，91 个断言全部通过。
- PHP CS Fixer 和针对性 PHPStan 检查通过。

Fixes #7301.