### PR TITLE
Fixed bug that `Hyperf\WebSocketServer\Sender::push()` always returns `true` even when the frame was not sent.

### DIFF
--- a/src/websocket-server/src/Sender.php
+++ b/src/websocket-server/src/Sender.php
@@ -78,9 +78,17 @@ class Sender
             return false;
         }
 
-        if (! $this->proxy($fd, $method, $arguments)) {
-            $this->sendPipeMessage($name, $arguments);
+        if ($this->proxy($fd, $method, $arguments)) {
+            return true;
         }
+
+        // BASE: the fd may just belong to another worker, and the broadcast result is not knowable here.
+        if ($this->getServer()->mode === SWOOLE_BASE) {
+            $this->sendPipeMessage($name, $arguments);
+            return true;
+        }
+
+        // PROCESS: connection_info() is shared, so a failed proxy() means the fd is dead.
         return true;
     }
 

--- a/src/websocket-server/src/Sender.php
+++ b/src/websocket-server/src/Sender.php
@@ -89,7 +89,7 @@ class Sender
         }
 
         // PROCESS: connection_info() is shared, so a failed proxy() means the fd is dead.
-        return true;
+        return false;
     }
 
     public function pushFrame(int $fd, FrameInterface $frame): bool


### PR DESCRIPTION
`Sender::__call()` returns `true` unconditionally under the async-style server,
discarding the real result of `proxy()`. This contradicts two things in the same class:

1. The class docblock declares `@method bool push(int $fd, $data, int $opcode = null, $finish = null)`.
2. `pushFrame()` takes the **same** `sendPipeMessage()` fallback path and returns `false`.

Probing the same non-existent fd in a single request:

```json
{"check()":false,"proxy()":false,"push()":true,"pushFrame()":false}