### PR TITLE
fix(crontab): 修复秒级定时任务调度时间计算问题 

### DIFF
--- a/src/crontab/src/CrontabManager.php
+++ b/src/crontab/src/CrontabManager.php
@@ -39,7 +39,10 @@ class CrontabManager
     {
         $result = [];
         $crontabs = $this->getCrontabs();
-        $last = time();
+        // Parse schedules from the beginning of the current minute. Using the
+        // current second as the base shifts second-level rules (e.g. */5) by
+        // that second and causes already elapsed slots to execute immediately.
+        $last = (int) (time() / 60) * 60;
         foreach ($crontabs as $key => $crontab) {
             if (! $crontab instanceof Crontab) {
                 unset($this->crontabs[$key]);

--- a/src/crontab/tests/CrontabManagerTest.php
+++ b/src/crontab/tests/CrontabManagerTest.php
@@ -16,6 +16,7 @@ use Hyperf\Crontab\Crontab;
 use Hyperf\Crontab\CrontabManager;
 use Hyperf\Crontab\Parser;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use function Hyperf\Tappable\tap;
@@ -48,5 +49,30 @@ class CrontabManagerTest extends TestCase
         }));
 
         $this->assertArrayNotHasKey('test2', $manager->getCrontabs());
+    }
+
+    public function testParseUsesCurrentMinuteAsStartTime(): void
+    {
+        /** @var Parser&MockObject $parser */
+        $parser = $this->createMock(Parser::class);
+        $parser->expects($this->once())
+            ->method('isValid')
+            ->willReturn(true);
+        $parser->expects($this->once())
+            ->method('parse')
+            ->with(
+                '*/5 * * * * *',
+                $this->callback(static fn (int $timestamp): bool => $timestamp % 60 === 0),
+                null
+            )
+            ->willReturn([]);
+
+        $manager = new CrontabManager($parser);
+        $manager->register(tap(new Crontab(), static function (Crontab $crontab): void {
+            $crontab->setName('seconds')->setRule('*/5 * * * * *')->setCallback(static function (): void {
+            });
+        }));
+
+        $this->assertSame([], $manager->parse());
     }
 }


### PR DESCRIPTION
 #7743

- 修改时间基准为当前分钟开始时间而非当前秒
- 防止秒级规则(如*/5)因时间偏移立即执行已过期的任务
- 添加单元测试验证当前分钟作为起始时间的逻辑
- 更新测试文件引入MockObject类型提示


可以稳定复现 Parser 的核心问题。

用仓库当前代码执行：

```php
$parser->parse('*/5 * * * * *', $startTime);
```

结果如下：

```text
start 12:00:00 => 12:00:00, 12:00:05, 12:00:10, ...
start 12:00:01 => 12:00:01, 12:00:06, 12:00:11, ...
start 12:00:02 => 12:00:02, 12:00:07, 12:00:12, ...
start 12:00:04 => 12:00:04, 12:00:09, 12:00:14, ...
```

也就是说，规则 `*/5` 并没有生成固定的 `00、05、10、15` 秒，而是以传入的当前秒数为偏移基准。

当调度进程在 `12:00:02` 执行解析时：

```text
当前时间：12:00:02
生成时间：12:00:02、12:00:07、12:00:12、...
```

这会造成：

- `12:00:02` 任务立即执行；
- 下一分钟调度时，之前的时间点可能已经过期；
- `Executor` 使用 `max($diff, 0)`，过期任务会立即执行；
- 多个过期任务连续执行，看起来就是重复执行。

因此 issue 中的问题可以复现，而且与调度进程是否恰好在整分钟运行有关，所以表现为“偶发”。

建议补充测试：

```php
$start = Carbon::create(2026, 9, 12, 12, 0, 2);

$result = $parser->parse(
    '*/5 * * * * *',
    $start->timestamp,
    'Asia/Shanghai'
);
```

当前实现会从 `02、07、12` 开始偏移。修复方向是让 `CrontabManager` 始终使用当前分钟的起点：

```php
$last = (int) (time() / 60) * 60;
```

这样秒级任务才会按照固定的 `00、05、10...` 秒执行。