### PR TITLE
Support multiple CacheEvict annotations

### DIFF
--- a/src/cache/src/Annotation/CacheEvict.php
+++ b/src/cache/src/Annotation/CacheEvict.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 namespace Hyperf\Cache\Annotation;
 
 use Attribute;
-use Hyperf\Di\Annotation\AbstractAnnotation;
+use Hyperf\Di\Annotation\AbstractMultipleAnnotation;
 
-#[Attribute(Attribute::TARGET_METHOD)]
-class CacheEvict extends AbstractAnnotation
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class CacheEvict extends AbstractMultipleAnnotation
 {
     public function __construct(
         public ?string $prefix = null,

--- a/src/cache/src/AnnotationManager.php
+++ b/src/cache/src/AnnotationManager.php
@@ -23,6 +23,7 @@ use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Di\Annotation\AbstractAnnotation;
 use Hyperf\Di\Annotation\AnnotationCollector;
+use Hyperf\Di\Annotation\MultipleAnnotationInterface;
 
 class AnnotationManager
 {
@@ -58,20 +59,22 @@ class AnnotationManager
 
     public function getCacheEvictValue(string $className, string $method, array $arguments): array
     {
-        /** @var CacheEvict $annotation */
-        $annotation = $this->getAnnotation(CacheEvict::class, $className, $method);
+        return $this->getCacheEvictValues($className, $method, $arguments)[0];
+    }
 
-        $prefix = $annotation->prefix;
-        $all = $annotation->all;
-        $group = $annotation->group;
-
-        if (! $all) {
-            $key = $this->getFormattedKey($prefix, $arguments, $annotation->value);
-        } else {
-            $key = $prefix . ':';
+    public function getCacheEvictValues(string $className, string $method, array $arguments): array
+    {
+        $values = [];
+        foreach ($this->getAnnotations(CacheEvict::class, $className, $method) as $annotation) {
+            /** @var CacheEvict $annotation */
+            $all = $annotation->all;
+            $key = $all
+                ? $annotation->prefix . ':'
+                : $this->getFormattedKey($annotation->prefix, $arguments, $annotation->value);
+            $values[] = [$key, $all, $annotation->group, $annotation];
         }
 
-        return [$key, $all, $group, $annotation];
+        return $values;
     }
 
     public function getCachePutValue(string $className, string $method, array $arguments): array
@@ -112,13 +115,25 @@ class AnnotationManager
 
     protected function getAnnotation(string $annotation, string $className, string $method): AbstractAnnotation
     {
+        return $this->getAnnotations($annotation, $className, $method)[0];
+    }
+
+    /**
+     * @return AbstractAnnotation[]
+     */
+    protected function getAnnotations(string $annotation, string $className, string $method): array
+    {
         $collector = AnnotationCollector::get($className);
         $result = $collector['_m'][$method][$annotation] ?? null;
-        if (! $result instanceof $annotation) {
-            throw new CacheException(sprintf('Annotation %s in %s:%s not exist.', $annotation, $className, $method));
+        $annotations = $result instanceof MultipleAnnotationInterface ? $result->toAnnotations() : [$result];
+
+        foreach ($annotations as $item) {
+            if (! $item instanceof $annotation) {
+                throw new CacheException(sprintf('Annotation %s in %s:%s not exist.', $annotation, $className, $method));
+            }
         }
 
-        return $result;
+        return $annotations;
     }
 
     protected function getFormattedKey(string $prefix, array $arguments, ?string $value = null): string

--- a/src/cache/src/AnnotationManager.php
+++ b/src/cache/src/AnnotationManager.php
@@ -115,7 +115,13 @@ class AnnotationManager
 
     protected function getAnnotation(string $annotation, string $className, string $method): AbstractAnnotation
     {
-        return $this->getAnnotations($annotation, $className, $method)[0];
+        $collector = AnnotationCollector::get($className);
+        $result = $collector['_m'][$method][$annotation] ?? null;
+        if (! $result instanceof $annotation) {
+            throw new CacheException(sprintf('Annotation %s in %s:%s not exist.', $annotation, $className, $method));
+        }
+
+        return $result;
     }
 
     /**

--- a/src/cache/src/Aspect/CacheEvictAspect.php
+++ b/src/cache/src/Aspect/CacheEvictAspect.php
@@ -35,23 +35,23 @@ class CacheEvictAspect extends AbstractAspect
         $method = $proceedingJoinPoint->methodName;
         $arguments = $proceedingJoinPoint->arguments['keys'];
 
-        [$key, $all, $group, $annotation] = $this->annotationManager->getCacheEvictValue($className, $method, $arguments);
+        foreach ($this->annotationManager->getCacheEvictValues($className, $method, $arguments) as [$key, $all, $group, $annotation]) {
+            $driver = $this->manager->getDriver($group);
 
-        $driver = $this->manager->getDriver($group);
-
-        if ($all) {
-            if ($driver instanceof KeyCollectorInterface && $annotation instanceof CacheEvict && $annotation->collect) {
-                $collector = $annotation->prefix . 'MEMBERS';
-                $keys = $driver->keys($collector);
-                if ($keys) {
-                    $driver->deleteMultiple($keys);
-                    $driver->delete($collector);
+            if ($all) {
+                if ($driver instanceof KeyCollectorInterface && $annotation instanceof CacheEvict && $annotation->collect) {
+                    $collector = $annotation->prefix . 'MEMBERS';
+                    $keys = $driver->keys($collector);
+                    if ($keys) {
+                        $driver->deleteMultiple($keys);
+                        $driver->delete($collector);
+                    }
+                } else {
+                    $driver->clearPrefix($key);
                 }
             } else {
-                $driver->clearPrefix($key);
+                $driver->delete($key);
             }
-        } else {
-            $driver->delete($key);
         }
 
         return $proceedingJoinPoint->process();

--- a/src/cache/tests/Cases/AnnotationTest.php
+++ b/src/cache/tests/Cases/AnnotationTest.php
@@ -62,6 +62,8 @@ class AnnotationTest extends TestCase
         foreach ($attributes as $attribute) {
             $attribute->newInstance()->collectMethod(CacheEvictStub::class, 'handle');
         }
+        $singleAttribute = (new ReflectionMethod(CacheEvictStub::class, 'handleSingle'))->getAttributes(CacheEvict::class)[0];
+        $singleAttribute->newInstance()->collectMethod(CacheEvictStub::class, 'handleSingle');
 
         $manager = new AnnotationManager(
             Mockery::mock(ConfigInterface::class),
@@ -78,6 +80,10 @@ class AnnotationTest extends TestCase
         $this->assertSame('secondary', $values[1][2]);
         $this->assertTrue($values[1][3]->collect);
         $this->assertSame($values[0], $manager->getCacheEvictValue(CacheEvictStub::class, 'handle', ['id' => 7]));
+        $this->assertSame(
+            ['single:7', false, 'default'],
+            array_slice($manager->getCacheEvictValue(CacheEvictStub::class, 'handleSingle', ['id' => 7]), 0, 3)
+        );
     }
 
     public function testIntCacheableAndCachePut()
@@ -161,6 +167,11 @@ class CacheEvictStub
     #[CacheEvict(prefix: 'user', value: 'user_#{id}')]
     #[CacheEvict(prefix: 'role', all: true, group: 'secondary', collect: true)]
     public function handle(int $id): void
+    {
+    }
+
+    #[CacheEvict(prefix: 'single')]
+    public function handleSingle(int $id): void
     {
     }
 }

--- a/src/cache/tests/Cases/AnnotationTest.php
+++ b/src/cache/tests/Cases/AnnotationTest.php
@@ -14,13 +14,17 @@ namespace HyperfTest\Cache\Cases;
 
 use Hyperf\Cache\Annotation\Cacheable;
 use Hyperf\Cache\Annotation\CacheAhead;
+use Hyperf\Cache\Annotation\CacheEvict;
 use Hyperf\Cache\Annotation\CachePut;
 use Hyperf\Cache\AnnotationManager;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Di\Annotation\AnnotationCollector;
+use Hyperf\Di\Annotation\MultipleAnnotationInterface;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 /**
  * @internal
@@ -29,6 +33,53 @@ use PHPUnit\Framework\TestCase;
 #[CoversNothing]
 class AnnotationTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        AnnotationCollector::clear(CacheEvictStub::class);
+        Mockery::close();
+    }
+
+    public function testCacheEvictCanBeRepeated(): void
+    {
+        $attributes = (new ReflectionMethod(CacheEvictStub::class, 'handle'))->getAttributes(CacheEvict::class);
+
+        foreach ($attributes as $attribute) {
+            $attribute->newInstance()->collectMethod(CacheEvictStub::class, 'handle');
+        }
+
+        $annotation = AnnotationCollector::getClassMethodAnnotation(CacheEvictStub::class, 'handle')[CacheEvict::class];
+        $this->assertInstanceOf(MultipleAnnotationInterface::class, $annotation);
+
+        $annotations = $annotation->toAnnotations();
+        $this->assertCount(2, $annotations);
+        $this->assertSame('user', $annotations[0]->prefix);
+        $this->assertSame('role', $annotations[1]->prefix);
+    }
+
+    public function testCacheEvictValues(): void
+    {
+        $attributes = (new ReflectionMethod(CacheEvictStub::class, 'handle'))->getAttributes(CacheEvict::class);
+        foreach ($attributes as $attribute) {
+            $attribute->newInstance()->collectMethod(CacheEvictStub::class, 'handle');
+        }
+
+        $manager = new AnnotationManager(
+            Mockery::mock(ConfigInterface::class),
+            Mockery::mock(StdoutLoggerInterface::class)
+        );
+        $values = $manager->getCacheEvictValues(CacheEvictStub::class, 'handle', ['id' => 7]);
+
+        $this->assertSame('user:user_7', $values[0][0]);
+        $this->assertFalse($values[0][1]);
+        $this->assertSame('default', $values[0][2]);
+        $this->assertSame('user', $values[0][3]->prefix);
+        $this->assertSame('role:', $values[1][0]);
+        $this->assertTrue($values[1][1]);
+        $this->assertSame('secondary', $values[1][2]);
+        $this->assertTrue($values[1][3]->collect);
+        $this->assertSame($values[0], $manager->getCacheEvictValue(CacheEvictStub::class, 'handle', ['id' => 7]));
+    }
+
     public function testIntCacheableAndCachePut()
     {
         $annotation = new Cacheable(
@@ -102,5 +153,14 @@ class AnnotationTest extends TestCase
         [$key, $ttl] = $manager->getCacheAheadValue('Foo', 'test', ['id' => $id = uniqid()]);
         $this->assertSame('test:' . $id, $key);
         $this->assertSame(3600, $ttl);
+    }
+}
+
+class CacheEvictStub
+{
+    #[CacheEvict(prefix: 'user', value: 'user_#{id}')]
+    #[CacheEvict(prefix: 'role', all: true, group: 'secondary', collect: true)]
+    public function handle(int $id): void
+    {
     }
 }

--- a/src/cache/tests/Cases/CacheEvictAspectTest.php
+++ b/src/cache/tests/Cases/CacheEvictAspectTest.php
@@ -116,8 +116,9 @@ class CacheEvictAspectTest extends TestCase
         $this->assertSame('result', (new CacheEvictAspect($manager, $annotationManager))->process($point));
     }
 
-    public function testProcessStopsOnFirstFailure(): void
+    public function testProcessStopsOnMiddleFailure(): void
     {
+        $events = [];
         $processCount = 0;
         $exception = new RuntimeException('cache delete failed');
 
@@ -125,13 +126,24 @@ class CacheEvictAspectTest extends TestCase
         $annotationManager->shouldReceive('getCacheEvictValues')->once()->andReturn([
             ['user:7', false, 'first', new CacheEvict('user')],
             ['role:7', false, 'second', new CacheEvict('role')],
+            ['permission:7', false, 'third', new CacheEvict('permission')],
         ]);
 
-        $driver = Mockery::mock(DriverInterface::class);
-        $driver->shouldReceive('delete')->once()->with('user:7')->andThrow($exception);
+        $firstDriver = Mockery::mock(DriverInterface::class);
+        $firstDriver->shouldReceive('delete')->once()->with('user:7')->andReturnUsing(function () use (&$events) {
+            $events[] = 'delete:user:7';
+            return true;
+        });
+        $secondDriver = Mockery::mock(DriverInterface::class);
+        $secondDriver->shouldReceive('delete')->once()->with('role:7')->andReturnUsing(function () use (&$events, $exception) {
+            $events[] = 'delete:role:7';
+            throw $exception;
+        });
 
         $manager = Mockery::mock(CacheManager::class);
-        $manager->shouldReceive('getDriver')->once()->with('first')->andReturn($driver);
+        $manager->shouldReceive('getDriver')->once()->ordered()->with('first')->andReturn($firstDriver);
+        $manager->shouldReceive('getDriver')->once()->ordered()->with('second')->andReturn($secondDriver);
+        $manager->shouldNotReceive('getDriver')->with('third');
 
         $point = new ProceedingJoinPoint(function () use (&$processCount) {
             ++$processCount;
@@ -147,6 +159,7 @@ class CacheEvictAspectTest extends TestCase
         } catch (RuntimeException $throwable) {
             $this->assertSame($exception, $throwable);
         }
+        $this->assertSame(['delete:user:7', 'delete:role:7'], $events);
         $this->assertSame(0, $processCount);
     }
 

--- a/src/cache/tests/Cases/CacheEvictAspectTest.php
+++ b/src/cache/tests/Cases/CacheEvictAspectTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\Cache\Cases;
+
+use Hyperf\Cache\Annotation\CacheEvict;
+use Hyperf\Cache\AnnotationManager;
+use Hyperf\Cache\Aspect\CacheEvictAspect;
+use Hyperf\Cache\CacheManager;
+use Hyperf\Cache\Driver\DriverInterface;
+use Hyperf\Cache\Driver\KeyCollectorInterface;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Mockery;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversNothing]
+class CacheEvictAspectTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testProcessEvictsAllCachesInOrder(): void
+    {
+        $events = [];
+        $processCount = 0;
+
+        $annotationManager = Mockery::mock(AnnotationManager::class);
+        $annotationManager->shouldReceive('getCacheEvictValues')->once()->andReturn([
+            ['user:7', false, 'first', new CacheEvict('user')],
+            ['role:7', false, 'second', new CacheEvict('role')],
+        ]);
+
+        $firstDriver = Mockery::mock(DriverInterface::class);
+        $firstDriver->shouldReceive('delete')->once()->with('user:7')->andReturnUsing(function () use (&$events) {
+            $events[] = 'delete:user:7';
+            return true;
+        });
+        $secondDriver = Mockery::mock(DriverInterface::class);
+        $secondDriver->shouldReceive('delete')->once()->with('role:7')->andReturnUsing(function () use (&$events) {
+            $events[] = 'delete:role:7';
+            return true;
+        });
+
+        $manager = Mockery::mock(CacheManager::class);
+        $manager->shouldReceive('getDriver')->once()->with('first')->andReturn($firstDriver);
+        $manager->shouldReceive('getDriver')->once()->with('second')->andReturn($secondDriver);
+
+        $point = new ProceedingJoinPoint(function () use (&$events, &$processCount) {
+            ++$processCount;
+            $events[] = 'process';
+            return 'result';
+        }, 'Example', 'update', ['keys' => ['id' => 7]]);
+        $point->pipe = static function (ProceedingJoinPoint $point) {
+            return $point->processOriginalMethod();
+        };
+
+        $result = (new CacheEvictAspect($manager, $annotationManager))->process($point);
+
+        $this->assertSame('result', $result);
+        $this->assertSame(1, $processCount);
+        $this->assertSame(['delete:user:7', 'delete:role:7', 'process'], $events);
+    }
+
+    public function testProcessClearsPrefix(): void
+    {
+        $annotationManager = Mockery::mock(AnnotationManager::class);
+        $annotationManager->shouldReceive('getCacheEvictValues')->once()->andReturn([
+            ['user:', true, 'default', new CacheEvict('user', all: true)],
+        ]);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('clearPrefix')->once()->with('user:')->andReturnTrue();
+        $driver->shouldNotReceive('delete');
+
+        $manager = Mockery::mock(CacheManager::class);
+        $manager->shouldReceive('getDriver')->once()->with('default')->andReturn($driver);
+
+        $point = $this->createProceedingJoinPoint();
+        $this->assertSame('result', (new CacheEvictAspect($manager, $annotationManager))->process($point));
+    }
+
+    public function testProcessDeletesCollectedKeys(): void
+    {
+        $annotationManager = Mockery::mock(AnnotationManager::class);
+        $annotationManager->shouldReceive('getCacheEvictValues')->once()->andReturn([
+            ['user:', true, 'default', new CacheEvict('user', all: true, collect: true)],
+        ]);
+
+        $driver = Mockery::mock(DriverInterface::class . ', ' . KeyCollectorInterface::class);
+        $driver->shouldReceive('keys')->once()->ordered()->with('userMEMBERS')->andReturn(['user:1', 'user:2']);
+        $driver->shouldReceive('deleteMultiple')->once()->ordered()->with(['user:1', 'user:2'])->andReturnTrue();
+        $driver->shouldReceive('delete')->once()->ordered()->with('userMEMBERS')->andReturnTrue();
+        $driver->shouldNotReceive('clearPrefix');
+
+        $manager = Mockery::mock(CacheManager::class);
+        $manager->shouldReceive('getDriver')->once()->with('default')->andReturn($driver);
+
+        $point = $this->createProceedingJoinPoint();
+        $this->assertSame('result', (new CacheEvictAspect($manager, $annotationManager))->process($point));
+    }
+
+    public function testProcessStopsOnFirstFailure(): void
+    {
+        $processCount = 0;
+        $exception = new RuntimeException('cache delete failed');
+
+        $annotationManager = Mockery::mock(AnnotationManager::class);
+        $annotationManager->shouldReceive('getCacheEvictValues')->once()->andReturn([
+            ['user:7', false, 'first', new CacheEvict('user')],
+            ['role:7', false, 'second', new CacheEvict('role')],
+        ]);
+
+        $driver = Mockery::mock(DriverInterface::class);
+        $driver->shouldReceive('delete')->once()->with('user:7')->andThrow($exception);
+
+        $manager = Mockery::mock(CacheManager::class);
+        $manager->shouldReceive('getDriver')->once()->with('first')->andReturn($driver);
+
+        $point = new ProceedingJoinPoint(function () use (&$processCount) {
+            ++$processCount;
+            return 'result';
+        }, 'Example', 'update', ['keys' => ['id' => 7]]);
+        $point->pipe = static function (ProceedingJoinPoint $point) {
+            return $point->processOriginalMethod();
+        };
+
+        try {
+            (new CacheEvictAspect($manager, $annotationManager))->process($point);
+            $this->fail('The cache exception was not thrown.');
+        } catch (RuntimeException $throwable) {
+            $this->assertSame($exception, $throwable);
+        }
+        $this->assertSame(0, $processCount);
+    }
+
+    private function createProceedingJoinPoint(): ProceedingJoinPoint
+    {
+        $point = new ProceedingJoinPoint(fn () => 'result', 'Example', 'update', ['keys' => ['id' => 7]]);
+        $point->pipe = static function (ProceedingJoinPoint $point) {
+            return $point->processOriginalMethod();
+        };
+        return $point;
+    }
+}


### PR DESCRIPTION
## 修改内容

- 允许在同一个方法上重复声明 `CacheEvict`。
- 多条缓存清除规则按声明顺序执行。
- 保留单个 `CacheEvict` 及 `AnnotationManager::getCacheEvictValue()` 的现有行为。

## 执行语义

- 每条规则独立解析 key、group、all 和 collect。
- 任意缓存清除抛出异常时立即停止，保留原异常，后续规则及原方法不再执行。
- 全部缓存清除成功后，原方法只执行一次。

## 测试

- 覆盖重复注解收集、声明顺序、复数解析和单数 API 兼容。
- 覆盖多驱动顺序执行、all、collect、group 与中间规则 fail-fast。
- 相关测试共 8 项、47 个断言，全部通过。
- PHP CS Fixer、目标 PHPStan 和 `git diff --check` 检查通过。

Fixes #7116.